### PR TITLE
New icons

### DIFF
--- a/128x128/apps/application-default-icon.svg
+++ b/128x128/apps/application-default-icon.svg
@@ -13,7 +13,7 @@
    viewBox="0 0 33.866666 33.866667"
    version="1.1"
    id="svg6"
-   sodipodi:docname="starred.svg"
+   sodipodi:docname="application-default-icon.svg"
    inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
   <metadata
      id="metadata99">
@@ -29,42 +29,6 @@
   </metadata>
   <defs
      id="defs2">
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient1056">
-      <stop
-         style="stop-color:#454f56;stop-opacity:1"
-         offset="0"
-         id="stop1052" />
-      <stop
-         style="stop-color:#222c34;stop-opacity:1"
-         offset="1"
-         id="stop1054" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient1033">
-      <stop
-         style="stop-color:#f1f2f3;stop-opacity:1"
-         offset="0"
-         id="stop1029" />
-      <stop
-         style="stop-color:#d9dee6;stop-opacity:1"
-         offset="1"
-         id="stop1031" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient1417">
-      <stop
-         style="stop-color:#189fda;stop-opacity:1"
-         offset="0"
-         id="stop1413" />
-      <stop
-         style="stop-color:#006ec3;stop-opacity:1"
-         offset="1"
-         id="stop1415" />
-    </linearGradient>
     <linearGradient
        gradientTransform="translate(0,-896)"
        gradientUnits="userSpaceOnUse"
@@ -132,35 +96,6 @@
        width="114px"
        height="114px"
        xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHIAAAByCAYAAACP3YV9AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAfzklEQVR4nO19eZQU1d32U2tPb9OzT8/0ALPP4ABxCYq8LEE0H2o85CUm8bhFfY2afOYkJyYumBMSPk9G38Px5PjFhRhfiEpUCC544CAiRFDgQxaBEYeZYbbeZuienn16rarvj56qqe6u3gsYDM85fbq7uqrur+rp+9zf/d3fvUXgMi4ECNm7MPlZiLNvVgVchjogol4kAOJHP/pRzr33PlCTl2cqDQSCo7t37/z6T3/60wgADmFCsyb1MpGZQYkw8plnmvOuv35Bg9GY26DRaBoZhq4nSaqBoqhKALR4sCAI/mAwsL2j4+z/Wbnye18hTCifrUGXoQy5HEq1y2g00i+/vL581qxZjTqdvoFhmAaapuspimogSdKcXhGCz+Vy/e+FCxf8A0AAWZB5mcg4cnjLLSs1P//5IzWFhQUNOTnaRoah6ymKbqAoqo4gCKOK5XM9PV0/uvHG5dsRJjMjmf13IlJRDtesWZu7ePGixtxcUwPLsg0MwzRQFFVPUVQVAOZCGMZxnP3xxx+7etu2bR4AoUzO8U0jUlEONRoNtX79a2VVVZWNer2hkWUlOawnSbIM0+A+9PT0/PzGG5dtAOBHBrWSTr7LtER07SIAkDfddBP76KO/qi4uLmrMyclpYFmmgaLoBpKk6kiSyL2oFidBQUH+cgCbkKG8TnciFeXwd7/7Xe6SJTfU5+WZGliWbWQYRnQ2qgmCuCByqDZYVnMFABbha0zb6ZkORCrKIQBy48aNZVVVtY0Gg66BYTQNNE03TMphOaaBHKoJhmGq8vPz2cHBQTKT4y/kzVCUwyVLljCPPfab6qKikkatVlvPMEyj2H4RBGG6gPZddGza9MbCP/xhzZcAvOkeez5qpKIcPvnkk4Zly5Y35OXlN2g0Gsk7nJRDzXmw45LDFVfMqQNwEpGhvJSQKZFx5fDVV18z19XVN+j1hgaNhm2UeYcV+IbJodooLCysA0DhPBApJ0wi69prr2WeeurpypISc2NOjqaBZdkGihIJI/LTvYDLCMNgMMiJTAtKRIqkUQ8//LBu1arbZ+fn5zewLNtI00w9TdP1JEnWqi2H1olO7B/YiX7ODgYMqjWz8Z2SW6GjDGoWM60gSHVOgCAI0Gg0NVCJSBIAvXv3nv8oKyv/LcuyNwA47+3XV8NH8cHgG2B04aJCCKGFP4L2nlP4r5mPw0BP6y5gUkQTBgA8z0MQBIRCIYRCIfA8B0CoQZiTtD1XSv6ZZdmcL744/oeSkpL1FEXVI+M2VABcn0LjeB05rq2gPZ+B8w0DhhqAoCL2DPA+vNH3F1D6yKIIgkCI4TA0NoDZxiszM+MCI8yRMPlZAM/z4HkeHBdCIOCHz+eD3+9DKBQEQQAsS8NoNKC4uAjl5WaUlZVpvV7v6wcOHBhEmqE68e6RANjPPjv0pNFoeCK+pYDABUHQifvcpHUT8oP/D6yWRvi/MgEu9Ck8Z9sRqn0MIKZI6xw7A44JgVYIaxIEgQ7/V+lcz3mHUu0ShPBnjuMQCgURCoUAEKBpCgxDQ6PRID8/FzqdDhqNBjRNg6LCf2iCiFTRFStW1K1bt+4s0nR46MkD6I0bX78yP9/0lNJOvHcCEx9vB3PmFMiAHyFDLvirF0C3aBkIIkoFxjqQ6zsEVhtJDEWRyGfscLn2ASU3SNv9nBcEGV9JgkIg1WtRFYnlMEwYz3MgSRIURYFlGej1Wuh0hdDptGBZFhRFgZy8tmjC4sFisdQD+BgZEsnOnTvv5xFVRbyMQAATG16E2TsGiqYAWgfwIfgO/Qtudz+M/3lnxP7E0JfQ5igrMk1TYMZbEMQUkeW6WeBGguFzK6CUtqR6LRkhWg7FF8/zUvslCDxIkgTD0GBZFgaDETqdDlptDhiGAUVRIAgiZbISIS8vrxYZODyi9uXodLrlSjtMHPgXSr2joMjIG51D08htbYG/twvszKqpH4QAkOiChGDE12JNGWqpJnRz7SCpyJoZ8PqxtOCWdK5HucikchhCKBREpnKoJvR6fcZEkjU1dTqaphVHt4muNtCkcm0xaliMtH8dQaSgq0Jw5BAYJvYYnhcQ0lTFbF9Vfh8+cLyOM/6ToBgaggDQARq3FdyJWmNTyheTSA45jkMwGJZDgiBB02E51Om0k5KoA8MwoGk6bTlUE5l2QWgA5NjYCImwvsQcTHAJAvEEAD7q94L5GB74GIW0J/JGCMDwBAOh5saY0zAki9srHsRgwA2ntxcaMgcz9bVgSFax2HhyKAhhOQwG5XLIgGWZSTnUQqvVqi6HaoJl2fIVK1YYdu7cOZzOcTQA9Pf3c4FAwMmybEyDxJXPAN/qAalwweOBINjK2siNBI1g1S/h6t0IA9cGmiIR4nhMEBYEZ90HMPH7hPlsEfLZIgBhsqYIEya/i3LIy7xDgKZJ0DSDnBwWeXm50Gp1yMm5cHKoMsgHH3ywdufOnU6k4fDQkzvyXq+3U4lI7aIbcO70CZRSAghZhQ3xPIbKZsJY2xh7VsYEruaXGPa7Ab8LYPIAbZmiAcnkMBQKgeNCIAix/WKh02mg1+dPGzlUG7W1tfUADqRzDI3wICY3NjbaaTKZFkfvQOWawPzkETi2bYG+3w6KJOEXAP8V82C4eVViJdcUhV9IJofh9kvuHTIMC4PBMOkdTm85VBuFhYVyhyflGskDCHk8g2ctlgrlnYrNMPzXL8ANDyE0PgqqoBiGnJyY/eS1K/xdiCOHAiiKAsMw0GhYmExGyTsUCQO+GbUrE2TiuYrSytls1rNz585NuDNlygNlyotov9KRQ50uDzqdDizLXnJyKAiRFeN82qzVakUiSYSTl5NCInLPnj0dN98c2WeLlUNAEKaCvXI5pOlwZ1mvN0idZZZlQZIkSJK8JMgCYgmLt00Ota+NZdnKsrIyjdPpTPnE4sCwDkDJ6dNnjlIUlS+PbgSDU94hRZGSHGq1Wuj1U3IoknWpEyYPGIjvHMfB4/HA5/NBr9cjPz9ful5SFl5U89rXr1//H4888shxpJj2IXmtAEIul6vLYNDnh+WQgVarQWHhpSuHSoiO7MjJ8/l86OvrQ19fH5xOJ5xOJ/r6+nDu3DnpzwwABoMBV199Nb773e+irKxMIlUQBNXuy5VXXlkP4ARSdHjEoCgHIGSxmDtnzpx59aUmh6lC3p77fD4cPnwYVqtVIm5wcDCpjALA2NgY9u3bh88//xwrV67ELbfcIjUhaqG4uDittA+RSAFAyOv1nmWY6ZsWKt7kbP5ggiAgEAigubkZVqs1rXKjEQqFsHXrVoyMjOCOO+6Q7FKjAuTm5qbluYp/IR4AZ7PZzmZtQZaIljx5ex0ti5me/+TJk4okxis7ma27du3CwYMHwU+GKzO1TQ6dTpdWzFUkUgDAHTx4sCNrC1JEIrKmRtY5aShpeHgYw8PD4DguxiFRq/x4YBgGFosFs2fPRn5+vuL+W7Zsgd/vl8jMFpPB85TTPuRZcnqDwWAeHh4+RZJkbG9fBcgvPtpDFAkcGBiQnAy5wzE2NgaCILBw4ULcd999oGk6bS9ZLMfn86G5uRk9PT0RvxkMBpjNZpjNZpSVlUnvhYWFUpCC53ns27cPb731Fjgusov30EMP4frrr5ciUNli9erV32pubm4D4Eu2r5zIHADFY2Nju/R6fUPWVkRBThrP8/B6vWhtbUVvb69EVn9/PwKB5BkBDz/8MK677rq0HbJoZ+fo0aPw+/0oLS1FWVkZjEaj9OeQt3fRZXAch23btuH999+P2L548WI88MAD0p8sW+zZs+eHy5cv34FwFySh/MidHR5AaHx8vFNtIuU3cHx8HNu2bcO+ffvg9/tTPl507wHg3LlzGcmqeA6SJJGTk4OFCxdGdBkSkReNpUuXxhBps9mkWq8GkRaLJWXPVZ6TwQMIDQ8Pd5aUlGRthAg5iTabDS+88ALcbnfCfRP9RlEU5s6dm/GNkpOZbL94dhAEgdzcXOTm5mJ4eGrY0Ol0RrS52ZJpMplS9lzlRAoAuL6+vo66urqsDIgGz/Nwu91Yt24dRkZG0q5NBEEgLy8PFosFN910E2bOnJnVTVKjthAEgbKysggivV4vBgcHUVxcnPX5gfSC59FEhlpaWjoWL44ZzcoIcidm48aNERetBIqiUFJSIjkccqdDq9VKkncxgxVy+TWbzWhtbY34YzqdThQVFalSVk5OjtgFSeq5RhPJv/LKK52PPPIIT8TkOWYGQRDQ2tqKr776SvouwmAwYPHixaiqqkJZWRmKi4tB02GT5E5HvLbrYkaexBoZrS4OhwPJRpFSBU3T5bfddlvuhx9+mDTtI0ZaT548OREIBOwajWaGGsYIgoBDhw7FXHBxcTF++9vfoqCgICbgnixCMh1ChyKRAGJqpBoBgckyiPvvv7/2ww8/tCOJwyOvdXLPtUsVSxC+yLNnYwNGP/7xj1FYWAiapqXcGnmMN9FruqC8vDyGNLnDowZqa2tFzzUhouWTBxAaGRnJOlQn996GhoYitgFAU1OTRN50J0wJBEGgoKAAOVGZEg6HQ5XIk4j8/PyUptopEul2uzuztkAGiqJiLkqtUNbFBEEQKC0tjfjTDg4Owuv1qlYjDQaDPFsgLqJ/FACEOjs7s465ymtWUVFRTEy1v78/2yIuGuTXJraTcjgcDtXKknmuadVIAQD/3nvvqRo8N5tjk9jVdAqiEW8UI9UgeaogCEJqJ+Uvl8ul2rWxLFs5Y8YMDTIgknv77bcHgsGgRw1DxP5WNORtiRqIJih6FGUqKYyTRlmiy0+XcIIgUFtbG7O9qKhItTaeJEl2zZo1lUji8ERPm5I814mJiS6TyVSQrSHyf60cTqcz21MDiE3dENvesbExOBwOOBwOOJ1OOBwODAwMID8/H7feeiuamppiwnTRTooon/Lv0dfW1NSEm266Cbt37wYA3Hzzzaivr1fVWZs3b14dgONI0AVRmv/GAQiNjY11mkyma9QwJJG0xrtJ6UAQBASDQezevRtHjhyBw+GIG0Xq7e3FqVOn8Oijj2L+/PkSmeKfwO12w+FwwOv1ora2FiUlJXEjSQRBgKIo/OQnP8EPfvADAOEgh9qRp6KioqTBcyUiBQAhj8dz1mJRZ25iSUkJaJpGMDg1pa6vrw8cx2U1dievhX/729+wf/9+aXsi8DyPv/zlL7jqqqtQWloKj8cDh8OBvr4+BAIBKeBNkiRuv/12rFy5MibpTB58F4Po4nY1Uz6A1NI+lIiU0j6yDTWJFyXGUO12u/RbMBiE2+1GeXl5SudSIkcksaurC/v27UvLNp7nceTIkYTlcRyHd955B7W1tZgzZ46itIqkK/2mFmQJy3FPqtQ3EQCEPv/8c1U8VyU3XaxJyRwepVSQaAfG6XTir3/9a0IbMvFa5fsdPnw4br/3QgQzNBpNNZKkfcSTVv7555+3rV271kuSpDZbQxIFmK+5RrkZjvY+g8Eg+vr6YLfbJefFbrfDarVmlfSUyjHyAWPxei4kKIoy/f73vzevXbt2KN4+8ZZf4bxeb8Dr9Xbr9frZahiTSYBZEAT4/X68+eab+PTTT6U2Nh3CtFotCgoKpP5dKqkk0RCVQ62R/0zwne98p27t2rVtiOPwxK2RmPRc1SCSIAhYLJYYAiYmJhT3l2cV/P3vf8eePXtSKkeeRbBo0SIsW7YMVVVVkqPCcRxaW1uxa9cuHDt2LO7x0RgcHMTExITk0FwMJEv7iFcjpbSP0tLSrI0gCAKzZs1CeXl5RPjqmmuuSZhS4fV68emnn8ZsT4SCggL84he/QG1tbcy5aZrGnDlz0NTUhCNHjmD9+vXwelNbUdPhcFxUIk0mU8LgeTwixbSPs/X19VkbQRAEaJrGE088gXfffRcejwfXXXcdFi1alJDI8fHxiDkXyZCbm4vVq1fDbDaD53ns3bsX+/fvh81mA0mSqKysxPLly3Httddi/vz5MBqNePbZZ1OSbIfDgYYG1ZMLU0ayhOVERIZaWlo6lixZkpUBche9uLgYP/3pT6XfEs2XEPN0WJZN2q6JBNx///0wm83wer1Yt24dWltbI/ZraWnBqVOnsHDhQvzsZz9DY2MjVq1ahbfffjvpddjt9vMWG04FOTk5tUjgucZzZwUA/EsvvdQlCEJKEy0TQZ5rIw4kpzKziyRJyKU9UTeipqYG3/72t0EQBF555RUpl0Zp3wMHDmDz5s0gCAIrVqyAyaS8ULP8OJFINQeN0wHDMOZVq1YZEadGJiKS++qrryb8fr89zj5pIV6nOV7oS97/THTzxN8WLlwIgiDQ1taGL774IunN3rFjBwYHB8GyLObPn5+0n6l2kD8DEPfee2/cdjJhjYTKaR8A0uo0iwF3IHmnvrq6GgRB4OjRo3HPJz8uFArhxIkTIAgCNTU1SY/p7++fXM7s4pFZXV1dhzSlFZhK+1A1WyBdKHVblGA0GiEIAjweT8qRnIGBAQiCIB2b6BiO49DX16fqtaWLRGkfSYl0u90XbIZWNOQ1MhrRN1zsRhgM8Vdcjj7GYDCAIAj4fEnnyABIzeFJNxSYDoxGY9y0j0RECgBCHR0dF3XOpDwilOjm9Pb2AgDmzJmTco0U9+3u7o7YHu/4RETGiwmLv6mBybQPcUXPCCQjkt+6dWu7KlZkAIIgoNFoFFPwo2/y4cOHAQBXXnklKisrk557wYIF0oD34cOHU6pB8tEbJYht7969e/GPf/wDZ86ckeZzqkEmy7KVNTU1imkfyYjktm7dOhgMBgeytiJNxPNc492U48ePo7OzEyRJ4le/+hUKCqaSG6KPnTVrFh588EEAwMGDByOyFeLVxkRdEPEzz/N4+eWX8cILL+Cf//wnVq9ejePHj6tWIwmCYFavXl0FhbSPpEQinPZxUR2eVMYsBUHASy+9hImJCZjNZjQ3N+OGG26ARjO1tr7RaMTKlSvxxz/+EQaDAW63Gxs2bEi5PZMHz5XK9/v92Lt3r/Sd53ns3LlT1dTPuXPnKjo8yRafl4LnJpNpvmrWpAEx4A7EzpOMhtVqRXNzM37zm98gLy8PDz30EB544AGcO3cOFEWhuLhYGtG32+149tlnk04sEssFwrOtBgYGEC/+LEaq5OsdiMNs4vdsR0+Ki4trMfUMFulGJJuoIwAIDQwMXLQaGT1ykszZOHPmDB577DHs3LkTPp8PNE2jvLwcpaWlIEkSo6Oj2LJlC5588smY7kQqTtLo6GhcWymKkhKWRfT390+uEKaOvBqNxoxrJGe1WjvmzZuniiGZQJ47lMoNGRkZwWuvvYY33ngDdXV1KCoqAsdx6O/vR2dnZ1qBeHl5Wq1WMSFZnqNjsVhgs9mk33ieh9PpRHV1dcplJoJWq1UMnicjUgAQ2r9/f8ett96qiiERJ5fdpEQzr4xGI4xGI0ZGRtI6t9/vR0tLS9q2xMM999wjzdOMZ6tS6qfNZkNVVewS4JlAo9HUkCRJ8zwfoaapSCv/5z//2c5xnPIocAZQkqxEzka8wIBcblPthKfaxwQAlmVRWVmJxYsXY82aNVixYkXSNfcqKiKXShUEQUoVUQMURRnXrFlThijuUnnSDuf3+4Ner7fbYDBcka0hclddzCMVh6vizY8UJevrr7+Oe75UtyvBaDTCYrHEvOQ5reLoTaK1B+JlQiTrf6aLpUuX1gE4A5nDk4q0Sqt9qEEkECbRbrejublZGnn/9a9/jXnz5kWMX4ogCCJuJz9VwsTxUJGk8vJyVFRUwGKxIDc3NyaYH++z+D0elHKB1U7eKisrq0dU2kcqNZIHEBoaGlIl7QMI3/wNGzZI/9Th4WG89NJLePHFF+MOdy1ZsgTvvvsuBgYSxyZYloXZbI6pXeXl5dJcRiXS5NuVkOpojU6nQ2FhoRSQB8I1UuyCqJG8pfSQl1SIlNI+1Ep1EAQhxvXv6+uDx+NBcXFxzMWSJAmDwYC1a9fitddeQ0tLCzQaDcrLy2NqV0lJScRS2olIU0KmNzq6GZAvQeP3++FyuVJOxk4GnU4nZgukRSQPIHTixImOpUuXqmIIEJ5GIHfTgfA/N3pFDHlqfnl5OZ5++ukYbzeeHMrfo3E+0xorKipw4sSJCDttNpti1yUTyB7yIjXYqa7cwb/44oudggppHyKU/p3RxIqQTz2Qp4pEv6bDOgTxuiDnzp1TrQyGYUrvuOMOE9IkUgDAtbW1eX0+n/KdThMEQUS46akME8lrmEjWdF04Qh7fFZFOECIFEHfeeaeYLUAAqRPJA+DUCp7L3fRo+UnUt5tOZIlQ6pO2tLTEbMvPV/fR09FpHylLK4Cgmmkf8kB4KjXyYiPR8JY40sFxHI4fPx6TVE0QBBoaGlT900UnLKf66F0eAOdyuc6qEWoiiPB8wuiwm9vthtfrVW2ZzGyQLPIkJ9DtdsNqteLo0aPYsWNHjIzOmTNH1enoAGA0GuUOD58qkQKAUHt7e8e1116blQHyDr/FYomJn9rtdjQ2Kjxv6wJCqcYFg0E4HA7YbDZYrVbYbDbYbDbY7faE0w4IgsBdd92l+ixmWcJyWjVSAMBv2bKl46677sraCLFts1gsOH36dMRvNpvtoqbmy2vaJ598ggMHDkhPIoheMTkV/PCHP4xYr0AtMlmWnTl79uycr7/+mgRSbyMFAKEPPvhgKBgMutQwJNpzFZFugDmdIHg659yxYweef/55HDp0CHa7PSUSo8tftWoV7r777ohnLasFgiCYJ554ogqTHKZVIwEEJ1f7yHpBUpHI6Jve09OjGJdMFhyX768Ur00HgiDgs88+U9yeKENBRE1NDe677z5cddVVGT0wO1U0NTXVATgKKDwcOwF4AKHR0dFOk8mUXUM5iVmzZsVsO3nyJFwulzSiLyKesyEIgrQUy+DgIGpqaqRRCyDzm1dSUhI3N0eOwsJCVFRUoKKiAjNmzEBTUxMqKysj+rrZ2JEIk6t9kMiESI/Hc1ZJEtMFQYSXNquoqJAiOoIQfgLAM888g8cffxwWi0W6AT6fT1o3R5x2Ln6W590wDIOnnnoKCxYsyCpuevfdd6Orqwvt7e2gKApms1kiTCStoqICOp0uaUDifHngMs81rRIoAKZt27atvO222/4nWyMEIZwDum3bNrz66quxhVEUqqurwbKsFFBPNRuturoaL7zwQsQivunYBUDqFw4NDUGv1ydcEFi+XY7z3YUaGRn5l8lkuh3AcDotsJj2oVrCMkmSWLFiBWbOnBnjrIRCIbS1taGlpQVutzslEsVjM1knQIR488UpgIWFhcjJyQFN09JjgKPjuvHChecbwWBwHGmE6ESIaR8OjuPG1TCEJEloNBo89dRTyMvLS92QBJ4qQRBYtWpVVnYliuvGi+9eDLhcrtNIY2BZhACACwaDocm0j6ZsjJAPT82YMQPPPfccnnvuOXR2dqbsHQLhALW87brqqqswe/bsrJ2Mix1ZSgZBEEKvv/76DoSTyIV0rdUAKHQ6na+YzebbVDJI6oAHg0F88skn+Oijj9De3h4hpyaTSdHZkCcdy1+X+nMuk6Gzs3NTTU3N0wBcALzpXiUDIL+1tXV1Q0PDL9UyKjohS3zkkrjuaUFBgTQFLp00jW8qiR6P58iCBQt+2t7ebgUwAiCYjrQCkw6Pw+HoUDOMJpdZMeXeaDRKcx2TeYfy377JEASBa29vf/d73/vef7e3t59D+JlZHJBeGwlMjoKcOHGiY9myZaoaKY/gJEs5/HeBIAiC1+vtGxoa6rHZbKc2bty48+WXX24FMIRwTfQjzEnqz7mfBAlAV1VVVXH27NlTBJFWQOEy4oDnef/o6Kh9aGio1+Vy9fT29vYcO3as66233urp7OwcBxBAmDQvgDEAE5giUQDSJ5IAoAVQPDExsVer1aqTB/9vgkAgMDIyMmIdHBzs6evr6+ns7Oz5/PPPu95880271+sNAAgBCCZ4D0y+OEzWRBGZtJHSah+XiYzFpByeGxkZ6XW73T1Op7Pn9OnT3Tt27OjetWuXG8okRb84TJHFyz6L9z8GmUijtNpHUVHRDRkc/40Ax3HB8fFxmyiHVqu159ixY93vvPNOd1tb2zgiSVIiTk6WnDRB9g7Ze0JkSiTncrnOqjVVbDojGAyOjoyM9A4ODvaKcnjw4MHuN954wzY+Pu5HLEHRZCnVMJEo+SsrZEKkACDU1tbWcd1112Vb/rSAIAiCz+dzDQ8P93o8nh673d7T2tra89FHH3Vt377dhUiSUpXD80JYPGTiy5MA9LfcckvN9u3bj2V4josCnueDY2Nj9qGhoV63291jtVp7vvzyy+7Nmzd3nz59egwXWA7VRCYkiJ5ryaTnWqmuSdkjGAyOjY6OWj0eT29/f393V1dXz8GDB7s3bdpkHR4eDiC+Z3hB5VBNZCqtHICA1Wr9qL6+/mGVbUrZDq/X6x4ZGZHksK2trfvjjz/ufv/9911ITNa0kEM1kaks0gByv//979dv3rx5O8MwWT+xJx54ng+Oj487JuWw12q1dp88ebJ78+bN3adOnRpFYrKCmPSyEV8OgUuIsHjIlEgSYXkt3LBhw/+65557/i9FUbETHtJAMBgcHxsbE+Wwp7u7u/vQoUPdmzZtsno8Hj+S973kZEX3u+REXdKExUM2jgoDQA+g6Pnnn1/80EMP/VGv1yd7nK/g8/kGJr3DXqfT2XPmzJnu3bt3d7/33nv9giAkk0Ox/YquXZekHKqJbIgkALAIk5lvNpuL1q9ff/O3vvWtRSaTaQYAjI2NnZuUw56TJ092b926tev48eMjSK3tiieH/9aExUO2XQcS4fZSizChBgA5mEplF9uny3J4nqFGH5BAOMOOmXyxmFr0TlrPDpfl8LxCzc48gamJl+KAopIUXibsPOD/A1j7+vDiyHV0AAAAAElFTkSuQmCC" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1417"
-       id="linearGradient1419"
-       x1="17.249893"
-       y1="29.643475"
-       x2="17.249893"
-       y2="3.0563629"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1033"
-       id="linearGradient1035"
-       x1="13.530622"
-       y1="7.7060499"
-       x2="20.747488"
-       y2="26.617634"
-       gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1056"
-       id="radialGradient1058"
-       cx="11.697494"
-       cy="12.584596"
-       fx="11.697494"
-       fy="12.584596"
-       r="6.8319204"
-       gradientTransform="matrix(3.8446428,6.9187561e-8,-3.9868318e-8,2.2154191,-33.656405,-16.192719)"
-       gradientUnits="userSpaceOnUse" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -169,9 +104,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="3.759267"
-     inkscape:cx="64.345102"
-     inkscape:cy="106.38527"
+     inkscape:zoom="42.531251"
+     inkscape:cx="76.920684"
+     inkscape:cy="71.960184"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      showgrid="false"
@@ -188,9 +123,9 @@
     <g
        id="g1702"
        transform="matrix(0.97573206,0,0,0.97573206,-65.748383,-37.203094)"
-       style="opacity:0.2967651">
+       style="opacity:0.29676508">
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1634"
          width="29.810888"
          height="29.810888"
@@ -206,9 +141,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1638"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.30000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1640"
          width="29.810888"
          height="29.810888"
@@ -224,9 +159,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1642"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.40000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1644"
          width="29.810888"
          height="29.810888"
@@ -242,9 +177,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1646"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.7;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.69999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1648"
          width="29.810888"
          height="29.810888"
@@ -260,9 +195,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1650"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.80000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1652"
          width="29.810888"
          height="29.810888"
@@ -278,9 +213,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1654"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.20000005;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.39999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1656"
          width="29.810888"
          height="29.810888"
@@ -296,9 +231,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1658"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.79999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1660"
          width="29.810888"
          height="29.810888"
@@ -314,9 +249,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1662"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.20000005;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1664"
          width="29.810888"
          height="29.810888"
@@ -332,9 +267,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1666"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.5999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1668"
          width="29.810888"
          height="29.810888"
@@ -350,9 +285,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1670"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3.4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3.4000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3.8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3.79999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1672"
          width="29.810888"
          height="29.810888"
@@ -368,9 +303,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1674"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:4.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:4.19999981;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:4.6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:4.5999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1676"
          width="29.810888"
          height="29.810888"
@@ -386,10 +321,10 @@
          height="29.810888"
          width="29.810888"
          id="rect1678"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
     </g>
     <rect
-       style="fill:url(#linearGradient1419);fill-opacity:1;stroke-width:2.68768;stroke-linecap:round;stroke-linejoin:round"
+       style="fill:#ffffff;fill-opacity:1;stroke-width:2.68768001;stroke-linecap:round;stroke-linejoin:round"
        id="rect849"
        width="29.087439"
        height="29.087439"
@@ -398,19 +333,14 @@
        rx="6.4494534"
        ry="6.4494534" />
     <rect
-       style="opacity:1;fill:url(#linearGradient1035);fill-opacity:1;stroke:none;stroke-width:15;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.9818184"
+       style="opacity:1;fill:#d3e0e5;fill-opacity:1;stroke:none;stroke-width:0.07451762;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.9818184"
        id="rect1421"
-       width="24.734966"
-       height="24.4561"
-       x="4.5725026"
-       y="4.8342566"
-       rx="4.1972442"
-       ry="4.1972442" />
-    <path
-       inkscape:connector-curvature="0"
-       id="rect875-5"
-       d="m 10.495751,10.422566 c -0.147493,-0.0014 -0.267059,0.115937 -0.268449,0.263419 l -0.0046,0.487492 -0.02143,2.269561 -0.07708,8.161491 -0.01611,1.705727 c -0.0014,0.147501 0.115921,0.267495 0.263423,0.268881 l 5.215746,0.04927 c 0.147492,0.0014 0.267504,-0.116366 0.268897,-0.263867 l 0.02604,-2.756607 c 0.0014,-0.147501 -0.116368,-0.267503 -0.26387,-0.268889 l -2.405863,-0.02273 0.06212,-6.578281 2.405868,0.02272 c 0.147491,0.0014 0.2675,-0.11593 0.268893,-0.263421 l 0.02604,-2.757053 c 0.0014,-0.147491 -0.11637,-0.267057 -0.263872,-0.268443 z m 7.796981,0.07364 c -0.147491,-0.0014 -0.267502,0.11592 -0.268894,0.263421 l -0.02604,2.757054 c -0.0014,0.14749 0.11637,0.267056 0.263873,0.268443 l 2.405865,0.02272 -0.06212,6.57828 -2.405869,-0.02271 c -0.147492,-0.0014 -0.267505,0.116376 -0.268898,0.263867 l -0.02603,2.756598 c -0.0014,0.14751 0.116365,0.267513 0.263866,0.268899 l 5.215744,0.04927 c 0.147492,0.0014 0.267062,-0.116374 0.268455,-0.263875 l 0.01611,-1.705737 0.07707,-8.16148 0.02143,-2.269562 0.0046,-0.487482 c 0.0014,-0.147502 -0.115926,-0.267049 -0.263426,-0.268445 z"
-       style="opacity:1;fill:url(#radialGradient1058);fill-opacity:1;stroke:none;stroke-width:0.30070975;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke" />
+       width="24.879999"
+       height="24.879999"
+       x="4.4933338"
+       y="4.4933338"
+       rx="4.2218547"
+       ry="4.2699952" />
     <path
        style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;paint-order:fill markers stroke"
        d="m 32.173292,11.90058 c -0.147493,-0.0014 -0.267059,0.115937 -0.268449,0.263419 l -0.0046,0.487492 -0.02143,2.269561 -0.07708,8.161491 -0.01611,1.705727 c -0.0014,0.147501 0.115921,0.267495 0.263423,0.268881 l 5.215746,0.04927 c 0.147492,0.0014 0.267504,-0.116366 0.268897,-0.263867 l 0.02604,-2.756607 c 0.0014,-0.147501 -0.116368,-0.267503 -0.26387,-0.268889 l -2.405863,-0.02273 0.06212,-6.578281 2.405868,0.02272 c 0.147491,0.0014 0.2675,-0.11593 0.268893,-0.263421 l 0.02604,-2.757053 c 0.0014,-0.147491 -0.11637,-0.267057 -0.263872,-0.268443 z m 7.796981,0.07364 c -0.147491,-0.0014 -0.267502,0.11592 -0.268894,0.263421 l -0.02604,2.757054 c -0.0014,0.14749 0.11637,0.267056 0.263873,0.268443 l 2.405865,0.02272 -0.06212,6.57828 -2.405869,-0.02271 c -0.147492,-0.0014 -0.267505,0.116376 -0.268898,0.263867 l -0.02603,2.756598 c -0.0014,0.14751 0.116365,0.267513 0.263866,0.268899 l 5.215744,0.04927 c 0.147492,0.0014 0.267062,-0.116374 0.268455,-0.263875 l 0.01611,-1.705737 0.07707,-8.16148 0.02143,-2.269562 0.0046,-0.487482 c 0.0014,-0.147502 -0.115926,-0.267049 -0.263426,-0.268445 z"
@@ -422,7 +352,7 @@
        d="m 32.173292,11.90058 c -0.147493,-0.0014 -0.267059,0.115937 -0.268449,0.263419 l -0.0046,0.487492 -0.02143,2.269561 -0.07708,8.161491 -0.01611,1.705727 c -0.0014,0.147501 0.115921,0.267495 0.263423,0.268881 l 5.215746,0.04927 c 0.147492,0.0014 0.267504,-0.116366 0.268897,-0.263867 l 0.02604,-2.756607 c 0.0014,-0.147501 -0.116368,-0.267503 -0.26387,-0.268889 l -2.405863,-0.02273 0.06212,-6.578281 2.405868,0.02272 c 0.147491,0.0014 0.2675,-0.11593 0.268893,-0.263421 l 0.02604,-2.757053 c 0.0014,-0.147491 -0.11637,-0.267057 -0.263872,-0.268443 z m 7.796981,0.07364 c -0.147491,-0.0014 -0.267502,0.11592 -0.268894,0.263421 l -0.02604,2.757054 c -0.0014,0.14749 0.11637,0.267056 0.263873,0.268443 l 2.405865,0.02272 -0.06212,6.57828 -2.405869,-0.02271 c -0.147492,-0.0014 -0.267505,0.116376 -0.268898,0.263867 l -0.02603,2.756598 c -0.0014,0.14751 0.116365,0.267513 0.263866,0.268899 l 5.215744,0.04927 c 0.147492,0.0014 0.267062,-0.116374 0.268455,-0.263875 l 0.01611,-1.705737 0.07707,-8.16148 0.02143,-2.269562 0.0046,-0.487482 c 0.0014,-0.147502 -0.115926,-0.267049 -0.263426,-0.268445 z"
        style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;paint-order:fill markers stroke" />
     <path
-       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;paint-order:fill markers stroke"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.30000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;paint-order:fill markers stroke"
        d="m 32.173292,11.90058 c -0.147493,-0.0014 -0.267059,0.115937 -0.268449,0.263419 l -0.0046,0.487492 -0.02143,2.269561 -0.07708,8.161491 -0.01611,1.705727 c -0.0014,0.147501 0.115921,0.267495 0.263423,0.268881 l 5.215746,0.04927 c 0.147492,0.0014 0.267504,-0.116366 0.268897,-0.263867 l 0.02604,-2.756607 c 0.0014,-0.147501 -0.116368,-0.267503 -0.26387,-0.268889 l -2.405863,-0.02273 0.06212,-6.578281 2.405868,0.02272 c 0.147491,0.0014 0.2675,-0.11593 0.268893,-0.263421 l 0.02604,-2.757053 c 0.0014,-0.147491 -0.11637,-0.267057 -0.263872,-0.268443 z m 7.796981,0.07364 c -0.147491,-0.0014 -0.267502,0.11592 -0.268894,0.263421 l -0.02604,2.757054 c -0.0014,0.14749 0.11637,0.267056 0.263873,0.268443 l 2.405865,0.02272 -0.06212,6.57828 -2.405869,-0.02271 c -0.147492,-0.0014 -0.267505,0.116376 -0.268898,0.263867 l -0.02603,2.756598 c -0.0014,0.14751 0.116365,0.267513 0.263866,0.268899 l 5.215744,0.04927 c 0.147492,0.0014 0.267062,-0.116374 0.268455,-0.263875 l 0.01611,-1.705737 0.07707,-8.16148 0.02143,-2.269562 0.0046,-0.487482 c 0.0014,-0.147502 -0.115926,-0.267049 -0.263426,-0.268445 z"
        id="path1092"
        inkscape:connector-curvature="0" />
@@ -430,7 +360,7 @@
        inkscape:connector-curvature="0"
        id="path1094"
        d="m 32.173292,11.90058 c -0.147493,-0.0014 -0.267059,0.115937 -0.268449,0.263419 l -0.0046,0.487492 -0.02143,2.269561 -0.07708,8.161491 -0.01611,1.705727 c -0.0014,0.147501 0.115921,0.267495 0.263423,0.268881 l 5.215746,0.04927 c 0.147492,0.0014 0.267504,-0.116366 0.268897,-0.263867 l 0.02604,-2.756607 c 0.0014,-0.147501 -0.116368,-0.267503 -0.26387,-0.268889 l -2.405863,-0.02273 0.06212,-6.578281 2.405868,0.02272 c 0.147491,0.0014 0.2675,-0.11593 0.268893,-0.263421 l 0.02604,-2.757053 c 0.0014,-0.147491 -0.11637,-0.267057 -0.263872,-0.268443 z m 7.796981,0.07364 c -0.147491,-0.0014 -0.267502,0.11592 -0.268894,0.263421 l -0.02604,2.757054 c -0.0014,0.14749 0.11637,0.267056 0.263873,0.268443 l 2.405865,0.02272 -0.06212,6.57828 -2.405869,-0.02271 c -0.147492,-0.0014 -0.267505,0.116376 -0.268898,0.263867 l -0.02603,2.756598 c -0.0014,0.14751 0.116365,0.267513 0.263866,0.268899 l 5.215744,0.04927 c 0.147492,0.0014 0.267062,-0.116374 0.268455,-0.263875 l 0.01611,-1.705737 0.07707,-8.16148 0.02143,-2.269562 0.0046,-0.487482 c 0.0014,-0.147502 -0.115926,-0.267049 -0.263426,-0.268445 z"
-       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;paint-order:fill markers stroke" />
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.40000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;paint-order:fill markers stroke" />
     <path
        style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;paint-order:fill markers stroke"
        d="m 32.173292,11.90058 c -0.147493,-0.0014 -0.267059,0.115937 -0.268449,0.263419 l -0.0046,0.487492 -0.02143,2.269561 -0.07708,8.161491 -0.01611,1.705727 c -0.0014,0.147501 0.115921,0.267495 0.263423,0.268881 l 5.215746,0.04927 c 0.147492,0.0014 0.267504,-0.116366 0.268897,-0.263867 l 0.02604,-2.756607 c 0.0014,-0.147501 -0.116368,-0.267503 -0.26387,-0.268889 l -2.405863,-0.02273 0.06212,-6.578281 2.405868,0.02272 c 0.147491,0.0014 0.2675,-0.11593 0.268893,-0.263421 l 0.02604,-2.757053 c 0.0014,-0.147491 -0.11637,-0.267057 -0.263872,-0.268443 z m 7.796981,0.07364 c -0.147491,-0.0014 -0.267502,0.11592 -0.268894,0.263421 l -0.02604,2.757054 c -0.0014,0.14749 0.11637,0.267056 0.263873,0.268443 l 2.405865,0.02272 -0.06212,6.57828 -2.405869,-0.02271 c -0.147492,-0.0014 -0.267505,0.116376 -0.268898,0.263867 l -0.02603,2.756598 c -0.0014,0.14751 0.116365,0.267513 0.263866,0.268899 l 5.215744,0.04927 c 0.147492,0.0014 0.267062,-0.116374 0.268455,-0.263875 l 0.01611,-1.705737 0.07707,-8.16148 0.02143,-2.269562 0.0046,-0.487482 c 0.0014,-0.147502 -0.115926,-0.267049 -0.263426,-0.268445 z"
@@ -440,6 +370,66 @@
        inkscape:connector-curvature="0"
        id="path1098"
        d="m 32.173292,11.90058 c -0.147493,-0.0014 -0.267059,0.115937 -0.268449,0.263419 l -0.0046,0.487492 -0.02143,2.269561 -0.07708,8.161491 -0.01611,1.705727 c -0.0014,0.147501 0.115921,0.267495 0.263423,0.268881 l 5.215746,0.04927 c 0.147492,0.0014 0.267504,-0.116366 0.268897,-0.263867 l 0.02604,-2.756607 c 0.0014,-0.147501 -0.116368,-0.267503 -0.26387,-0.268889 l -2.405863,-0.02273 0.06212,-6.578281 2.405868,0.02272 c 0.147491,0.0014 0.2675,-0.11593 0.268893,-0.263421 l 0.02604,-2.757053 c 0.0014,-0.147491 -0.11637,-0.267057 -0.263872,-0.268443 z m 7.796981,0.07364 c -0.147491,-0.0014 -0.267502,0.11592 -0.268894,0.263421 l -0.02604,2.757054 c -0.0014,0.14749 0.11637,0.267056 0.263873,0.268443 l 2.405865,0.02272 -0.06212,6.57828 -2.405869,-0.02271 c -0.147492,-0.0014 -0.267505,0.116376 -0.268898,0.263867 l -0.02603,2.756598 c -0.0014,0.14751 0.116365,0.267513 0.263866,0.268899 l 5.215744,0.04927 c 0.147492,0.0014 0.267062,-0.116374 0.268455,-0.263875 l 0.01611,-1.705737 0.07707,-8.16148 0.02143,-2.269562 0.0046,-0.487482 c 0.0014,-0.147502 -0.115926,-0.267049 -0.263426,-0.268445 z"
-       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;paint-order:fill markers stroke" />
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0;paint-order:fill markers stroke" />
+    <ellipse
+       style="opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.26458333;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.8;paint-order:markers fill stroke"
+       id="path877"
+       cx="16.933332"
+       cy="16.933332"
+       rx="12.337402"
+       ry="12.337403" />
+    <circle
+       cy="16.933332"
+       cx="16.933332"
+       id="ellipse879"
+       style="opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.26458333;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.8;paint-order:markers fill stroke"
+       r="7.4808536" />
+    <ellipse
+       style="opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.26458333;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.8;paint-order:markers fill stroke"
+       id="ellipse881"
+       cx="16.933332"
+       cy="16.933332"
+       rx="5.2871022"
+       ry="5.2871017" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:0.26458707;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.8"
+       d="M 4.5870108,4.5868797 29.279656,29.279787"
+       id="path883"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path885"
+       d="M 29.279788,4.5868805 4.5868786,29.279786"
+       style="fill:none;stroke:#ffffff;stroke-width:0.26458851;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.8" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:0.26458333;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.8"
+       d="M 16.933333,4.5658333 V 29.300833"
+       id="path887"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path891"
+       d="M 16.933333,4.5658333 V 29.300833"
+       style="fill:none;stroke:#ffffff;stroke-width:0.26458333;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.8" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:0.26458333;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.8"
+       d="M 16.933333,4.5658333 V 29.300833"
+       id="path893"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path889"
+       d="M 29.300833,16.933333 H 4.5658336"
+       style="fill:none;stroke:#ffffff;stroke-width:0.26458333;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.8" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:0.26458333;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.8"
+       d="M 29.300833,16.933333 H 4.5658336"
+       id="path895"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path897"
+       d="M 29.300833,16.933333 H 4.5658336"
+       style="fill:none;stroke:#ffffff;stroke-width:0.26458333;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.8" />
   </g>
 </svg>

--- a/128x128/apps/badge.svg
+++ b/128x128/apps/badge.svg
@@ -2278,114 +2278,6 @@
          stdDeviation=".73305274"
          id="feGaussianBlur17" />
     </filter>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient1054">
-      <stop
-         style="stop-color:#ffc76a;stop-opacity:1"
-         offset="0"
-         id="stop1050" />
-      <stop
-         id="stop1058"
-         offset="0.11614581"
-         style="stop-color:#fabd58;stop-opacity:1" />
-      <stop
-         style="stop-color:#e49742;stop-opacity:1"
-         offset="0.13221182"
-         id="stop1060" />
-      <stop
-         id="stop1062"
-         offset="0.16846231"
-         style="stop-color:#eda947;stop-opacity:1" />
-      <stop
-         style="stop-color:#f9c36b;stop-opacity:1"
-         offset="0.18334739"
-         id="stop1064" />
-      <stop
-         id="stop1066"
-         offset="0.30698717"
-         style="stop-color:#fbb74e;stop-opacity:1" />
-      <stop
-         style="stop-color:#e3933b;stop-opacity:1"
-         offset="0.31985357"
-         id="stop1068" />
-      <stop
-         id="stop1070"
-         offset="0.33463591"
-         style="stop-color:#ea9c41;stop-opacity:1" />
-      <stop
-         style="stop-color:#febc66;stop-opacity:1"
-         offset="0.37737453"
-         id="stop1072" />
-      <stop
-         id="stop1074"
-         offset="0.39273262"
-         style="stop-color:#f8b349;stop-opacity:1" />
-      <stop
-         style="stop-color:#f6b141;stop-opacity:1"
-         offset="0.48691064"
-         id="stop1076" />
-      <stop
-         id="stop1078"
-         offset="0.49985108"
-         style="stop-color:#df912b;stop-opacity:1" />
-      <stop
-         style="stop-color:#ef9f38;stop-opacity:1"
-         offset="0.51570511"
-         id="stop1080" />
-      <stop
-         id="stop1082"
-         offset="0.55728894"
-         style="stop-color:#f4bb5a;stop-opacity:1" />
-      <stop
-         style="stop-color:#f7aa35;stop-opacity:1"
-         offset="0.57362735"
-         id="stop1084" />
-      <stop
-         id="stop1086"
-         offset="0.66876256"
-         style="stop-color:#f9a937;stop-opacity:1" />
-      <stop
-         style="stop-color:#e38e29;stop-opacity:1"
-         offset="0.68181235"
-         id="stop1088" />
-      <stop
-         id="stop1090"
-         offset="0.69518405"
-         style="stop-color:#ed982e;stop-opacity:1" />
-      <stop
-         style="stop-color:#fab44f;stop-opacity:1"
-         offset="0.74149609"
-         id="stop1092" />
-      <stop
-         id="stop1094"
-         offset="0.75258344"
-         style="stop-color:#f7a331;stop-opacity:1" />
-      <stop
-         style="stop-color:#f8a42c;stop-opacity:1"
-         offset="0.84909678"
-         id="stop1096" />
-      <stop
-         id="stop1098"
-         offset="0.86134851"
-         style="stop-color:#db8521;stop-opacity:1" />
-      <stop
-         style="stop-color:#ea942d;stop-opacity:1"
-         offset="0.87651384"
-         id="stop1100" />
-      <stop
-         id="stop1102"
-         offset="0.92930543"
-         style="stop-color:#fab04e;stop-opacity:1" />
-      <stop
-         style="stop-color:#f6a02b;stop-opacity:1"
-         offset="0.94400853"
-         id="stop1104" />
-      <stop
-         style="stop-color:#ee911d;stop-opacity:1"
-         offset="1"
-         id="stop1052" />
-    </linearGradient>
     <filter
        color-interpolation-filters="sRGB"
        height="1.12"
@@ -2426,14 +2318,229 @@
          stdDeviation="0.16371" />
     </filter>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1054"
-       id="linearGradient1627"
-       x1="15.719925"
-       y1="2.6047144"
-       x2="15.719925"
-       y2="31.614388"
-       gradientUnits="userSpaceOnUse" />
+       gradientTransform="matrix(0.26458333,0,0,0.26458333,34.339137,12.832292)"
+       id="b-3"
+       gradientUnits="userSpaceOnUse"
+       x1="32.228001"
+       x2="32.228001"
+       y1="4.6100001"
+       y2="59.592999">
+      <stop
+         offset="0"
+         stop-color="#525252"
+         id="stop2-6" />
+      <stop
+         offset="1"
+         id="stop4-7" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.01436423,0,0,0.01436423,35.56601,13.980584)"
+       id="c-5"
+       gradientUnits="userSpaceOnUse"
+       x1="548.22198"
+       x2="728.22198"
+       y1="295.892"
+       y2="918.55798">
+      <stop
+         offset="0"
+         stop-color="#d5e7ec"
+         id="stop7-3" />
+      <stop
+         offset=".229"
+         stop-color="#cadbde"
+         id="stop9-5" />
+      <stop
+         offset=".666"
+         stop-color="#9fa5a1"
+         id="stop11" />
+      <stop
+         offset="1"
+         stop-color="#868685"
+         id="stop13" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.01436423,0,0,0.01436423,35.56601,13.980584)"
+       id="d-6"
+       gradientUnits="userSpaceOnUse"
+       x1="616.677"
+       x2="720.677"
+       xlink:href="#a-2"
+       y1="616.94202"
+       y2="934.94202" />
+    <linearGradient
+       id="a-2">
+      <stop
+         offset="0"
+         stop-color="#535555"
+         id="stop16" />
+      <stop
+         offset=".078"
+         stop-color="#606262"
+         id="stop18" />
+      <stop
+         offset=".271"
+         stop-color="#7a7b7b"
+         id="stop20-9" />
+      <stop
+         offset=".47"
+         stop-color="#8c8d8d"
+         id="stop22-1" />
+      <stop
+         offset=".677"
+         stop-color="#979898"
+         id="stop24" />
+      <stop
+         offset=".902"
+         stop-color="#9b9c9c"
+         id="stop26" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.01436423,0,0,0.01436423,35.56601,13.980584)"
+       id="e-2"
+       gradientUnits="userSpaceOnUse"
+       x1="560.41699"
+       x2="560.41699"
+       y1="318.677"
+       y2="970.04498">
+      <stop
+         offset="0"
+         stop-color="#d5e7ec"
+         id="stop30-7" />
+      <stop
+         offset=".252"
+         stop-color="#c5d4d7"
+         id="stop32-0" />
+      <stop
+         offset=".751"
+         stop-color="#989d9e"
+         id="stop34" />
+      <stop
+         offset="1"
+         stop-color="#818076"
+         id="stop36" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.01436423,0,0,0.01436423,35.56601,13.980584)"
+       id="f-9"
+       gradientUnits="userSpaceOnUse"
+       x1="527.086"
+       x2="527.086"
+       xlink:href="#a-2"
+       y1="649"
+       y2="970.03699" />
+    <linearGradient
+       gradientTransform="matrix(0.01436423,0,0,0.01436423,35.56601,13.980584)"
+       id="g-3"
+       gradientUnits="userSpaceOnUse"
+       x1="562.59998"
+       x2="217.43201"
+       y1="321.423"
+       y2="990.64301">
+      <stop
+         offset="0"
+         stop-color="#d5e6eb"
+         id="stop40-6" />
+      <stop
+         offset=".252"
+         stop-color="#c3d2d3"
+         id="stop42-0" />
+      <stop
+         offset=".751"
+         stop-color="#989d9e"
+         id="stop44" />
+      <stop
+         offset="1"
+         stop-color="#868685"
+         id="stop46" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.01436423,0,0,0.01436423,35.56601,13.980584)"
+       id="h-6"
+       gradientUnits="userSpaceOnUse"
+       x1="672.19702"
+       x2="582.07098"
+       y1="153.623"
+       y2="183.217">
+      <stop
+         offset=".015"
+         stop-color="#afb5b8"
+         id="stop49-2" />
+      <stop
+         offset=".573"
+         stop-color="#a3abaf"
+         id="stop51-6" />
+      <stop
+         offset="1"
+         stop-color="#97a1a5"
+         id="stop53" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.01436423,0,0,0.01436423,35.56601,13.980584)"
+       id="i-1"
+       gradientUnits="userSpaceOnUse"
+       x1="406.97601"
+       x2="556.47601"
+       y1="104.929"
+       y2="417.92899">
+      <stop
+         offset="0"
+         stop-color="#c0cdce"
+         id="stop56" />
+      <stop
+         offset=".238"
+         stop-color="#b1bcbd"
+         id="stop58" />
+      <stop
+         offset=".71"
+         stop-color="#888f90"
+         id="stop60-8" />
+      <stop
+         offset="1"
+         stop-color="#6d7171"
+         id="stop62-7" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.01436423,0,0,0.01436423,35.56601,13.980584)"
+       id="j-9"
+       gradientUnits="userSpaceOnUse"
+       x1="526.67999"
+       x2="531.42999"
+       y1="401.496"
+       y2="420.746">
+      <stop
+         offset="0"
+         stop-color="#989b9b"
+         id="stop65-2" />
+      <stop
+         offset=".46"
+         stop-color="#878a8a"
+         id="stop67-0" />
+      <stop
+         offset="1"
+         stop-color="#6d7171"
+         id="stop69" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.01436423,0,0,0.01436423,35.56601,13.980584)"
+       id="k-2"
+       gradientUnits="userSpaceOnUse"
+       x1="388.30099"
+       x2="667.75098"
+       y1="174.45399"
+       y2="174.45399">
+      <stop
+         offset="0"
+         stop-color="#c9cfd0"
+         id="stop72-3" />
+      <stop
+         offset=".591"
+         stop-color="#b8bfc1"
+         id="stop74-7" />
+      <stop
+         offset="1"
+         stop-color="#a9b2b4"
+         id="stop76-5" />
+    </linearGradient>
   </defs>
   <sodipodi:namedview
      id="base"
@@ -2442,9 +2549,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="2.8"
-     inkscape:cx="250.64113"
-     inkscape:cy="20.400632"
+     inkscape:zoom="7.9195959"
+     inkscape:cx="52.251798"
+     inkscape:cy="53.089053"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      showgrid="false"
@@ -2461,9 +2568,9 @@
     <g
        id="g1702"
        transform="matrix(0.97573206,0,0,0.97573206,-65.748383,-37.203094)"
-       style="opacity:0.295">
+       style="opacity:0.29500002">
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1634"
          width="29.810888"
          height="29.810888"
@@ -2479,9 +2586,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1638"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.30000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1640"
          width="29.810888"
          height="29.810888"
@@ -2497,9 +2604,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1642"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.40000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1644"
          width="29.810888"
          height="29.810888"
@@ -2515,9 +2622,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1646"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.7;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.69999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1648"
          width="29.810888"
          height="29.810888"
@@ -2533,9 +2640,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1650"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.80000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1652"
          width="29.810888"
          height="29.810888"
@@ -2551,9 +2658,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1654"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.20000005;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.39999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1656"
          width="29.810888"
          height="29.810888"
@@ -2569,9 +2676,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1658"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.79999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1660"
          width="29.810888"
          height="29.810888"
@@ -2587,9 +2694,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1662"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.20000005;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1664"
          width="29.810888"
          height="29.810888"
@@ -2605,9 +2712,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1666"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.5999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1668"
          width="29.810888"
          height="29.810888"
@@ -2623,9 +2730,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1670"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3.4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3.4000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3.8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3.79999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1672"
          width="29.810888"
          height="29.810888"
@@ -2641,9 +2748,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1674"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:4.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:4.19999981;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:4.6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:4.5999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1676"
          width="29.810888"
          height="29.810888"
@@ -2659,739 +2766,221 @@
          height="29.810888"
          width="29.810888"
          id="rect1678"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
-    </g>
-    <rect
-       style="fill:url(#linearGradient1627);fill-opacity:1;stroke-width:2.688;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
-       id="rect849"
-       width="29.087439"
-       height="29.087439"
-       x="2.3962641"
-       y="2.518585"
-       rx="6.4494534"
-       ry="6.4494534" />
-    <g
-       transform="matrix(0.26458333,0,0,0.26458333,87.950943,39.026754)"
-       id="g13037" />
-    <g
-       id="g1561"
-       transform="translate(0,9.9257943)">
-      <path
-         id="path1557"
-         d="M -0.05386295,15.685776 H 41.953224"
-         style="color:#000000;fill:none;stroke-width:0.5" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
     </g>
     <g
-       id="g1723">
+       id="g1659"
+       transform="matrix(1.9987477,0,0,1.9987477,-68.624669,-25.637911)">
       <path
-         id="path1725"
-         d="M -0.05386295,14.022171 H 34.214139"
-         style="color:#000000;fill:none;stroke-width:0.4" />
-    </g>
-    <g
-       id="g1729">
+         id="path79"
+         d="m 38.969081,14.022917 c -1.905529,0 -3.439583,1.534054 -3.439583,3.439583 v 7.672917 c 0,1.905529 1.534054,3.439583 3.439583,3.439583 h 7.673446 c 1.905529,0 3.439583,-1.534054 3.439583,-3.439583 V 17.4625 c 0,-1.905529 -1.534054,-3.439583 -3.439583,-3.439583 z"
+         style="fill:url(#b-3);stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
       <path
-         id="path1731"
-         d="M -0.05386295,17.681981 H 34.214139"
-         style="color:#000000;fill:none;stroke-width:0.4" />
-    </g>
-    <g
-       id="g1735">
+         id="path81"
+         d="m 46.452556,26.306463 -0.0717,-0.144992 0.0979,-0.173831 -0.510117,-0.377825 0.126471,-0.331788 -0.287337,-0.237066 -0.03889,-0.144992 0.0979,-0.3175 -0.248709,-0.169333 -0.09895,-0.202671 0.195263,-0.35904 -0.172509,-0.178064 -0.0056,-0.214313 0.170921,-0.410633 -0.1524,-0.481277 c 0,0 0.339196,-0.02302 0.336021,-0.183886 -0.0013,-0.08731 -0.06297,-0.313002 -0.11774,-0.49821 a 2.24155,2.24155 0 0 0 0.580496,-1.50839 c 0,-1.229518 -0.982663,-2.226468 -2.194984,-2.226468 -1.212321,0 -2.194719,0.99695 -2.194719,2.226468 0,1.190625 0.922073,2.164821 2.0828,2.223559 l 1.412112,4.370916 c 0,0 0.155046,0.313267 0.567267,0.158221 0.412221,-0.155046 0.521229,-0.488421 0.5715,-0.725487 z M 43.68766,19.870209 c -0.306123,0 -0.554567,-0.248709 -0.554567,-0.554567 0,-0.305858 0.248709,-0.554302 0.554567,-0.554302 a 0.55456667,0.55456667 0 0 1 0,1.108869 z"
+         style="fill:#535555;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
       <path
-         id="path1737"
-         d="M -0.05386295,21.341791 H 34.214139"
-         style="color:#000000;fill:none;stroke-width:0.4" />
-    </g>
-    <g
-       id="g1741">
+         id="path83-9"
+         d="m 46.367911,26.342439 -0.0474,-0.149388 0.109168,-0.178116 -0.514239,-0.336123 0.08762,-0.372034 -0.267174,-0.201099 -0.04884,-0.17668 0.09193,-0.277229 -0.242754,-0.163753 -0.06895,-0.244192 0.199663,-0.380652 -0.186735,-0.112041 -0.04022,-0.180989 c 0.188172,-0.271484 0.158007,-0.521422 0.158007,-0.521422 l -0.119223,-0.396452 c 0,0 0.262865,-0.07469 0.324632,-0.132151 0.05171,-0.0474 -0.07469,-0.481202 -0.123533,-0.636336 0.359106,-0.390707 0.577442,-0.910692 0.577442,-1.483824 0,-1.210905 -0.982513,-2.193418 -2.193418,-2.193418 -1.210904,0 -2.187672,0.988259 -2.187672,2.199163 0,1.203723 0.969585,2.18049 2.170435,2.191982 l 1.410567,4.368162 c 0,0 0.155134,0.31314 0.567388,0.158006 0.215463,-0.08044 0.347614,-0.209717 0.432363,-0.34905 0,0 0.04884,-0.114914 0.0632,-0.311704 z m -2.680366,-6.472522 c -0.305958,0 -0.554459,-0.248501 -0.554459,-0.554459 0,-0.305958 0.248501,-0.554459 0.554459,-0.554459 0.305958,0 0.554459,0.248501 0.554459,0.554459 0,0.305958 -0.248501,0.554459 -0.554459,0.554459 z"
+         style="fill:url(#c-5);stroke-width:0.01436423"
+         inkscape:connector-curvature="0" />
       <path
-         id="path1743"
-         d="M -0.05386295,25.001603 H 34.214139"
-         style="color:#000000;fill:none;stroke-width:0.4" />
-    </g>
-    <g
-       id="g1747">
+         id="path85"
+         d="m 46.452556,26.306463 -0.08467,0.03598 0.1524,0.121973 0.07593,-0.06456 z m -0.535781,-0.626004 0.51435,0.33602 -0.109273,0.178065 0.059,-0.03307 0.09631,-0.173831 -0.510117,-0.377825 z m -0.109008,-0.639498 -0.07038,0.06615 0.268552,0.201083 0.08758,-0.03016 z m -0.268817,-0.548482 0.241565,0.16219 -0.09049,0.277283 0.07885,-0.03598 0.0979,-0.3175 -0.248709,-0.169333 z m -0.06879,-0.732895 0.199761,0.10795 -0.199761,0.38047 0.04895,-0.04154 0.195263,-0.35904 -0.172508,-0.178064 z"
+         style="fill:#717475;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
       <path
-         id="path1749"
-         d="M -0.05386295,28.661412 H 34.214139"
-         style="color:#000000;fill:none;stroke-width:0.4" />
-    </g>
-    <image
-       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGYAAABsCAYAAACYRMcEAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz AAAOxAAADsQBlSsOGwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAuNSURB VHic1Z3bcuO6DkShZP7/i3eS83I4A7W6gSZ1sYMqlSiKVywCoGTH2eJ62W5o8+7+fi5o49K2rpjU bBtPg7tDXOUvQzqjpK6u0/ZvglQpuQMwDejq1a7uV/V+AxylWJZ/BuBfmVHKjNIxbwXYmbKz4igM y8xeT/V3xt10yt/MeytjWik76046a1Dp7p41nitcU5e+C9CsBZ0J2B2QLs9pdyezinEhVFAcOFe4 vkpm3YwDoDt3be9kNW50IDajDOvHhbQKaDWIO8pXadVW2f8fMVCUDgqmrwY04wIrcZTiuC2W3kT7 2DYrd8hjYJwgrmA4edhO1Y+b7mQmOHeWgukfyGd9b+IsZWVn1UGojiDpqh8nzxFnN3UGiHOoduk4 Z13ZDIQPkhdFGvtxzphGceKEk6egfJPraixoKdJy/kChINculA8jPRt/3DJMzuygXChb7AFF1JC6 ePQ3X1nMDJQP8zzr2jrXmcsr6RRd5eV77MhQsM73/+etLKiNN44rY5bEoGCagclpbCuKe10dJpWS q2tVB91XVuwW/yBkKAhnlM99UBlgnEBbWYo6ENq4Vm2q/M7imCjlsrwKEEIZykYweRxYLmIPcwiz mi0ifv4UExuFOjfGjs+o4awe2EaQ81DCOJ/dRTEo41wF+wGlWkDSatCVVY04cD5F2ok3HYTOJbJJ O7uoVSiqf6ZstJwszGrKGFO5GeWuMhAE48BRMLoNRcRx4goKnhWgSPkVFJTcP87vh9Sju7OZ55gV a5mFw6yii1lMSRWU76gh5eMj3UconZWOumycZeCP6F/JMGupFPcZeygumArIltpjoDowCAIPx3ry anegVHCqTcBfUQ+Y2PlMXKhijVrxCGbmqMAwEOzYUvktjmC3qJ9JWHl2DF2iSztY0MpzzMhjSnSU qywEoc24RnQTCsxXOqPSMgC2EUBBV5fngNaW9cYsBu+3YJQb6yymSzvxBIEoF6nADAVnGHlOTEYs GfUj9oF/CLqpKv4oiylFbZcrwTIutNmDWdsnHB2YoawBJaDMSLM21Ep3joA0toPpw3UV/JULy53i 4Nm9avWoegwQQmFWE3EEk6GwAI39KVeDSkVhc1LXrXQvMUea0WflnQGxvTxrD+EwSBUYBiq7nEp+ SJrluXOI0DBpW+5zjCs4eHawchvcz4IWpeJRlvzG14GixurO4XK5CgwDktM4qRxMc5BlZSN6C2KB eaQrC2Fb3erZBp9/1HhPg5wBo7aMajD4TDAAoHl/wL1qlWZRQbd6llBjZSAUGFWnGquCImE5YLLP RkvIaQYlP5ShSxorO69wtAq24rrdUIS2EDZe9pyj3gR0bxAcSJYoMFkJ6h4DkQ/8gAj3/RnOEKyf J4z9Y50uTy2g6lBWgoCYlZ0CxcAM5bH8yjrQZeV6CGWk0XVF7MGwCUfwCaKr6saO7X/F3mI691WB ZG8PcGwlpM6VZRfm+Gi2SnN9TONubIt/r0sql9JOTMxFWcqXSHdxpXKBlcWwse/yEAyzlqxcBSMH b1QEWsio8xFHMBF7KN0OiK3KTjFZ4QgErcYF47jAqQVVWUyG1MHBehkIWkgGhAE+0v2xW6sm64ga M7OYDsysW1NQ2L2dVMEfX0GwRhEKa2MAYHBwcMxanJ2PazEMNIPSWQ0DwwB1Y2U6i4g9GObGsAIG eXwTmxWDAEbbH3EEM9oe8SVbS+eaqkk6gJj1uGCUa1MWhuPKY91JtyvDCuN6QBlA2EPiUDBrk4EZ dYdyPsNfgcxiQpRjq/srjjHmKzwwlfV0C0kuLDfGsIYypIj9cwlaSgUmUv2vOMaWakWyyVWwEIqy Htw2q5jRuTh3IR1E7coqqxmSd1cjzbbDLK5kaxqC2+TKJTgurSuvrIfByeXdttnYcXzyeuY5RkmG ol6TYB7uxtjTvrMjY1YzqzDl2lyLcfvEcjjuLD9VjJmxHqyrgETU78fcHU1nLSHKIWAGf3ZHGCJd lWHj3Mmf2CueVVDbZizDdmAMTJB0tiIWB9REI44TVsA65TlbX2YhaixVmp3zOP+6MoSDVlI901RB fQaMuz1VkNjicqxNwXFcWadwF8ZBVp78O0GA6on/O5VxAYS4xvOMm1Fw8nUFZuZcpXfSPWAqOHjG PFYeX7VkOOzTS6XMgPxKOiWsQMptqUWCZWbGExH+B2Wd5XTuLcuAMmMplQVFHCesgHWQZw7sl42D pdn1Ic95u4z5owHXtWE7DpRcvuqjg+CUcRaBCwbzHCBUZj8oww1CBH+Cd5TpAlHuYmVRYP9OmVkw Kn+mbPt2WTXCAI38SmEY7HMbKh/LYH41XpQOhmrbdaNun+292XdlrEEFadyr8qqVO2sRK6KgOIsE 81i7Tt9UnFcyEfVqVJDGPQQ38tREV13U7L2Z9hWwlfatOu73yhxATqcMXBdInZXr9ufIGaU77Voy +03Myjpm2rjaMq4WBufR8Z75iiyLHU7ZVaDvIFe4Mkuu/FJ5txu7qi1s1217pizKk9YaEccPq14t dygAYaiXqVWdx+XdwGxwnr2n8hicGSiPg7r672Pukhl3xc5dnZdbCMq7WQzKbAyp8t8SgJJ3B6PE tQSVVh/eVdePym8D4yh4pc23ATLklTFGxYNuNTtBG6Gxg9XpxrnyUceSPG0xzuQx/65dEos9M9Bv lafA3KFgJ1awdGclV7nIU3I3GDa5bsLK5TjKqgK+GsMqiFvBvUPw7xRzdrtc9eP09xKruROMqyhV z7UMp4+un8pC3XYulbvAOEGU3at2aFe4Dqe9zmIegfOkK2MBWV1HrMF1+mf5MxZyZgy23AHGXVHd bkrVUzL7fDGzIGY3HqflCYtZjTVu/Yj6Gy5df5ULrfq/1WquBuP6587HV7DUd85WvjDRWUyVh2l2 vSyvijHq/qzrmvlingLkWoxjRZfJlWBWV88MEKX87m9qsI1uPCztlHfrtPLUS8xqG9wJc1EIY4t/ 38SP2MNx/qCWjbdyX7e/yHwCjLuiKkgdFFRk9we2EUdr6sbF5vErviWT5awvrlxW/gNW9uyB5dRf quW+IriSFQw8Xy5XgVnxxSgsFjAg7M++h5KG5HvsL5C7ODQrlwN6ty9jdFYylD1+5GHUYT+DksG4 P0PyNvJOYFiQZ0AQygoY9uMK2Hce06yctqBXg6keDpXbqsAEqf8VEf/B2d0c5POj8kowahusLCXv vrBs/jGHfC9by3/Braf7PYGXyJNg8i6mejZhO6/qZ+LxXkBbCAcBqZ9NjDiO8zF5tcUglPGgqLbE EUel5x/EZtY0FJ/dGXNpjuW4cE5DfBqMazUDSISGMqzlA8pWLpHFmzsBLctTYMZE8oPZyM/Wkg/2 /14QngITcXx/hu6r+qnFKtY8sim48rf9q9f0G6RVwFfvz9AC2H9citiDyTutrPwKSvec8xikuywm A0BFowsbLx/xRSTW+Y5/P8fI/tsSs6ysYPYc08F52Zb56V3ZkPxOi/3gKdYbIJS1VPDRpWHccWLL 41vpq//Uz3Fn4zqnKyi4+tn/OAvRProkBoe5MLZ1ZmPDubDrJbnTYtCdORP8TmkHiAMGXRoDwGJL ZT23yyueY3BiQ+kj+Ec6D0VspFz3US/bkrNXMAyEu12+DdIdn12rD8bUZ+f5QGtQv3DegUHFqV2g k8c2Abe6sYjXvZIJSA9Ba/gJD4iyGDyvHFV7t8kdFsPa3Ui6shyWp+p1wlxaTivLUOkgaXZ9Sp58 8mcPmaocllUW4oLB82w6nzF9i9xlMaptZTnq7AJRMYZdO8qfhXI5qDvBqPYZnJyuIMxYSpZuR+WC eARKxGvAsPxO+So9I46yZ2PIr9ouz/ThAKra6cavFDcDwGnjcnkCTNeXq/Crxuqu/Erxvzr4r/Q3 A++MnFH67VAingcz0+9TY3MV/QiQIa8Cc0X/bt2zCn0UyJBXg8nyLmN5CQiU/wHsisD3hU8oywAA AABJRU5ErkJggg== "
-       width="102"
-       height="108"
-       id="image1314"
-       transform="matrix(0.26458333,0,0,0.26458333,3.4395833,3.175)"
-       style="opacity:0.135" />
-    <image
-       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEMAAABjCAYAAADAZr1FAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz AAAOxAAADsQBlSsOGwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAsxSURB VHicvZvrdqM4EITb9mzm9v7vupPY8f5YKhRFlSQuHp3DMXZASB/Vre6GXOrvt8uBc5+njcK0IwM7 ep0t13YQTgfzahja/2Vgv2o90efg3w61V8HoTTp9cnsOfurxu9u3ox2YliZ/Md/1GDQ38We1zeUS /j7czoTRg5A2PRft2dn0WPSzG8hZMBSEwrjKp+5rH27yn/KpUA4DOQOGA8Ebg+CN/6b9OBDYLrUE U3Ie+toM5GwzSRBuNUPgfQWC5kA86BNAqk4EchRG8g2sgFvNAHT/KuehORDXWoJ40PEJyKZ2BEYP xM1s32oJhBWSYDxku9cSBM5zQDapYy+MFFE6EN9kU0AKU02EIdxrDa5qnvCnfMe4hoCcYSbOPzgI /9QayBZlqFm5xv6Cvw+1PTBG/QRDwMZwcFzPZwBGz7/wOVCDfjbbWUurmoiCeKusDBdr8MRutYbB x7iNTW64HfEZPacJGAChMNydVnk/awmi6HcXg0AVTj3dthWG2qoDor6CFcIgrqZPB4VjiqLfFQI2 VsdfV4aLKRwENo/kBJ+1BHKR33AMTx7OlWF81tpUunDOcqBbltQr9eXScZfbJBgag7jVZnhlOWtp 7QVbCQQnXtynmhF+e9YMGorg7UHn8qoy1M52oAkI3zHn+NIqoIncjc4FkHst/ZA65pcEXercXMDl 8hEeIJpLwNCgAGcuUAaWXAWeYpGhtnc1UZtMabqLMHlZBAiog/v9rLWpMBAFMaKOpkqOJmoMpweC B6LFGoWhg0b/RecnZSR1vGQ14ab0nS9pSTaV8ZJPYqjwGSmiZSc61M7IWpMP0Ymkc3sK04miL/Ub LdMccqJn1DN4XyeVvDomqVmmBm4auV5quWRCGa2cZ3hVORJ0pf205KbViHMKTvQ0271N5z3r/+UU MO61BpFKA80A7MystRd3sLzx26OWMUYLBiYH80Bf96r6qFwrcQGYVcnZD5HcMovJsTo02OJzXYKn MD9oHxWwj5qh3Gutjq6pnL2auIRNJ4QBKYiLOU9TfvYT7DcYxgf1w+G5qmIFZhRGsnfeZ0WkmobL WBVkSvCKJv9es1K4RgoYUAsncLrMnmomLUXcaobwVlU/alaIk28qAWiCB7OA2QHOo5bKuNMnwnc+ nufwBWVvbuJU4ZwfQPyoqu/T9xQX8Pn8yaYFBUBlAKQwPqZjWB0uKt1lJgwkrRjs9N6myQPEr+mT a6EKJaX8UAVgwEnynVaf8V5LlcB/uLT+6/sIDBfOMhC+i6wIwPg1bT9raS4KJO2zw71PE00w3mWD Onh1SSnAJgfaWzkciJ/T9ruW6ngTGK3ss2pO6JyJYLIM4c90jXe5jhaN0fcmGA5MWjXYPH7WrIzf 03f4jhQkaTjtYKhD/ZgA/Kmqf6dr/JmOfTd92uRtqwMdcZjfpw2qAAhAAYzkO9yg2RycD3mfIPyQ /l1FPgZgPRgpAUvBlVMGQ2FT6T1q5LsHeX/Q71AFzIJBJNguxtlkJikBcyAUhgKBE1UYreQKE+fq N6uCAbRAHFaGQnFAdEl1QHhTM2mZR9XsLxQEJ3IMYeQBt81k94TjKVDSgQEK+xH+rVV/4MYPharm yrjmLwpgc6H4DGWoOvRh85v5reXYij45vQcItxS7pdmFA04Ru2Bw0zTdmYzCUfm2HkCjcXD0DNfl 8xOEobbHTLCvWareJSfZVs2Sr4Omz01dXrRpwq22dTXhQeiANGhyEk5ba0Jp0q33M3SrCiE4tzMK wq1QXX9LdpxMRL8/zXd9+q5VNHzXfldgrvrDyc05raPSdg+g9Ik8P7Z0D7gd1CEY7g65Dnt/O9Lc w2p9HZKrW1zHUKXE8YwqI3Uyaq/p2Nb10jkK4242fW/Dmc9qDFt9hnNGKkMnYTeIHpQEoQcCBR2F 0b3mHgfampR78z+9e8VRpVNoApFMRIvBAOJuSJUBcvRRQUvGI5uLCDmBaoFwakjmkoAs2l4zwX5P HTwQ9+4V9+WyyZYiekBaDtSazFlP1EbsmyeguUcq6IysHgnIJlVU7X9zx7UWEB4sq0Jh6N8SiNYq MrKsnuZA0VxY7ibBg0SlCsdotqmm8jR9jABRRbiAa5MDbYXbI6E0A8GzDk7F3auLrhDcMosUWwzF FVtgMBD+rnlGq0LFiuDyvkvlXW2DzcytGK3gKplHNJfRrDVlp66+iIvwJGACCYSm+2wq3E+KJTQf GfYTIzCcIlL67SQOVcBE8CRL37JJJTuud7KppafsKagaMo8eDADoqULvqHsC9k5w2FnyI0mujjGM qqUj5meovThC57ELhku507MSV74DDNxNTOhu+mEQ/PiAq18MwymjFT84CBFMy0zUQbqyXkvegAHz cOriQjEeHTJcwOBYBepQGG7sadXDGDnaXcFIhRhXCXf2rs9Aq+aXQ3ggDAMg3mr5kqs+RmR1aBL2 pL5TpS0B+WqjytB4QO0c0lan90l98oWvdL4ukfpCG/fHjhTnqSp02XdL/wpEgqF3UH2FPgZgM2Gn B3+hKT3DgBo0B3Ew1HeoiTgzHCk8f4H5Jj/yfstE0r9msr+oWkqc03bAcOpBmO5gMJC7gTECwiWE pTAUglOG+gnn8ABAQ2mWNPoCCB3cTb6zb3AVLAdj5FWHRUtm0oor3HNOjQs0FIesGcY/074+SGIY qU7CPgmrgqpCPx0QBvn14PliPltxRXr3QTNNftkMg79M5/Ik1Oc8pD8Nqlw22gKSnGhcWvWgls9w mWbRQPWFM3h/AIB5wHfwS2hVc1KnJsJOeARIepKn/nHlQPmPzme4JVbzEacKhYE85TL1wUkXxykK Q4MrVQ2PPeVRzol2g67kN9IFeFCaYbKZAEZNn5qCwzwAg/2DC7kB3wHRCFpNZNVG4gwHhjsDCAxe VQEYGDB8A1ShMKpm9XCwpcpAc6m7m0sXiPoMPVk7SgNBe9Q8eQYBGFWziSDOcDDcMuqizaqlaaYS n7ZNPsPto7GtouyP3/jtO1YGBooLw0RcsZev4+IUNgc0LRZrNjtSz7hwXdI1LZZoFAj7h50nE+GV pGo9cGzor+Q6KeLUYzWjTVAsHKcM56RcOIzcg50elMHqgPPkCfCSyhNm786JWUsdbhXjQM/VRN18 49t+Lurji8GJIo8oA8P5C44jWNoKl/vTLNU5Ui0cs0Jcum9NhyPBkgOYuAPxrDkU18HrYDhBuwgA zm2e0p+re6Zap9ZKnck0fQgrA1BcyHuvdbSJQgznJDxJDITvJJbVK4FQpQGKk72uGOrP0jlaPbdQ 1EyessGpYfBonzXfUQ662M51udTEiAM5VVoLhqt78s1jh9uql1oz0YaOEVvAQfLfeTVRJ8Zmpd4f +ymChRMtA8OtKu7muVVIayp63gqGDhpAHnIMV6M0L9GIkWFca3kN/sREVGmtO+wmxSveg/roOk+F oVA4zFYY6j/4b24pu9Ra2oCB81IdVYvALRguDNAxxbjD+QydnH5H9Kipuw5IJ36t9QBUaQ6GRqHO 9tP1FUCKNYph8PKqE9cL43eNXN2g0t8VBq9WaOwQtdTXg9G6OQs18DjT0qp+4yLHQDEKUCdadFwL hjM7J3dWhSZkuu++rwBwa0Wgi8JHLQE4B1iyrzAUCJtCqzTQs/l0p3ufum+TtJS1ahqfMtrUtNii yysnfcn+k+T52mmyzmxXA0wD3/K9dZFUYHHFI1Wam3xL8t0Jh98WA93691EYTkkOSjK7lv3rtVqq bP3NDvbMY1vnp2oaf+okR+y/Gr9tGuCrWssn9fwP2l5z2NxeDaN1nZ4f6k34FACtAby6jfqow/a/ p/1tGHuv/zIA3P4DXLNwU4l+DXAAAAAASUVORK5CYII= "
-       width="67"
-       height="99"
-       id="image2062"
-       transform="matrix(0.26458333,0,0,0.26458333,7.4083333,5.55625)"
-       style="opacity:0.25" />
-    <g
-       transform="matrix(0.02122815,0,0,0.02122815,5.5784702,6.2460433)"
-       id="g259">
-      <g
-         id="g70">
-        <g
-           id="g58">
-          <path
-             style="fill:#535555"
-             inkscape:connector-curvature="0"
-             id="path4"
-             d="m 757.9,858.1 -5,-10.1 6.8,-12.1 -35.5,-26.3 8.8,-23.1 -20,-16.5 -2.7,-10.1 6.8,-22.1 -17.3,-11.8 -6.9,-14.1 13.6,-25 -12,-12.4 -0.4,-14.9 L 706,631 695.4,597.5 c 0,0 23.6,-1.6 23.4,-12.8 -0.1,-6.1 -4.4,-21.8 -8.2,-34.7 25,-27.6 40.4,-64.5 40.4,-105 0,-85.6 -68.4,-155 -152.8,-155 -84.4,0 -152.8,69.4 -152.8,155 0,82.9 64.2,150.7 145,154.8 l 98.3,304.3 c 0,0 10.8,21.8 39.5,11 28.7,-10.8 36.3,-34 39.8,-50.5 z M 565.4,410 c -21.3,0 -38.6,-17.3 -38.6,-38.6 0,-21.3 17.3,-38.6 38.6,-38.6 21.3,0 38.6,17.3 38.6,38.6 0,21.3 -17.3,38.6 -38.6,38.6 z"
-             class="st0" />
-          <linearGradient
-             y2="918.55829"
-             x2="728.22162"
-             y1="295.89169"
-             x1="548.22162"
-             gradientUnits="userSpaceOnUse"
-             id="SVGID_1_">
-            <stop
-               id="stop6"
-               style="stop-color:#C7D7DC"
-               offset="0" />
-            <stop
-               id="stop8"
-               style="stop-color:#BCC9CD"
-               offset="0.2289" />
-            <stop
-               id="stop10-6"
-               style="stop-color:#9FA5A7"
-               offset="0.6656" />
-            <stop
-               id="stop12-75"
-               style="stop-color:#868685"
-               offset="1" />
-          </linearGradient>
-          <path
-             inkscape:connector-curvature="0"
-             style="fill:url(#SVGID_1_)"
-             id="path15"
-             d="m 752,860.6 -3.3,-10.4 7.6,-12.4 -35.8,-23.4 6.1,-25.9 -18.6,-14 -3.4,-12.3 6.4,-19.3 -16.9,-11.4 -4.8,-17 13.9,-26.5 -13,-7.8 -2.8,-12.6 c 13.1,-18.9 11,-36.3 11,-36.3 l -8.3,-27.6 c 0,0 18.3,-5.2 22.6,-9.2 3.6,-3.3 -5.2,-33.5 -8.6,-44.3 25,-27.2 40.2,-63.4 40.2,-103.3 0,-84.3 -68.4,-152.7 -152.7,-152.7 -84.3,0 -152.3,68.8 -152.3,153.1 0,83.8 67.5,151.8 151.1,152.6 L 688.6,904 c 0,0 10.8,21.8 39.5,11 15,-5.6 24.2,-14.6 30.1,-24.3 0,0 3.4,-8 4.4,-21.7 z M 565.4,410 c -21.3,0 -38.6,-17.3 -38.6,-38.6 0,-21.3 17.3,-38.6 38.6,-38.6 21.3,0 38.6,17.3 38.6,38.6 0,21.3 -17.3,38.6 -38.6,38.6 z"
-             class="st1" />
-          <polygon
-             style="fill:#717475"
-             id="polygon17"
-             points="767.9,864.6 757.9,858.1 752,860.6 762.6,869.1 "
-             class="st2" />
-          <polygon
-             style="fill:#717475"
-             id="polygon19"
-             points="752.9,848 759.6,835.9 724.1,809.6 720.6,814.5 756.4,837.9 748.8,850.3 "
-             class="st2" />
-          <polygon
-             style="fill:#717475"
-             id="polygon21"
-             points="732.9,786.5 713,770 708.1,774.6 726.8,788.6 "
-             class="st2" />
-          <polygon
-             style="fill:#717475"
-             id="polygon23"
-             points="710.3,759.9 717.1,737.8 699.8,726 694.3,731.8 711.1,743.1 704.8,762.4 "
-             class="st2" />
-          <polygon
-             style="fill:#717475"
-             id="polygon25"
-             points="692.9,711.9 706.5,686.9 694.5,674.5 689.5,680.8 703.4,688.3 689.5,714.8 "
-             class="st2" />
-          <polygon
-             style="fill:#e8e9e9"
-             id="polygon27"
-             points="751.2,863.6 752,860.6 762.6,869.1 762.4,872.1 "
-             class="st3" />
-          <polygon
-             style="fill:#e8e9e9"
-             id="polygon29"
-             points="752.7,838.9 718.9,815.6 720.6,814.5 754.3,836.5 "
-             class="st3" />
-          <polygon
-             style="fill:#e8e9e9"
-             id="polygon31"
-             points="706.6,776.5 708.1,774.6 726.8,788.6 726.2,790.9 "
-             class="st3" />
-          <polygon
-             style="fill:#e8e9e9"
-             id="polygon33"
-             points="692.8,733.4 694.3,731.8 711.1,743.1 710.1,746.2 "
-             class="st3" />
-          <polygon
-             style="fill:#e8e9e9"
-             id="polygon35"
-             points="691,683.2 702.2,690.6 703.4,688.3 690.4,680.5 "
-             class="st3" />
-          <polygon
-             style="fill:#e8e9e9"
-             id="polygon37"
-             points="690,903.3 592,599.3 590.4,600 688.6,904.1 "
-             class="st3" />
-          <g
-             id="g56">
-            <path
-               style="fill:#585a5a"
-               inkscape:connector-curvature="0"
-               id="path39"
-               d="m 729.3,914.7 c -0.4,0.2 -0.8,0.3 -1.2,0.5 -8.4,3.1 -15.2,3.5 -20.7,2.5 L 616.2,634.4 c 0,0 -4.5,-30.3 4.8,-34.9 l 13.3,19.4 c 0,0 0.5,-0.4 5.2,12.3 4.6,12.5 40.4,122.9 89.8,283.5 z"
-               class="st4" />
-            <linearGradient
-               y2="934.9422"
-               x2="720.6767"
-               y1="616.9422"
-               x1="616.6767"
-               gradientUnits="userSpaceOnUse"
-               id="SVGID_2_">
-              <stop
-                 id="stop41"
-                 style="stop-color:#535555"
-                 offset="0" />
-              <stop
-                 id="stop43"
-                 style="stop-color:#606262"
-                 offset="7.793793e-02" />
-              <stop
-                 id="stop45-3"
-                 style="stop-color:#7A7B7B"
-                 offset="0.2712" />
-              <stop
-                 id="stop47-5"
-                 style="stop-color:#8C8D8D"
-                 offset="0.4703" />
-              <stop
-                 id="stop49"
-                 style="stop-color:#979898"
-                 offset="0.6767" />
-              <stop
-                 id="stop51"
-                 style="stop-color:#9B9C9C"
-                 offset="0.9022" />
-            </linearGradient>
-            <path
-               inkscape:connector-curvature="0"
-               style="fill:url(#SVGID_2_)"
-               id="path54"
-               d="m 712.1,918.1 c 1.8,0.1 3.7,0 5.7,-0.3 L 618,611.5 l 7.6,41.6 z"
-               class="st5" />
-          </g>
-        </g>
-        <g
-           id="g62">
-          <path
-             style="fill:#d2dadd"
-             inkscape:connector-curvature="0"
-             id="path60"
-             d="m 695.1,354.8 c 12.6,12.7 22.6,28 29.1,44.8 6.5,16.8 9.7,35 9.1,53.1 -0.5,18.1 -4.8,36.2 -12.3,52.8 -7.5,16.6 -18.5,31.6 -31.8,44 -13.4,12.3 -29.2,22.1 -46.3,28.3 -17.1,6.2 -35.4,9.1 -53.6,8.2 -9.1,-0.4 -18.1,-1.7 -26.8,-4 -8.8,-2.2 -17.3,-5.3 -25.4,-9.2 -16.2,-7.9 -30.8,-19 -42.4,-32.5 12.6,12.6 27.4,22.9 43.7,29.9 16.2,7 33.7,10.8 51.2,11.2 8.8,0.2 17.5,-0.5 26.2,-1.9 8.6,-1.5 17.1,-3.8 25.3,-6.9 16.3,-6.2 31.5,-15.5 44.2,-27.4 12.9,-11.8 23.4,-26.2 30.8,-42 7.5,-15.8 11.8,-33.1 12.8,-50.6 0.9,-17.5 -1.5,-35.3 -7.2,-51.9 -5.9,-16.8 -14.9,-32.4 -26.6,-45.9 z"
-             class="st6" />
-        </g>
-        <g
-           id="g66">
-          <path
-             style="fill:#7f8587"
-             inkscape:connector-curvature="0"
-             id="path64"
-             d="m 494.7,540.2 c -12.6,-12.7 -22.6,-28 -29.1,-44.8 -6.5,-16.8 -9.7,-35 -9.1,-53.1 0.5,-18.1 4.8,-36.2 12.3,-52.8 7.5,-16.6 18.5,-31.6 31.8,-44 13.4,-12.3 29.2,-22.1 46.3,-28.3 17.1,-6.2 35.4,-9.1 53.6,-8.2 9.1,0.4 18.1,1.7 26.8,4 8.8,2.2 17.3,5.3 25.4,9.2 16.2,7.9 30.8,19 42.4,32.5 -12.6,-12.6 -27.4,-22.9 -43.7,-29.9 -16.2,-7 -33.7,-10.8 -51.2,-11.2 -8.8,-0.2 -17.5,0.5 -26.2,1.9 -8.6,1.5 -17.1,3.8 -25.3,6.9 -16.3,6.2 -31.5,15.5 -44.2,27.4 -12.9,11.8 -23.4,26.2 -30.8,42 -7.5,15.8 -11.8,33.1 -12.8,50.6 -0.9,17.5 1.5,35.3 7.2,51.9 5.9,16.8 14.9,32.4 26.6,45.9 z"
-             class="st7" />
-        </g>
-        <path
-           style="fill:#7f8587"
-           inkscape:connector-curvature="0"
-           id="path68"
-           d="m 526.8,371.4 c 0,-12.9 6.3,-24.3 16,-31.3 -11.9,6.3 -19.8,18 -19.8,31.3 0,13.3 8,24.9 19.8,31.3 -9.7,-7.1 -16,-18.5 -16,-31.3 z"
-           class="st7" />
-      </g>
-      <g
-         id="g136">
-        <path
-           style="fill:#535555"
-           inkscape:connector-curvature="0"
-           id="path72"
-           d="m 564.6,318.7 c -85.1,0 -154.1,69.4 -154.1,155 0,54.1 27.5,101.6 69.2,129.4 -10.3,15.3 -3,42.9 -3,42.9 l 26.1,6.5 -3.8,293.8 c 0,0 4.3,24.9 33.1,23.7 28.8,-1.2 44,-16.3 56,-36 l -7.9,-9.6 -0.5,-10.9 9.9,-9.4 -25.4,-37.3 15.8,-19.8 -13.9,-22 1.5,-9.4 16.5,-15.5 -14.5,-20.4 17.1,-10.1 -18.5,-7.9 17.9,-18 6.4,-23.5 -10.5,-2.9 22.9,-29.1 v -30.6 c 0,0 17.1,-1 29.3,-8 V 612 c 50.2,-25.6 84.6,-77.9 84.6,-138.4 0,-85.5 -69.1,-154.9 -154.2,-154.9 z m -12,109.5 c -21.3,0 -38.6,-17.3 -38.6,-38.6 0,-21.3 17.3,-38.6 38.6,-38.6 21.3,0 38.6,17.3 38.6,38.6 0,21.3 -17.3,38.6 -38.6,38.6 z"
-           class="st0" />
-        <linearGradient
-           y2="970.04547"
-           x2="560.41663"
-           y1="318.67731"
-           x1="560.41663"
-           gradientUnits="userSpaceOnUse"
-           id="SVGID_3_">
-          <stop
-             id="stop74"
-             style="stop-color:#C7D7DC"
-             offset="0" />
-          <stop
-             id="stop76"
-             style="stop-color:#BAC7CB"
-             offset="0.2521" />
-          <stop
-             id="stop78"
-             style="stop-color:#989D9E"
-             offset="0.7514" />
-          <stop
-             id="stop80-6"
-             style="stop-color:#868685"
-             offset="1" />
-        </linearGradient>
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:url(#SVGID_3_)"
-           id="path83"
-           d="m 560.4,318.7 c -82.8,0 -149.9,69.4 -149.9,155 0,54.6 27.3,102.7 68.6,130.3 -9.4,15.5 -2.5,42 -2.5,42 l 26.1,6.5 -3.8,293.8 c 0,0 4.3,24.9 33.1,23.7 16.4,-0.7 28.4,-5.9 37.9,-13.8 l 11.9,-19.3 -8.3,-12.1 v -10 l 11.9,-10.6 -26.5,-35.6 14.6,-20.8 -13,-20.5 4.1,-14.8 15.1,-11.4 -17.3,-20.4 22.1,-12.1 -19.9,-7.3 18.1,-18.3 7.6,-23.5 -16.3,-0.7 c 0,0 19.7,-18.2 23.5,-29 l 1,-32.5 c 0,0 21.7,2 24.3,-0.8 2.5,-2.6 4.5,-5.1 7.6,-46 47.4,-26 79.7,-77.6 79.7,-137 0.2,-85.4 -66.9,-154.8 -149.7,-154.8 z m -7.8,109.5 c -21.3,0 -38.6,-17.3 -38.6,-38.6 0,-21.3 17.3,-38.6 38.6,-38.6 21.3,0 38.6,17.3 38.6,38.6 0,21.3 -17.3,38.6 -38.6,38.6 z"
-           class="st8" />
-        <polygon
-           style="fill:#717475"
-           id="polygon85"
-           points="581.8,936.9 573.5,924.8 580.1,924.4 588,934 "
-           class="st2" />
-        <polygon
-           style="fill:#717475"
-           id="polygon87"
-           points="579.6,913.5 589.5,904.1 564.1,866.9 558.9,868.5 585.4,904.1 573.5,914.8 "
-           class="st2" />
-        <polygon
-           style="fill:#717475"
-           id="polygon89"
-           points="580,847 566.1,825 560.5,827.3 573.5,847.8 "
-           class="st2" />
-        <polygon
-           style="fill:#717475"
-           id="polygon91"
-           points="567.6,815.6 584.1,800.1 569.6,779.8 586.8,769.6 584.6,768.7 562.5,780.8 579.8,801.1 564.6,812.5 "
-           class="st2" />
-        <polygon
-           style="fill:#717475"
-           id="polygon93"
-           points="582.8,743.1 564.6,761.4 568.3,761.8 586.1,743.8 "
-           class="st2" />
-        <path
-           style="fill:#e8e9e9"
-           inkscape:connector-curvature="0"
-           id="path95"
-           d="m 580.2,939.4 c -0.3,-0.5 -9,-13.7 -9,-13.7 l 2.3,-1 8.3,12.1 z"
-           class="st3" />
-        <polygon
-           style="fill:#e8e9e9"
-           id="polygon97"
-           points="556.5,870.3 558.9,868.5 585.4,904.1 583.8,905.5 "
-           class="st3" />
-        <polygon
-           style="fill:#e8e9e9"
-           id="polygon99"
-           points="558.9,830.3 572.2,849.5 573.5,847.8 561.3,828.5 "
-           class="st3" />
-        <polygon
-           style="fill:#e8e9e9"
-           id="polygon101"
-           points="562.5,786.8 565.7,784.5 579.8,801.1 577.4,802.9 "
-           class="st3" />
-        <polygon
-           style="fill:#e8e9e9"
-           id="polygon103"
-           points="576.7,722.9 589.5,722.3 590.4,719.7 576.7,719.1 "
-           class="st3" />
-        <polygon
-           style="fill:#e8e9e9"
-           id="polygon105"
-           points="500.7,945.9 504.6,653 502.7,653 498.9,945.9 "
-           class="st3" />
-        <g
-           id="g126">
-          <path
-             style="fill:#585a5a"
-             inkscape:connector-curvature="0"
-             id="path107"
-             d="m 535.3,969.8 c -1.1,0.1 -2.2,0.2 -3.3,0.2 -8.7,0.4 -15.2,-1.7 -20,-4.7 0,0 2.7,-272.3 4.7,-282.7 2,-10.3 11.3,-48.7 21.3,-55.7 0,0 2.7,8.8 2.8,31.8 0.2,23.1 -5.5,311.1 -5.5,311.1 z"
-             class="st4" />
-          <linearGradient
-             y2="970.03668"
-             x2="527.08612"
-             y1="649"
-             x1="527.08612"
-             gradientUnits="userSpaceOnUse"
-             id="SVGID_4_">
-            <stop
-               id="stop109"
-               style="stop-color:#535555"
-               offset="0" />
-            <stop
-               id="stop111"
-               style="stop-color:#606262"
-               offset="7.793793e-02" />
-            <stop
-               id="stop113"
-               style="stop-color:#7A7B7B"
-               offset="0.2712" />
-            <stop
-               id="stop115"
-               style="stop-color:#8C8D8D"
-               offset="0.4703" />
-            <stop
-               id="stop117"
-               style="stop-color:#979898"
-               offset="0.6767" />
-            <stop
-               id="stop119"
-               style="stop-color:#9B9C9C"
-               offset="0.9022" />
-          </linearGradient>
-          <path
-             inkscape:connector-curvature="0"
-             style="fill:url(#SVGID_4_)"
-             id="path122"
-             d="m 529,970 c -2.2,0 -4.2,-0.2 -6,-0.6 l 4.2,-320.5 h 4 z"
-             class="st9" />
-          <path
-             style="fill:#535555"
-             inkscape:connector-curvature="0"
-             id="path124"
-             d="m 539,632 c -0.6,-3.5 -1,-5 -1,-5 -10,7 -19.3,45.3 -21.3,55.7 -2,10.3 -4.7,282.7 -4.7,282.7 1.7,1.1 3.6,2 5.8,2.8 0,0 1.1,-267.1 3.2,-276.9 0.8,-8 1.9,-14.3 4.5,-24 C 528.2,657.5 539,632 539,632 Z"
-             class="st0" />
-        </g>
-        <g
-           id="g130">
-          <path
-             style="fill:#d2dadd"
-             inkscape:connector-curvature="0"
-             id="path128"
-             d="m 662.2,383 c 12.5,12.9 22.3,28.6 28.7,45.5 3.2,8.5 5.5,17.3 6.9,26.3 1.5,9 1.9,18.1 1.6,27.3 -0.7,18.3 -5.3,36.4 -13,52.9 -7.8,16.6 -19.1,31.5 -32.7,43.8 -13.7,12.2 -29.8,21.8 -47.1,27.7 -17.3,5.9 -35.8,8.5 -54,7.2 -9.1,-0.6 -18.2,-2.1 -26.9,-4.5 -8.8,-2.4 -17.3,-5.7 -25.4,-9.8 -16.2,-8.2 -30.7,-19.6 -42.2,-33.4 12.5,12.9 27.2,23.5 43.4,30.8 16.2,7.4 33.7,11.5 51.3,12.2 8.8,0.3 17.7,-0.1 26.4,-1.4 8.7,-1.3 17.3,-3.5 25.5,-6.5 16.6,-5.9 31.9,-15.1 45,-26.8 13.1,-11.7 23.9,-26 31.6,-41.8 7.8,-15.8 12.2,-33.1 13.5,-50.8 1.2,-17.6 -1,-35.5 -6.6,-52.4 -5.6,-16.6 -14.5,-32.5 -26,-46.3 z"
-             class="st6" />
-        </g>
-        <g
-           id="g134">
-          <path
-             style="fill:#7f8587"
-             inkscape:connector-curvature="0"
-             id="path132"
-             d="m 458,566.2 c -12.5,-12.9 -22.3,-28.6 -28.7,-45.5 -3.2,-8.5 -5.5,-17.3 -6.9,-26.3 -1.5,-9 -1.9,-18.1 -1.6,-27.3 0.7,-18.3 5.3,-36.4 13,-52.9 7.8,-16.6 19.1,-31.5 32.7,-43.8 13.7,-12.2 29.8,-21.8 47.1,-27.7 17.3,-5.9 35.8,-8.5 54,-7.2 9.1,0.6 18.2,2.1 26.9,4.5 8.8,2.4 17.3,5.7 25.4,9.8 16.2,8.2 30.7,19.6 42.2,33.4 -12.5,-12.9 -27.2,-23.5 -43.4,-30.8 -16.2,-7.4 -33.7,-11.5 -51.3,-12.2 -8.8,-0.3 -17.7,0.1 -26.4,1.4 -8.7,1.3 -17.3,3.5 -25.5,6.5 -16.6,5.9 -31.9,15.1 -45,26.8 -13.1,11.7 -23.9,26 -31.6,41.8 -7.8,15.8 -12.2,33.1 -13.5,50.8 -1.2,17.6 1,35.5 6.6,52.4 5.6,16.7 14.5,32.5 26,46.3 z"
-             class="st7" />
-        </g>
-      </g>
-      <g
-         id="g193">
-        <path
-           style="fill:#535555"
-           inkscape:connector-curvature="0"
-           id="path138"
-           d="m 487.3,318.7 c -87.7,0 -158.8,70.1 -158.8,156.6 0,34.3 11.2,66.1 30.2,91.9 0,0 0,0 0,0 -12.5,22.3 -15.2,33 -14.4,35.9 0.8,3 19,12.5 19,12.5 l -122.6,268 c 0,0 -7.4,27.3 29.8,36.6 37.2,9.3 57.8,-14 57.8,-14 l -3.6,-12 3.4,-9.8 13.9,-4.6 -8.3,-44.5 22.1,-11.4 -3.9,-25.8 4.3,-8.9 21.8,-12.8 -6,-21.3 5,-14.3 27.3,-10 v -16.1 l 8.4,-11.1 c 0,0 26.4,-9.9 29.5,-15.5 3.1,-5.6 13.5,-27.1 13.5,-27.1 l 25.1,4.6 c 0,0 3.7,3.6 21.3,-34.5 80.8,-7.3 144,-74.3 144,-155.9 C 646,388.8 574.9,318.7 487.3,318.7 Z m 31.8,116.6 c -21.3,0 -38.6,-17.3 -38.6,-38.6 0,-21.3 17.3,-38.6 38.6,-38.6 21.3,0 38.6,17.3 38.6,38.6 0,21.4 -17.3,38.6 -38.6,38.6 z"
-           class="st0" />
-        <linearGradient
-           y2="990.64313"
-           x2="217.4324"
-           y1="321.42261"
-           x1="562.59991"
-           gradientUnits="userSpaceOnUse"
-           id="SVGID_5_">
-          <stop
-             id="stop140"
-             style="stop-color:#C7D7DC"
-             offset="0" />
-          <stop
-             id="stop142"
-             style="stop-color:#BAC7CB"
-             offset="0.2521" />
-          <stop
-             id="stop144"
-             style="stop-color:#989D9E"
-             offset="0.7514" />
-          <stop
-             id="stop146"
-             style="stop-color:#868685"
-             offset="1" />
-        </linearGradient>
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:url(#SVGID_5_)"
-           id="path149"
-           d="m 487.3,318.7 c -87.6,-2.2 -158.8,70.1 -158.8,156.6 0,34.3 11.2,66.1 30.2,91.9 0,0 0,0 0,0 -12.5,22.3 -15.2,33 -14.4,35.9 0.8,3 19,12.5 19,12.5 l -122.6,268 c 0,0 -7.4,27.3 29.8,36.6 12.4,3.1 23,2.6 31.5,0.5 l 18.8,-14.3 -2.2,-13.3 5.2,-10.3 13.3,-4.5 -9.7,-41.7 22,-14.8 -4,-23.7 5.8,-11.5 17.5,-9.5 -4.2,-21.2 7.2,-14.8 29.4,-10.3 -4.1,-15.3 6.9,-11.9 c 0,0 27.8,-8.4 33.7,-20.1 5.9,-11.7 12,-25.2 12,-25.2 0,0 17.3,8.3 21.5,8.8 4.2,0.5 9.1,-6.7 27.1,-40.7 80.8,-7.3 140.4,-73.1 140.4,-151 0.2,-87 -66,-154.5 -151.3,-156.7 z m 31.8,116.6 c -21.3,0 -38.6,-17.3 -38.6,-38.6 0,-21.3 17.3,-38.6 38.6,-38.6 21.3,0 38.6,17.3 38.6,38.6 0,21.4 -17.3,38.6 -38.6,38.6 z"
-           class="st10" />
-        <polygon
-           style="fill:#717475"
-           id="polygon151"
-           points="404.3,714.9 404.3,731 401.3,730.8 397.1,715.5 "
-           class="st2" />
-        <polygon
-           style="fill:#717475"
-           id="polygon153"
-           points="372,755.3 378,776.5 356.3,789.3 351.3,786.5 368.8,777 364.7,755.8 "
-           class="st2" />
-        <polygon
-           style="fill:#717475"
-           id="polygon155"
-           points="352,798.1 355.9,823.9 349.5,821.7 345.5,798 "
-           class="st2" />
-        <polygon
-           style="fill:#717475"
-           id="polygon157"
-           points="333.8,835.3 342,879.8 328.1,884.4 323.8,882.7 337.2,878.2 327.5,836.5 "
-           class="st2" />
-        <polygon
-           style="fill:#717475"
-           id="polygon159"
-           points="324.8,894.1 328.3,906.2 320.8,906.3 318.7,893 "
-           class="st2" />
-        <polygon
-           style="fill:#e8e9e9"
-           id="polygon161"
-           points="316.7,893 318.7,893 320.8,906.3 318.2,908.3 "
-           class="st3" />
-        <polygon
-           style="fill:#e8e9e9"
-           id="polygon163"
-           points="325.2,837.1 327.5,836.5 337.2,878.2 335.3,878.8 "
-           class="st3" />
-        <path
-           style="fill:#e8e9e9"
-           inkscape:connector-curvature="0"
-           id="path165"
-           d="m 347.4,823.1 c -0.1,-0.9 -4.4,-24.4 -4.4,-24.4 l 2.4,-0.7 4,23.7 z"
-           class="st3" />
-        <polygon
-           style="fill:#e8e9e9"
-           id="polygon167"
-           points="362.4,756.6 364.7,755.8 368.8,777 366.7,778.2 "
-           class="st3" />
-        <polygon
-           style="fill:#e8e9e9"
-           id="polygon169"
-           points="394.8,716.1 397.1,715.5 401.3,730.8 398.7,731.6 "
-           class="st3" />
-        <path
-           style="fill:#e8e9e9"
-           inkscape:connector-curvature="0"
-           id="path171"
-           d="m 363.4,615.6 -122.6,268 c 0,0 1.8,-0.7 3,-2.8 1.2,-2.1 121,-264.7 121,-264.7 z"
-           class="st3" />
-        <path
-           style="fill:#e8e9e9"
-           inkscape:connector-curvature="0"
-           id="path173"
-           d="m 350.7,608.4 c -3.3,-2.1 -6.1,-4.1 -6.4,-5.3 -0.5,-1.7 0.2,-5.8 3.1,-13.2 0.1,0.1 -4.3,14 3.3,18.5 z"
-           class="st3" />
-        <path
-           style="fill:#585a5a"
-           inkscape:connector-curvature="0"
-           id="path175"
-           d="m 245.7,905.8 c 4.1,5.4 11.2,10.6 23,13.9 0,0 141.6,-303 137,-314.4 0,0 -32.3,21 -46,51.7 -13.7,30.7 -114,248.8 -114,248.8 z"
-           class="st4" />
-        <path
-           style="fill:#d8d8d8"
-           inkscape:connector-curvature="0"
-           id="path177"
-           d="m 364.7,709.1 c -40.4,91.6 -96,210.6 -96,210.6 -1.5,-0.4 -2.9,-0.9 -4.2,-1.3 z"
-           class="st11" />
-        <path
-           style="fill:#535555"
-           inkscape:connector-curvature="0"
-           id="path179"
-           d="m 404.4,612.3 c 1.1,-3.8 1.6,-6.2 1.2,-7 0,0 -32.3,21 -46,51.7 -13.7,30.7 -114,248.8 -114,248.8 1,1.4 2.2,2.7 3.7,4 0,0 112.9,-246.3 117.7,-254.5 4.8,-8.2 21.7,-29.4 28.5,-35.6 6.8,-6.2 8.9,-7.4 8.9,-7.4 z"
-           class="st0" />
-        <g
-           id="g183">
-          <path
-             style="fill:#d2dadd"
-             inkscape:connector-curvature="0"
-             id="path181"
-             d="m 589,381.3 c 12.6,13 22.4,28.8 28.9,45.9 3.2,8.6 5.5,17.5 7,26.5 1.5,9.1 1.9,18.3 1.6,27.5 -0.7,18.4 -5.3,36.6 -13.1,53.3 -7.9,16.7 -19.2,31.7 -32.9,44.1 -13.8,12.3 -30,21.9 -47.4,27.9 -17.5,6 -36.1,8.6 -54.4,7.3 -9.2,-0.6 -18.3,-2.1 -27.1,-4.5 -8.8,-2.4 -17.4,-5.7 -25.6,-9.8 -16.3,-8.2 -30.9,-19.8 -42.5,-33.7 12.6,13 27.4,23.7 43.7,31 16.3,7.4 33.9,11.6 51.7,12.3 8.9,0.3 17.8,-0.1 26.6,-1.5 8.8,-1.3 17.4,-3.5 25.7,-6.5 16.7,-5.9 32.1,-15.2 45.3,-27 13.2,-11.8 24.1,-26.2 31.8,-42.1 7.8,-15.9 12.3,-33.4 13.6,-51.1 1.2,-17.7 -1.1,-35.7 -6.7,-52.7 -5.6,-17.1 -14.6,-33 -26.2,-46.9 z"
-             class="st6" />
-        </g>
-        <g
-           id="g187">
-          <path
-             style="fill:#7f8587"
-             inkscape:connector-curvature="0"
-             id="path185"
-             d="m 383.4,565.8 c -12.6,-13 -22.4,-28.8 -28.9,-45.9 -3.2,-8.6 -5.5,-17.5 -7,-26.5 -1.5,-9.1 -1.9,-18.3 -1.6,-27.5 0.7,-18.4 5.3,-36.6 13.1,-53.3 7.9,-16.7 19.2,-31.7 32.9,-44.1 13.8,-12.3 30,-21.9 47.4,-27.9 17.5,-6 36.1,-8.6 54.4,-7.3 9.2,0.6 18.3,2.1 27.1,4.5 8.8,2.4 17.4,5.7 25.6,9.8 16.3,8.2 30.9,19.8 42.5,33.7 -12.6,-13 -27.4,-23.7 -43.7,-31 -16.3,-7.4 -33.9,-11.6 -51.7,-12.3 -8.9,-0.3 -17.8,0.1 -26.6,1.5 -8.8,1.3 -17.4,3.5 -25.7,6.5 -16.7,5.9 -32.1,15.2 -45.3,27 -13.2,11.8 -24.1,26.2 -31.8,42.1 -7.8,15.9 -12.3,33.4 -13.6,51.1 -1.2,17.7 1.1,35.7 6.7,52.7 5.6,17 14.6,33 26.2,46.9 z"
-             class="st7" />
-        </g>
-        <path
-           style="fill:#7f8587"
-           inkscape:connector-curvature="0"
-           id="path189"
-           d="m 490.4,370.9 c 14.2,-15.8 38.6,-17.1 54.5,-2.9 0.6,0.5 1.2,1.1 1.7,1.6 -7.7,-10.8 -20.5,-17.6 -34.6,-16.8 -22,1.2 -38.8,20 -37.7,42.2 0.9,16.7 11.7,30.4 26.4,35.7 -2.6,-1.4 -5.2,-3.2 -7.5,-5.3 -15.7,-14.2 -17,-38.6 -2.8,-54.5 z"
-           class="st7" />
-        <path
-           style="fill:#d2dadd"
-           inkscape:connector-curvature="0"
-           id="path191"
-           d="m 523,435.1 c 45.2,-19.9 30.1,-56.6 30.1,-56.6 2.2,4.9 4.6,12.5 4.6,18.2 0,20 -15.2,36.5 -34.7,38.4"
-           class="st6" />
-      </g>
+         id="path87"
+         d="m 46.36789,26.342446 0.1524,0.121973 -0.0029,0.04313 -0.160866,-0.121973 z m -0.475457,-0.646377 0.02434,-0.01587 0.484188,0.316177 -0.02302,0.0344 z m -0.155045,-0.588962 0.268552,0.201083 -0.0087,0.03307 -0.281516,-0.206904 z m -0.198438,-0.614628 0.241565,0.16219 -0.01455,0.04445 -0.248445,-0.183885 z m 0.113771,-0.591873 0.0172,-0.03307 -0.186796,-0.112183 0.0085,0.03889 z m -1.583003,-1.311539 -0.02302,0.01005 1.410494,4.368271 0.02011,-0.01164 z"
+         style="fill:#e8e9e9;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
       <path
-         style="fill:#8e9698"
-         inkscape:connector-curvature="0"
-         id="path195"
-         d="m 657,301.9 c -11.7,-4.9 -24.1,-8.5 -37,-10.3 0,0 6.7,-14.4 7.8,-25.5 1.1,-11.1 -5.5,-85.8 -18.3,-110.6 -12.8,-24.8 -35.5,-68.3 -85,-72.5 -49.5,-4.2 -88.2,58.5 -95.3,82.2 -7.2,23.7 -13.7,56.5 -12,76.2 0.5,5.5 -0.5,8 -11.5,9.3 0,3.5 0,11.5 0,11.5 0,0 26.2,43.2 29.5,52.5 3.3,9.3 21,48 54.8,69.8 33.8,21.8 64,-3.2 64,-3.2 1.6,6 4.1,20.7 -5.9,34.8 0,0 -34.7,1.1 -48.8,-5.2 -5.7,-1.8 -16.5,0.5 -25.3,-2.3 -8.8,-2.8 -45.5,-15 -83.3,-90.8 0,0 12.5,-5.8 11.7,-7.2 -0.8,-1.3 -7.7,-16 -13.2,-22.5 -5.5,-6.5 -19.8,-20.7 -15.5,-50.3 4.3,-29.7 2.7,-43.3 9,-63.7 6.3,-20.3 24.5,-98.3 110,-117.5 19.3,-5.2 30.7,-9.5 47,-6.7 16.3,2.8 65.8,8.3 101.3,74.8 25,48.7 28.2,83.7 28.7,97 0.5,13.3 1.2,47.3 -4.5,61.2 -5.7,13.8 -8.2,19 -8.2,19 z"
-         class="st12" />
+         id="path89"
+         d="m 46.041658,27.119792 c -0.0056,0.0026 -0.01138,0.004 -0.01693,0.0069 -0.12065,0.04472 -0.218546,0.05027 -0.297392,0.03598 l -1.31022,-4.069309 c 0,0 -0.06456,-0.43524 0.06906,-0.501386 l 0.191029,0.278607 c 0,0 0.0071,-0.0058 0.07461,0.176741 0.06615,0.179388 0.580496,1.7653 1.290109,4.072202 z"
+         style="fill:#585a5a;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
       <path
-         style="fill:#b3bbbd"
-         inkscape:connector-curvature="0"
-         id="path197"
-         d="m 408.8,331 c 26.1,56.4 77.6,77.3 77.6,77.3 -58,-11.9 -82.4,-77.7 -85.9,-83.4 -3.5,-5.7 -4.4,3.2 -4.4,3.2 -1.8,-3.3 -3.6,-6.8 -5.4,-10.5 0,0 5,-2.3 8.4,-4.4 z"
-         class="st13" />
-      <g
-         id="g212">
-        <linearGradient
-           y2="183.21651"
-           x2="582.0708"
-           y1="153.6228"
-           x1="672.19702"
-           gradientUnits="userSpaceOnUse"
-           id="SVGID_6_">
-          <stop
-             id="stop199"
-             style="stop-color:#AFB5B8"
-             offset="1.464978e-02" />
-          <stop
-             id="stop201"
-             style="stop-color:#A3ABAF"
-             offset="0.5733" />
-          <stop
-             id="stop203"
-             style="stop-color:#97A1A5"
-             offset="1" />
-        </linearGradient>
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:url(#SVGID_6_)"
-           id="path206"
-           d="m 630.5,264.9 c 5.5,-22.5 -5.8,-42.4 -5.8,-42.4 -3,-24.9 -8.2,-53.4 -15.2,-67 0,0 -11,-53.2 -68.2,-70.3 0,0 -12.3,-5.5 -22.8,-6.3 0,0 36,-12.8 73,15.8 37,28.6 48.3,108.8 48.8,119.9 0.5,11.1 4.4,42.9 -8.9,73.9 l -2.6,4.7 c -2,-0.4 -4.1,-0.8 -6.1,-1.1 -0.1,-0.1 2.3,-4.7 7.8,-27.2 z"
-           class="st14" />
-        <path
-           style="fill:#ccd1d3"
-           inkscape:connector-curvature="0"
-           id="path208"
-           d="m 624.3,189.3 c 10.1,11.1 9.9,31.9 9.8,35.5 -0.1,3.6 -0.8,14.8 -3.9,6 -3.1,-8.8 -5.5,-8.2 -5.5,-8.2 0,0 -3.5,-25.5 -6,-37.3 0,-0.1 0.6,-5.6 5.6,4 z"
-           class="st15" />
-        <path
-           style="fill:#ccd1d3"
-           inkscape:connector-curvature="0"
-           id="path210"
-           d="m 573.2,93.8 c 0,0 27.9,27.8 37.5,53 0,0 7.4,10.2 15.3,16.3 0,0 -6.5,-23.3 -14,-34 -7.5,-10.6 -23.3,-31.4 -38.8,-35.3 z"
-           class="st15" />
-      </g>
-      <g
-         id="g240">
-        <g
-           id="g229">
-          <linearGradient
-             y2="417.92899"
-             x2="556.47638"
-             y1="104.929"
-             x1="406.97641"
-             gradientUnits="userSpaceOnUse"
-             id="SVGID_7_">
-            <stop
-               id="stop214"
-               style="stop-color:#C0CDCE"
-               offset="0" />
-            <stop
-               id="stop216"
-               style="stop-color:#B1BCBD"
-               offset="0.2381" />
-            <stop
-               id="stop218"
-               style="stop-color:#888F90"
-               offset="0.7097" />
-            <stop
-               id="stop220"
-               style="stop-color:#6D7171"
-               offset="1" />
-          </linearGradient>
-          <path
-             inkscape:connector-curvature="0"
-             style="fill:url(#SVGID_7_)"
-             id="path223"
-             d="m 549.3,414.4 c -0.4,0.6 -0.7,1.1 -1.1,1.7 0,0 -34.7,1.1 -48.8,-5.2 0,0 -43.7,-13.8 -62.5,-42.8 -18.8,-29 -27.2,-32.7 -28,-40.5 -0.8,-7.8 0.5,-12.3 -6,-23.5 -1.6,-2.8 -8.2,-9.5 -13.7,-16 -5.5,-6.5 -19.8,-20.7 -15.5,-50.3 4.3,-29.7 2.7,-43.3 9,-63.7 6.3,-20.3 24.5,-98.3 110,-117.5 0,0 -32.3,14.2 -47.2,29 -14.9,14.8 -36.5,46 -40.5,55.7 -4,9.7 -10.5,21.8 -13.2,38.2 -2.7,16.3 -6,37.5 -5.7,50.5 0.3,13 0.5,8.8 1.3,12.5 0.8,3.7 -1.2,7.2 5,8.5 3.3,3 7,8.5 9.2,11.8 2.2,3.3 25.8,40.8 29.3,48.7 3.5,7.8 15.3,28.7 19.3,34.7 4,6 26.2,33.8 38.3,40.3 12.1,6.4 29.5,13.3 45.6,7.6 16.1,-5.8 20.5,-9.9 20.5,-9.9 1.4,6.4 2.2,18.4 -5.3,30.2"
-             class="st16" />
-          <path
-             style="fill:#e5e6e6"
-             inkscape:connector-curvature="0"
-             id="path225"
-             d="m 407.9,316.5 c 0,3.4 -1.9,-7.2 -5,-12.5 -1.6,-2.8 -8.2,-9.5 -13.7,-16 -4.5,-5.3 -14.7,-15.6 -16.1,-35.2 0,0 4.6,-8 8.6,-4.9 4.1,3.1 2.1,13.2 4.6,20.5 2.5,7.3 3.8,12.3 9.5,19.1 5.7,6.8 12.2,12 12.1,29 z"
-             class="st17" />
-          <path
-             style="fill:#adb2b2"
-             inkscape:connector-curvature="0"
-             id="path227"
-             d="m 550.1,413.1 m 5.2,-24.5 c 0.6,6.6 0,15.5 -5.3,24.5 0,0 -1.3,2 -3.7,2 -2.4,0 -31,-1.8 -44.7,-5.7 -13.7,-3.9 -39.8,-18.6 -50.3,-29.9 -10.5,-11.3 -33.8,-43.5 -35.1,-49.2 -1.3,-5.7 2.4,-12.6 6.7,-8.6 4.3,4 15.5,21.1 24.6,31 9.1,9.9 20.4,23.1 33,30.8 12.6,7.8 28.3,17 42.6,13.9 14.3,-3.1 26.8,-10.3 30.2,-12 0,0.1 1.5,1 2,3.2 z"
-             class="st18" />
-        </g>
-        <linearGradient
-           y2="420.74619"
-           x2="531.42987"
-           y1="401.49619"
-           x1="526.67987"
-           gradientUnits="userSpaceOnUse"
-           id="SVGID_8_">
-          <stop
-             id="stop231"
-             style="stop-color:#989B9B"
-             offset="0" />
-          <stop
-             id="stop233"
-             style="stop-color:#878A8A"
-             offset="0.4599" />
-          <stop
-             id="stop235"
-             style="stop-color:#6D7171"
-             offset="1" />
-        </linearGradient>
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:url(#SVGID_8_)"
-           id="path238"
-           d="m 550.1,413.1 m 5.4,-22.5 c 0.3,6.3 -0.7,14.4 -5.4,22.5 0,0 -1.3,2 -3.7,2 -2.4,0 -31,-1.8 -44.7,-5.7 -1.5,-0.4 -3.2,-1 -4.9,-1.7 0,0 18.8,2.6 30.3,0.2 11.5,-2.4 15.8,-3.3 19.4,-7.7 3.6,-4.3 9,-9.6 9,-9.6 z"
-           class="st19" />
-      </g>
-      <g
-         id="g257">
-        <linearGradient
-           y2="174.45399"
-           x2="667.75092"
-           y1="174.45399"
-           x1="388.30139"
-           gradientUnits="userSpaceOnUse"
-           id="SVGID_9_">
-          <stop
-             id="stop242"
-             style="stop-color:#C9CFD0"
-             offset="0" />
-          <stop
-             id="stop244"
-             style="stop-color:#B8BFC1"
-             offset="0.5907" />
-          <stop
-             id="stop246"
-             style="stop-color:#A9B2B4"
-             offset="1" />
-        </linearGradient>
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:url(#SVGID_9_)"
-           id="path249"
-           d="m 506.7,84.3 c -40.8,9.4 -71.3,60.1 -77.6,80.9 -7.2,23.7 -13.7,56.5 -12,76.2 0.5,5.5 -0.5,8 -11.5,9.3 0,0 -17,1.8 -17.2,-2 -0.1,-3.9 -0.4,-20.1 0,-27.8 0.4,-7.6 7,-70.1 29,-96.4 22,-26.3 40.5,-59.2 114.9,-75.5 2.4,0.1 4.8,0.4 7.4,0.8 16.3,2.8 65.8,8.3 101.3,74.8 7.9,15.4 13.6,29.4 17.8,41.8 0,0 13,55.6 7.7,77 -1.9,21.5 -5.9,34.8 -9.1,43.4 -3.2,8.6 -5.3,13 -5.3,13 -6.7,-2.6 -13.6,-4.6 -20.7,-6.2 0,0 22.1,-48.4 5.4,-103.4 -16.7,-55 -30.3,-77.5 -52.3,-93.8 -22,-16.3 -57.3,-17.3 -62.5,-16.1 -5.2,1.2 -15.3,4 -15.3,4 z"
-           class="st20" />
-        <path
-           style="fill:#e2e5e6"
-           inkscape:connector-curvature="0"
-           id="path251"
-           d="m 417.2,244.7 c -0.5,3.2 -3.1,4.9 -11.5,5.9 0,0 -17,1.8 -17.2,-2 0,0 11.9,-12.2 28.7,-3.9 z"
-           class="st21" />
-        <path
-           style="opacity:0.8;fill:#babebf"
-           inkscape:connector-curvature="0"
-           id="path253"
-           d="m 391.4,209.9 c -0.7,8.3 6,41.2 6,41.2 -4.4,0 -8.9,-0.5 -8.9,-2.5 -0.1,-3.9 -0.4,-20.1 0,-27.8 0.2,-3.1 1.3,-15 4.1,-29.8 0,0.1 -0.5,10.6 -1.2,18.9 z"
-           class="st22" />
-        <path
-           sodipodi:nodetypes="ccscccsscccccc"
-           style="fill:#ccd1d3"
-           inkscape:connector-curvature="0"
-           id="path255"
-           d="M 615.2,133.6 C 606.3,116.4 596.7,105.5 584.5,96.5 562.5,80.2 527.2,79.1 522,80.2 c -5.2,1.1 -15.3,4.1 -15.3,4.1 -17.7,4.1 -33.5,15.9 -46.1,29.7 0,0 -16.3,13.5 -20.1,15.6 0,0 6,-17.3 20.5,-30.5 14.5,-13.2 42,-41.8 87.3,-33.8 45.3,8 83.5,51.8 89.8,63.2 6.3,11.3 18.09781,44.7714 14.39781,66.6714 0,0 -18.09781,-41.6714 -19.19781,-42.2714 l -1.5,8.5 c 0,0 -8.5,-23.8 -13.8,-27 -2.2,-1.1 -2.8,-0.8 -2.8,-0.8 z"
-           class="st15" />
-      </g>
+         id="path91"
+         d="m 45.794778,27.168382 c 0.02585,0.0014 0.05315,0 0.08188,-0.0043 l -1.433554,-4.399773 0.109168,0.597552 z"
+         style="fill:url(#d-6);stroke-width:0.01436423"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path93"
+         d="m 45.550592,19.076988 c 0.180975,0.182562 0.324643,0.402166 0.418041,0.643466 0.0934,0.2413 0.139171,0.502709 0.130705,0.762794 -0.0071,0.260086 -0.06879,0.519906 -0.176742,0.758561 -0.10795,0.238654 -0.265642,0.45376 -0.456671,0.631825 a 1.9764375,1.9764375 0 0 1 -1.4351,0.524404 1.8190104,1.8190104 0 0 1 -0.384969,-0.05741 1.9073812,1.9073812 0 0 1 -0.364861,-0.132292 1.9060583,1.9060583 0 0 1 -0.60907,-0.466725 2.0185062,2.0185062 0 0 0 0.627856,0.429419 1.9737917,1.9737917 0 0 0 1.111779,0.133615 2.0013083,2.0013083 0 0 0 0.363273,-0.09922 1.9388667,1.9388667 0 0 0 0.635,-0.393435 1.9595042,1.9595042 0 0 0 0.522817,-2.075657 2.0372917,2.0372917 0 0 0 -0.382058,-0.659341 z"
+         style="fill:#d2dadd;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path95-2"
+         d="m 42.671925,21.740019 c -0.180975,-0.182298 -0.324644,-0.402167 -0.418042,-0.643467 -0.0934,-0.2413 -0.139171,-0.502708 -0.130704,-0.762793 0.0074,-0.259821 0.06906,-0.519907 0.176741,-0.758296 0.107686,-0.23839 0.265907,-0.454025 0.456936,-0.63209 0.192352,-0.176742 0.419364,-0.3175 0.664898,-0.4064 0.245533,-0.0889 0.508529,-0.130704 0.769937,-0.117739 0.130704,0.0056 0.260086,0.02434 0.384969,0.05741 a 1.9060583,1.9060583 0 0 1 0.973667,0.599016 2.0185062,2.0185062 0 0 0 -0.627327,-0.429684 1.9737917,1.9737917 0 0 0 -1.112044,-0.133614 2.0013083,2.0013083 0 0 0 -0.363273,0.09922 1.9388667,1.9388667 0 0 0 -0.635,0.3937 1.9595042,1.9595042 0 0 0 -0.522817,2.075656 2.0372917,2.0372917 0 0 0 0.382059,0.659077 z"
+         style="fill:#7f8587;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path97"
+         d="m 43.133093,19.315377 c 0,-0.185208 0.09049,-0.348985 0.229923,-0.449527 -0.170921,0.09049 -0.284427,0.258498 -0.284427,0.449792 0,0.191294 0.114829,0.357452 0.284427,0.449527 a 0.55694792,0.55694792 0 0 1 -0.229923,-0.449792 z"
+         style="fill:#7f8587;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path99"
+         d="m 43.676283,18.558404 c -1.222375,0 -2.213769,0.99695 -2.213769,2.226469 a 2.2285854,2.2285854 0 0 0 0.99404,1.858698 c -0.148167,0.219604 -0.04313,0.616479 -0.04313,0.616479 l 0.374914,0.09313 -0.0545,4.220105 c 0,0 0.06165,0.357716 0.475456,0.340519 0.413809,-0.0172 0.631825,-0.234157 0.804334,-0.516996 l -0.113507,-0.137848 -0.0071,-0.156634 0.142081,-0.134937 -0.36486,-0.535781 0.227012,-0.284427 -0.199496,-0.316177 0.02143,-0.134938 0.237067,-0.222779 -0.208227,-0.292894 0.245533,-0.144992 -0.265641,-0.11377 0.25691,-0.258498 0.09208,-0.337344 -0.150812,-0.0418 0.328877,-0.418042 v -0.439208 c 0,0 0.245533,-0.01455 0.420687,-0.115094 v -0.540279 a 2.2277917,2.2277917 0 0 0 1.215497,-1.987815 c 0,-1.228196 -0.992718,-2.225146 -2.215093,-2.225146 z m -0.172508,1.572948 c -0.306123,0 -0.554567,-0.248708 -0.554567,-0.554566 0,-0.305859 0.248708,-0.554302 0.554567,-0.554302 a 0.55456667,0.55456667 0 0 1 0,1.108868 z"
+         style="fill:#535555;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path101"
+         d="m 43.615724,18.558463 c -1.189358,0 -2.153198,0.996878 -2.153198,2.226456 0,0.784287 0.392144,1.475206 0.985386,1.871659 -0.135024,0.222645 -0.03591,0.603298 -0.03591,0.603298 l 0.374907,0.09337 -0.05458,4.220211 c 0,0 0.06177,0.357668 0.475456,0.340432 0.235573,-0.01005 0.407944,-0.08475 0.544404,-0.198226 l 0.170935,-0.27723 -0.119224,-0.173807 v -0.143642 l 0.170935,-0.152261 -0.380652,-0.511367 0.209717,-0.298776 -0.186735,-0.294467 0.05889,-0.21259 0.2169,-0.163752 -0.248501,-0.293031 0.317449,-0.173807 -0.285848,-0.104859 0.259992,-0.262865 0.109169,-0.337559 -0.234137,-0.01005 c 0,0 0.282975,-0.261429 0.337559,-0.416562 l 0.01436,-0.466838 c 0,0 0.311704,0.02873 0.349051,-0.01149 0.03591,-0.03735 0.06464,-0.07326 0.109168,-0.660754 0.680865,-0.37347 1.14483,-1.114664 1.14483,-1.9679 0.0029,-1.226705 -0.960968,-2.223582 -2.150326,-2.223582 z m -0.112041,1.572883 c -0.305958,0 -0.554459,-0.248501 -0.554459,-0.554459 0,-0.305958 0.248501,-0.554459 0.554459,-0.554459 0.305958,0 0.554459,0.248501 0.554459,0.554459 0,0.305958 -0.248501,0.554459 -0.554459,0.554459 z"
+         style="fill:url(#e-2);stroke-width:0.01436423"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path103"
+         d="m 43.803812,27.264519 0.09499,-0.0056 0.113506,0.137583 -0.08917,0.0418 z m -0.20955,-0.808831 0.380471,0.511704 -0.170921,0.153458 0.08758,-0.01852 0.142346,-0.134937 -0.36486,-0.534458 z m 0.103188,-0.624417 -0.08017,0.03281 0.186531,0.294482 0.0934,-0.01138 z m 0.258762,-0.357981 -0.208227,-0.291571 0.246856,-0.146315 -0.03175,-0.01323 -0.317235,0.174096 0.248708,0.291571 -0.218546,0.163777 0.04313,0.04445 z m -0.279929,-0.55589 0.05292,0.0058 0.255587,-0.258498 -0.04736,-0.01005 z"
+         style="fill:#717475;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path105"
+         d="m 43.90012,27.474334 c -0.0042,-0.0071 -0.129381,-0.19685 -0.129381,-0.19685 l 0.03307,-0.01429 0.119063,0.173831 z m -0.305858,-1.018646 0.380471,0.511704 -0.02275,0.02011 -0.392377,-0.505618 z m 0.191029,-0.272521 0.01852,-0.02461 -0.175154,-0.277284 -0.0344,0.02593 z m -0.0934,-0.933979 0.202407,0.238654 -0.0344,0.02567 -0.214048,-0.231246 z m 0.341842,-0.893234 0.01297,-0.03731 -0.19685,-0.0087 v 0.0545 z M 42.81427,23.360327 h -0.02725 l -0.05477,4.207405 h 0.02593 z"
+         style="fill:#e8e9e9;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path107-2"
+         d="m 43.255066,27.910896 c -0.01588,0.0016 -0.03148,0.0029 -0.04736,0.0029 -0.124883,0.0058 -0.218281,-0.02434 -0.287337,-0.06747 0,0 0.03889,-3.911336 0.06773,-4.060825 0.02858,-0.147902 0.162189,-0.699559 0.305858,-0.8001 0,0 0.03889,0.126471 0.04022,0.456935 0.0027,0.331788 -0.07911,4.468813 -0.07911,4.468813 z"
+         style="fill:#585a5a;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path109"
+         d="m 43.164687,27.913886 c -0.0316,0 -0.06033,-0.0029 -0.08619,-0.0086 l 0.06033,-4.603735 h 0.05746 z"
+         style="fill:url(#f-9);stroke-width:0.01436423"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path111"
+         d="M 43.308512,23.058702 A 0.923925,0.923925 0 0 0 43.29396,22.987 c -0.143669,0.100542 -0.277283,0.650875 -0.305858,0.8001 -0.02884,0.147902 -0.06773,4.060825 -0.06773,4.060825 0.02461,0.01587 0.05186,0.02858 0.08334,0.04022 0,0 0.01588,-3.836723 0.04604,-3.977481 a 1.9685,1.9685 0 0 1 0.06456,-0.344752 c 0.03889,-0.140762 0.193939,-0.50721 0.193939,-0.50721 z"
+         style="fill:#535555;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path113"
+         d="m 45.078045,19.482065 a 1.9195521,1.9195521 0 0 1 0.51144,1.031346 1.9854333,1.9854333 0 0 1 -0.163777,1.151995 1.9896667,1.9896667 0 0 1 -1.146175,1.027113 1.978025,1.978025 0 0 1 -1.162315,0.03863 1.9301354,1.9301354 0 0 1 -0.36486,-0.140758 1.9174354,1.9174354 0 0 1 -0.605896,-0.47969 2.0396729,2.0396729 0 0 0 0.623094,0.442384 c 0.232833,0.106362 0.484187,0.165364 0.737129,0.175418 0.126206,0.0042 0.254,-0.0016 0.379148,-0.02011 0.125148,-0.01852 0.248444,-0.05027 0.366183,-0.0934 a 1.9571229,1.9571229 0 0 0 1.100402,-0.985573 1.9722042,1.9722042 0 0 0 0.19394,-0.729721 1.9727333,1.9727333 0 0 0 -0.09499,-0.752475 2.0896792,2.0896792 0 0 0 -0.373328,-0.665162 z"
+         style="fill:#d2dadd;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path115"
+         d="m 42.144875,22.113611 a 1.9195521,1.9195521 0 0 1 -0.51144,-1.031346 1.9846396,1.9846396 0 0 1 -0.02302,-0.392113 1.9854333,1.9854333 0 0 1 0.186796,-0.759883 1.9896667,1.9896667 0 0 1 1.146175,-1.027113 1.978025,1.978025 0 0 1 1.16205,-0.03863 c 0.126471,0.0344 0.248708,0.08202 0.365125,0.140759 a 1.9174354,1.9174354 0 0 1 0.605896,0.479689 2.0396729,2.0396729 0 0 0 -0.623358,-0.442383 1.9642667,1.9642667 0 0 0 -0.736865,-0.175419 c -0.126471,-0.0042 -0.254,0.0016 -0.379148,0.02011 -0.125148,0.01852 -0.248708,0.05027 -0.366448,0.0934 a 1.9571229,1.9571229 0 0 0 -1.100137,0.985573 1.9722042,1.9722042 0 0 0 -0.19394,0.729721 1.9727333,1.9727333 0 0 0 0.09472,0.752475 2.0743333,2.0743333 0 0 0 0.373592,0.665163 z"
+         style="fill:#7f8587;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path117"
+         d="m 42.565827,18.558404 c -1.259946,0 -2.281238,1.007005 -2.281238,2.249488 0,0.492654 0.160867,0.949589 0.433917,1.320271 -0.179652,0.320146 -0.218281,0.473604 -0.206904,0.515408 0.01138,0.04313 0.27305,0.179652 0.27305,0.179652 l -1.761067,3.849688 c 0,0 -0.106362,0.392112 0.427831,0.525727 0.534194,0.133614 0.830263,-0.201083 0.830263,-0.201083 l -0.05159,-0.172509 0.04895,-0.140758 0.199496,-0.06615 -0.119063,-0.639233 0.3175,-0.163513 -0.05609,-0.370681 0.06165,-0.127794 0.313267,-0.183885 -0.08625,-0.306123 0.0717,-0.205317 0.392112,-0.143669 v -0.231245 l 0.12065,-0.159544 c 0,0 0.379413,-0.142082 0.423863,-0.222515 0.04445,-0.08043 0.19394,-0.389202 0.19394,-0.389202 l 0.360627,0.06615 c 0,0 0.05292,0.05159 0.305858,-0.495829 1.160727,-0.104771 2.068513,-1.067061 2.068513,-2.239165 -0.0016,-1.24116 -1.02288,-2.248165 -2.280973,-2.248165 z m 0.456671,1.674813 c -0.305859,0 -0.554567,-0.248444 -0.554567,-0.554302 0,-0.305859 0.248708,-0.554567 0.554567,-0.554567 0.305858,0 0.554566,0.248708 0.554566,0.554567 0,0.307446 -0.248708,0.554302 -0.554566,0.554302 z"
+         style="fill:#535555;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path119"
+         d="m 42.565699,18.558463 c -1.258307,-0.0316 -2.28104,1.006933 -2.28104,2.249439 0,0.492693 0.16088,0.949475 0.4338,1.320072 -0.179553,0.320323 -0.218336,0.47402 -0.206845,0.515676 0.01149,0.04309 0.272921,0.179553 0.272921,0.179553 l -1.761055,3.849614 c 0,0 -0.106295,0.392143 0.428054,0.52573 0.178116,0.04453 0.330377,0.03735 0.452473,0.0072 l 0.270048,-0.205409 -0.0316,-0.191044 0.07469,-0.147952 0.191044,-0.06464 -0.139333,-0.598988 0.316013,-0.21259 -0.05746,-0.340433 0.08331,-0.165188 0.251374,-0.136461 -0.06033,-0.304521 0.103423,-0.212591 0.422308,-0.147951 -0.05889,-0.219773 0.09911,-0.170934 c 0,0 0.399325,-0.12066 0.484074,-0.288722 0.08475,-0.168076 0.172371,-0.361993 0.172371,-0.361993 0,0 0.248502,0.119223 0.308831,0.126405 0.06033,0.0072 0.130715,-0.09624 0.389271,-0.584624 1.16063,-0.104859 2.016738,-1.050025 2.016738,-2.168999 0.0029,-1.249688 -0.948039,-2.219273 -2.173308,-2.250874 z m 0.456782,1.674869 c -0.305958,0 -0.554459,-0.248501 -0.554459,-0.554459 0,-0.305958 0.248501,-0.554459 0.554459,-0.554459 0.305958,0 0.55446,0.248501 0.55446,0.554459 0,0.307395 -0.248502,0.554459 -0.55446,0.554459 z"
+         style="fill:url(#g-3);stroke-width:0.01436423"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path121"
+         d="m 41.37335,24.480838 -0.04286,-0.0026 -0.06032,-0.220133 0.103187,-0.0085 z m -0.760942,0.797454 0.251354,-0.13679 -0.059,-0.30427 0.104775,-0.0074 0.08625,0.304536 -0.311679,0.183885 z m 0.06588,0.537104 -0.09208,-0.03175 -0.05741,-0.340519 0.0934,0.0016 z m -0.461169,0.84455 0.192617,-0.06482 -0.139436,-0.598752 0.09049,-0.01746 0.11774,0.639233 -0.199496,0.06615 z m 0.06456,0.337609 -0.107685,0.0013 -0.03016,-0.191029 0.08758,0.01587 z"
+         style="fill:#717475;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path123"
+         d="m 40.144095,26.807848 0.0299,0.191029 -0.03704,0.02884 -0.0217,-0.219869 z m 0.126207,-0.811477 0.139435,0.598752 -0.02752,0.0087 -0.144992,-0.599016 z m 0.28575,-0.192617 c -0.0013,-0.01296 -0.06323,-0.350572 -0.06323,-0.350572 l 0.0344,-0.01005 0.05768,0.340519 z m 0.248708,-0.966787 0.05874,0.304535 -0.03016,0.0172 -0.06165,-0.310091 z m 0.465402,-0.578908 0.06032,0.219868 -0.03757,0.01164 -0.05583,-0.222779 z m -0.484187,-1.4351 -1.761067,3.849687 c 0,0 0.02593,-0.0098 0.04313,-0.03995 0.0172,-0.03016 1.738048,-3.802063 1.738048,-3.802063 z m -0.182298,-0.103188 c -0.04762,-0.03016 -0.08784,-0.059 -0.09207,-0.0762 -0.0071,-0.02434 0.0026,-0.08334 0.04445,-0.189442 0.0016,0.0013 -0.06165,0.201084 0.04762,0.265642 z"
+         style="fill:#e8e9e9;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path125"
+         d="m 39.095287,26.991734 c 0.059,0.07752 0.160867,0.152135 0.330465,0.19976 0,0 2.033852,-4.352396 1.967706,-4.516438 0,0 -0.463815,0.301625 -0.660665,0.74295 -0.19685,0.441325 -1.637506,3.573728 -1.637506,3.573728 z"
+         style="fill:#585a5a;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path127"
+         d="m 40.80476,24.166248 c -0.580496,1.315773 -1.379008,3.025246 -1.379008,3.025246 -0.0217,-0.0058 -0.0418,-0.01323 -0.06033,-0.01879 z"
+         style="fill:#d8d8d8;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path129"
+         d="m 41.374937,22.775863 c 0.01587,-0.05477 0.02302,-0.08917 0.0172,-0.100542 0,0 -0.464079,0.301625 -0.660664,0.742685 -0.196586,0.441061 -1.637771,3.573728 -1.637771,3.573728 a 0.34395833,0.34395833 0 0 0 0.05318,0.05741 c 0,0 1.621896,-3.538008 1.690687,-3.655748 0.06879,-0.117739 0.311944,-0.422275 0.409575,-0.511175 0.09763,-0.0889 0.127794,-0.106362 0.127794,-0.106362 z"
+         style="fill:#535555;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path131"
+         d="m 44.026591,19.457459 a 1.9372792,1.9372792 0 0 1 0.515673,1.040077 1.9954875,1.9954875 0 0 1 -0.1651,1.160727 2.0269729,2.0269729 0 0 1 -0.47281,0.633412 2.016125,2.016125 0 0 1 -0.680773,0.400844 1.984375,1.984375 0 0 1 -1.538288,-0.100542 1.9269604,1.9269604 0 0 1 -0.610658,-0.484187 2.0425833,2.0425833 0 0 0 0.627856,0.445294 1.9880792,1.9880792 0 0 0 1.493838,0.06191 c 0.239712,-0.08467 0.461169,-0.218281 0.650875,-0.387879 0.189706,-0.169598 0.346075,-0.376502 0.456671,-0.604838 a 2.0031604,2.0031604 0 0 0 0.195262,-0.733954 1.9957521,1.9957521 0 0 0 -0.09631,-0.756973 2.0507854,2.0507854 0 0 0 -0.376238,-0.673629 z"
+         style="fill:#d2dadd;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path133"
+         d="m 41.073312,22.10779 a 1.9372792,1.9372792 0 0 1 -0.515937,-1.039813 1.9954875,1.9954875 0 0 1 0.1651,-1.160727 2.0269729,2.0269729 0 0 1 0.47281,-0.633412 2.016125,2.016125 0 0 1 0.681038,-0.400844 1.984375,1.984375 0 0 1 1.538287,0.100542 1.9269604,1.9269604 0 0 1 0.610394,0.484187 2.0425833,2.0425833 0 0 0 -0.627592,-0.445294 1.9880792,1.9880792 0 0 0 -1.493837,-0.06191 c -0.239977,0.08467 -0.461169,0.218546 -0.650875,0.387879 -0.189707,0.169333 -0.346075,0.376502 -0.456671,0.604838 a 2.0031604,2.0031604 0 0 0 -0.195263,0.733954 c -0.01746,0.254 0.01588,0.512762 0.09604,0.756973 0.08017,0.24421 0.209815,0.474133 0.376502,0.673629 z"
+         style="fill:#7f8587;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path135"
+         d="m 42.610012,19.308234 a 0.555625,0.555625 0 0 1 0.783167,-0.04154 c 0.0085,0.0071 0.0172,0.01587 0.02434,0.02302 a 0.57097083,0.57097083 0 0 0 -0.497152,-0.2413 0.57520417,0.57520417 0 0 0 -0.541338,0.605895 0.57652708,0.57652708 0 0 0 0.379148,0.513027 0.55668333,0.55668333 0 0 1 -0.148167,-0.859101 z"
+         style="fill:#7f8587;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path137"
+         d="m 43.078325,20.230571 c 0.649552,-0.28575 0.432593,-0.813065 0.432593,-0.813065 0.03175,0.07038 0.06615,0.179388 0.06615,0.261409 a 0.55377292,0.55377292 0 0 1 -0.498475,0.551656"
+         style="fill:#d2dadd;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path139"
+         d="M 45.003433,18.317104 A 2.1436542,2.1436542 0 0 0 44.47162,18.169202 c 0,0 0.09657,-0.206904 0.112184,-0.366183 0.01561,-0.159279 -0.07885,-1.232694 -0.262731,-1.588823 -0.183886,-0.356129 -0.510117,-0.981075 -1.221053,-1.0414 -0.710935,-0.06033 -1.266825,0.840317 -1.368954,1.180835 -0.103187,0.340255 -0.19685,0.811478 -0.172243,1.094582 0.0071,0.07885 -0.0071,0.114829 -0.165365,0.133614 v 0.1651 c 0,0 0.376502,0.620448 0.423862,0.754063 0.04736,0.133614 0.301625,0.689504 0.787136,1.002771 0.48551,0.313266 0.919427,-0.04604 0.919427,-0.04604 0.02302,0.08625 0.05874,0.297391 -0.08467,0.500062 0,0 -0.49874,0.01561 -0.701146,-0.07488 -0.08202,-0.02593 -0.237066,0.0071 -0.363537,-0.03307 -0.126471,-0.04022 -0.653521,-0.215371 -1.196446,-1.304396 0,0 0.179652,-0.08334 0.168011,-0.103188 -0.01138,-0.01879 -0.110596,-0.230187 -0.189442,-0.323321 -0.07885,-0.09313 -0.284427,-0.297391 -0.222779,-0.722312 0.06191,-0.426773 0.03889,-0.6223 0.129381,-0.915458 0.09049,-0.291307 0.351896,-1.411817 1.580092,-1.687513 0.277018,-0.07461 0.440795,-0.136525 0.674952,-0.09631 0.234156,0.04022 0.945356,0.119062 1.455208,1.074473 0.35904,0.699558 0.404813,1.202266 0.412221,1.393296 0.0074,0.191029 0.0172,0.67945 -0.06456,0.87921 -0.08202,0.198173 -0.11774,0.272785 -0.11774,0.272785 z"
+         style="fill:#8e9698;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path141"
+         d="m 41.437908,18.735146 c 0.375179,0.810154 1.114954,1.110456 1.114954,1.110456 -0.833437,-0.170921 -1.183746,-1.116277 -1.234017,-1.198033 -0.05027,-0.08176 -0.06324,0.04604 -0.06324,0.04604 -0.02566,-0.04763 -0.05159,-0.0979 -0.07752,-0.150813 0,0 0.07197,-0.03307 0.12065,-0.0635 z"
+         style="fill:#b3bbbd;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path143"
+         d="m 44.622657,17.785668 c 0.079,-0.323195 -0.08331,-0.609043 -0.08331,-0.609043 -0.04309,-0.35767 -0.117787,-0.76705 -0.218336,-0.962404 0,0 -0.158007,-0.764177 -0.979641,-1.009805 0,0 -0.17668,-0.079 -0.327504,-0.0905 0,0 0.517112,-0.183862 1.048589,0.226955 0.531476,0.410817 0.693792,1.562828 0.700974,1.722271 0.0072,0.159443 0.0632,0.616225 -0.127842,1.061516 l -0.03735,0.06751 c -0.02873,-0.0057 -0.05889,-0.01149 -0.08762,-0.0158 -0.0014,-0.0014 0.03304,-0.06751 0.112042,-0.390706 z"
+         style="fill:url(#h-6);stroke-width:0.01436423"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path145"
+         d="m 44.533533,16.699706 c 0.145256,0.159544 0.142346,0.458259 0.140758,0.509853 -0.0016,0.05159 -0.01138,0.212725 -0.05583,0.08625 -0.04445,-0.126471 -0.07911,-0.11774 -0.07911,-0.11774 0,0 -0.05027,-0.366183 -0.08625,-0.535781 0,-0.0013 0.0087,-0.08043 0.08043,0.05741 z m -0.733954,-1.371864 c 0,0 0.400844,0.399521 0.538691,0.761471 0,0 0.106363,0.146579 0.219605,0.234156 0,0 -0.09313,-0.334698 -0.201084,-0.488421 -0.107685,-0.1524 -0.334433,-0.451114 -0.557212,-0.507206 z"
+         style="fill:#ccd1d3;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path147"
+         d="m 43.456281,19.93312 c -0.0057,0.0086 -0.01005,0.0158 -0.0158,0.02442 0,0 -0.498439,0.0158 -0.700974,-0.07469 0,0 -0.627717,-0.198226 -0.897765,-0.614789 -0.270047,-0.416562 -0.390707,-0.46971 -0.402198,-0.581751 -0.01149,-0.112041 0.0072,-0.17668 -0.08619,-0.337559 -0.02298,-0.04022 -0.117787,-0.13646 -0.19679,-0.229828 -0.079,-0.09337 -0.284412,-0.297339 -0.222646,-0.722521 0.06177,-0.426617 0.03878,-0.621971 0.129278,-0.915001 0.09049,-0.291594 0.351924,-1.412004 1.580065,-1.687797 0,0 -0.463964,0.203972 -0.677991,0.416563 -0.214027,0.21259 -0.524294,0.660754 -0.581751,0.800087 -0.05746,0.139333 -0.150825,0.31314 -0.189608,0.548714 -0.03878,0.234137 -0.08619,0.538658 -0.08188,0.725393 0.0043,0.186735 0.0072,0.126406 0.01867,0.179553 0.01149,0.05315 -0.01724,0.103423 0.07182,0.122096 0.0474,0.04309 0.100549,0.122096 0.132151,0.169498 0.0316,0.0474 0.370597,0.586061 0.420872,0.699538 0.05027,0.112041 0.219772,0.412253 0.277229,0.498439 0.05746,0.08618 0.376343,0.485511 0.55015,0.578878 0.173807,0.09193 0.423745,0.191045 0.655009,0.109168 0.231264,-0.08331 0.294467,-0.142205 0.294467,-0.142205 0.02011,0.09193 0.0316,0.264301 -0.07613,0.433799"
+         style="fill:url(#i-1);stroke-width:0.01436423"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path149-8"
+         d="m 41.425208,18.526919 c 0,0.04868 -0.02725,-0.103452 -0.07197,-0.179652 -0.02275,-0.04022 -0.117739,-0.136525 -0.196585,-0.229658 -0.06482,-0.0762 -0.211138,-0.224103 -0.231246,-0.505619 0,0 0.06615,-0.115094 0.123296,-0.07064 0.059,0.04472 0.03043,0.189706 0.06615,0.294481 0.03572,0.104775 0.05477,0.176742 0.136525,0.274373 0.08176,0.09763 0.175154,0.172508 0.173831,0.416719 z"
+         style="fill:#e5e6e6;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path151"
+         d="m 43.542404,19.562498 c 0.0087,0.09472 0,0.222779 -0.0762,0.351896 0,0 -0.01852,0.02884 -0.05292,0.02884 -0.0344,0 -0.445294,-0.02593 -0.642144,-0.08202 -0.19685,-0.05609 -0.5715,-0.267229 -0.722312,-0.429419 -0.150813,-0.16219 -0.485775,-0.624946 -0.504561,-0.706702 -0.01878,-0.08176 0.0344,-0.180975 0.09631,-0.123561 0.06191,0.05741 0.222779,0.303213 0.353483,0.445294 0.130704,0.142081 0.292894,0.331788 0.473869,0.442384 0.180975,0.112183 0.406664,0.24421 0.611981,0.19976 0.205317,-0.04445 0.384969,-0.148167 0.433917,-0.172508 0,0.0016 0.02143,0.01455 0.02857,0.04604 z"
+         style="fill:#adb2b2;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path153"
+         d="m 43.545339,19.591251 c 0.0043,0.0905 -0.01005,0.206845 -0.07757,0.323196 0,0 -0.01867,0.02873 -0.05315,0.02873 -0.03447,0 -0.445291,-0.02585 -0.642081,-0.08188 -0.02154,-0.0057 -0.04597,-0.01436 -0.07039,-0.02442 0,0 0.270048,0.03735 0.435237,0.0029 0.165188,-0.03447 0.226954,-0.0474 0.278666,-0.110605 0.05171,-0.06177 0.129278,-0.137897 0.129278,-0.137897 z"
+         style="fill:url(#j-9);stroke-width:0.01436423"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path155"
+         d="m 42.844365,15.191488 c -0.586061,0.135024 -1.02417,0.86329 -1.114664,1.162066 -0.103423,0.340432 -0.19679,0.811579 -0.172371,1.094554 0.0072,0.079 -0.0072,0.114914 -0.165189,0.133588 0,0 -0.244191,0.02585 -0.247064,-0.02873 -0.0014,-0.05602 -0.0057,-0.288721 0,-0.399326 0.0057,-0.109168 0.100549,-1.006933 0.416562,-1.384712 0.316013,-0.377779 0.581752,-0.850362 1.65045,-1.084499 0.03447,0.0014 0.06895,0.0057 0.106296,0.01149 0.234136,0.04022 0.945166,0.119223 1.455096,1.074444 0.113477,0.22121 0.195353,0.422309 0.255683,0.600425 0,0 0.186735,0.798651 0.110605,1.106046 -0.02729,0.308831 -0.08475,0.499875 -0.130715,0.623407 -0.04597,0.123533 -0.07613,0.186735 -0.07613,0.186735 -0.09624,-0.03735 -0.195353,-0.06608 -0.297339,-0.08906 0,0 0.317449,-0.695228 0.07757,-1.485261 -0.239883,-0.790033 -0.435237,-1.113228 -0.75125,-1.347365 -0.316013,-0.234137 -0.82307,-0.248501 -0.897764,-0.231264 -0.07469,0.01724 -0.219773,0.05746 -0.219773,0.05746 z"
+         style="fill:url(#k-2);stroke-width:0.01436423"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path157"
+         d="m 41.558823,17.495573 c -0.0071,0.04577 -0.04471,0.07038 -0.165365,0.08467 0,0 -0.243946,0.02593 -0.246856,-0.02884 0,0 0.170921,-0.175154 0.412221,-0.05583 z"
+         style="fill:#e2e5e6;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path159"
+         d="m 41.188141,16.995511 c -0.01005,0.119327 0.08625,0.591873 0.08625,0.591873 -0.06323,0 -0.127793,-0.0071 -0.127793,-0.03598 a 7.3244604,7.3244604 0 0 1 0,-0.399257 c 0.0026,-0.04445 0.01852,-0.215371 0.05874,-0.428096 0,0.0016 -0.0071,0.1524 -0.0172,0.271463 z"
+         style="opacity:0.8;fill:#babebf;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path161"
+         d="m 44.402829,15.899606 c -0.127794,-0.24712 -0.265642,-0.403489 -0.440796,-0.53287 -0.316177,-0.234157 -0.823119,-0.250032 -0.897996,-0.234157 -0.07488,0.01587 -0.219604,0.059 -0.219604,0.059 -0.254265,0.05874 -0.481277,0.228336 -0.662252,0.426509 0,0 -0.234156,0.193939 -0.288661,0.224102 0,0 0.08599,-0.248708 0.294482,-0.43815 0.208491,-0.189442 0.60325,-0.600604 1.254125,-0.485511 0.650875,0.115094 1.199091,0.744009 1.289579,0.907786 0.09049,0.162454 0.260085,0.642937 0.206904,0.957792 0,0 -0.259821,-0.598488 -0.275696,-0.607219 l -0.0217,0.121973 c 0,0 -0.121973,-0.341842 -0.198173,-0.387615 -0.03175,-0.01588 -0.04022,-0.01164 -0.04022,-0.01164 z"
+         style="fill:#ccd1d3;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
     </g>
   </g>
   <style

--- a/128x128/apps/org.gnome.Todo.svg
+++ b/128x128/apps/org.gnome.Todo.svg
@@ -1,18 +1,45 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   inkscape:version="1.1-dev (1:0.92.0+devel+202004260039+9758c7a)"
-   sodipodi:docname="com.github.zren.todolist.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="org.gnome.Todo.svg"
    id="svg6"
    version="1.1"
    viewBox="0 0 33.866666 33.866667"
    height="128"
    width="128">
+  <metadata
+     id="metadata119">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
   <defs
      id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient941">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop937" />
+      <stop
+         style="stop-color:#f3f1ee;stop-opacity:1"
+         offset="1"
+         id="stop939" />
+    </linearGradient>
     <linearGradient
        id="lgrad"
        x1="32"
@@ -406,6 +433,15 @@
        width="120"
        height="120"
        rx="28" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient941"
+       id="linearGradient943"
+       x1="16.872171"
+       y1="2.588928"
+       x2="16.872171"
+       y2="31.527933"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <sodipodi:namedview
      inkscape:window-maximized="1"
@@ -417,111 +453,134 @@
      showgrid="false"
      inkscape:current-layer="layer1"
      inkscape:document-units="mm"
-     inkscape:cy="50.447597"
-     inkscape:cx="68.964108"
-     inkscape:zoom="0.44919235"
+     inkscape:cy="-2.1568105"
+     inkscape:cx="4.4253402"
+     inkscape:zoom="3.5935388"
      inkscape:pageshadow="2"
      inkscape:pageopacity="0.0"
      borderopacity="1.0"
      bordercolor="#666666"
      pagecolor="#ffffff"
-     id="base" />
+     id="base"
+     inkscape:snap-global="false" />
   <g
      id="layer1"
      inkscape:groupmode="layer"
      inkscape:label="Layer 1">
     <g
-       style="opacity:0.2967651"
+       style="opacity:0.29676508"
        transform="matrix(0.97573206,0,0,0.97573206,-65.748383,-37.203094)"
        id="g1702">
       <path
          d="m 76.449369,40.709618 h 16.591166 c 3.661863,0 6.609861,2.947998 6.609861,6.609861 v 16.591166 c 0,3.661863 -2.947998,6.609861 -6.609861,6.609861 H 76.449369 c -3.661863,0 -6.609861,-2.947998 -6.609861,-6.609861 V 47.319479 c 0,-3.661863 2.947998,-6.609861 6.609861,-6.609861 z"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
-         id="rect1634" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+         id="rect1634"
+         inkscape:connector-curvature="0" />
       <path
          d="m 76.449369,40.709618 h 16.591166 c 3.661863,0 6.609861,2.947998 6.609861,6.609861 v 16.591166 c 0,3.661863 -2.947998,6.609861 -6.609861,6.609861 H 76.449369 c -3.661863,0 -6.609861,-2.947998 -6.609861,-6.609861 V 47.319479 c 0,-3.661863 2.947998,-6.609861 6.609861,-6.609861 z"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
-         id="rect1638" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+         id="rect1638"
+         inkscape:connector-curvature="0" />
       <path
          d="m 76.449369,40.709618 h 16.591166 c 3.661863,0 6.609861,2.947998 6.609861,6.609861 v 16.591166 c 0,3.661863 -2.947998,6.609861 -6.609861,6.609861 H 76.449369 c -3.661863,0 -6.609861,-2.947998 -6.609861,-6.609861 V 47.319479 c 0,-3.661863 2.947998,-6.609861 6.609861,-6.609861 z"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
-         id="rect1640" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.30000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+         id="rect1640"
+         inkscape:connector-curvature="0" />
       <path
          d="m 76.449369,40.709618 h 16.591166 c 3.661863,0 6.609861,2.947998 6.609861,6.609861 v 16.591166 c 0,3.661863 -2.947998,6.609861 -6.609861,6.609861 H 76.449369 c -3.661863,0 -6.609861,-2.947998 -6.609861,-6.609861 V 47.319479 c 0,-3.661863 2.947998,-6.609861 6.609861,-6.609861 z"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
-         id="rect1642" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.40000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+         id="rect1642"
+         inkscape:connector-curvature="0" />
       <path
          d="m 76.449369,40.709618 h 16.591166 c 3.661863,0 6.609861,2.947998 6.609861,6.609861 v 16.591166 c 0,3.661863 -2.947998,6.609861 -6.609861,6.609861 H 76.449369 c -3.661863,0 -6.609861,-2.947998 -6.609861,-6.609861 V 47.319479 c 0,-3.661863 2.947998,-6.609861 6.609861,-6.609861 z"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
-         id="rect1644" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+         id="rect1644"
+         inkscape:connector-curvature="0" />
       <path
          d="m 76.449369,40.709618 h 16.591166 c 3.661863,0 6.609861,2.947998 6.609861,6.609861 v 16.591166 c 0,3.661863 -2.947998,6.609861 -6.609861,6.609861 H 76.449369 c -3.661863,0 -6.609861,-2.947998 -6.609861,-6.609861 V 47.319479 c 0,-3.661863 2.947998,-6.609861 6.609861,-6.609861 z"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
-         id="rect1646" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+         id="rect1646"
+         inkscape:connector-curvature="0" />
       <path
          d="m 76.449369,40.709618 h 16.591166 c 3.661863,0 6.609861,2.947998 6.609861,6.609861 v 16.591166 c 0,3.661863 -2.947998,6.609861 -6.609861,6.609861 H 76.449369 c -3.661863,0 -6.609861,-2.947998 -6.609861,-6.609861 V 47.319479 c 0,-3.661863 2.947998,-6.609861 6.609861,-6.609861 z"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.7;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
-         id="rect1648" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.69999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+         id="rect1648"
+         inkscape:connector-curvature="0" />
       <path
          d="m 76.449369,40.709618 h 16.591166 c 3.661863,0 6.609861,2.947998 6.609861,6.609861 v 16.591166 c 0,3.661863 -2.947998,6.609861 -6.609861,6.609861 H 76.449369 c -3.661863,0 -6.609861,-2.947998 -6.609861,-6.609861 V 47.319479 c 0,-3.661863 2.947998,-6.609861 6.609861,-6.609861 z"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
-         id="rect1650" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.80000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+         id="rect1650"
+         inkscape:connector-curvature="0" />
       <path
          d="m 76.449369,40.709618 h 16.591166 c 3.661863,0 6.609861,2.947998 6.609861,6.609861 v 16.591166 c 0,3.661863 -2.947998,6.609861 -6.609861,6.609861 H 76.449369 c -3.661863,0 -6.609861,-2.947998 -6.609861,-6.609861 V 47.319479 c 0,-3.661863 2.947998,-6.609861 6.609861,-6.609861 z"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
-         id="rect1652" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+         id="rect1652"
+         inkscape:connector-curvature="0" />
       <path
          d="m 76.449369,40.709618 h 16.591166 c 3.661863,0 6.609861,2.947998 6.609861,6.609861 v 16.591166 c 0,3.661863 -2.947998,6.609861 -6.609861,6.609861 H 76.449369 c -3.661863,0 -6.609861,-2.947998 -6.609861,-6.609861 V 47.319479 c 0,-3.661863 2.947998,-6.609861 6.609861,-6.609861 z"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
-         id="rect1654" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.20000005;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+         id="rect1654"
+         inkscape:connector-curvature="0" />
       <path
          d="m 76.449369,40.709618 h 16.591166 c 3.661863,0 6.609861,2.947998 6.609861,6.609861 v 16.591166 c 0,3.661863 -2.947998,6.609861 -6.609861,6.609861 H 76.449369 c -3.661863,0 -6.609861,-2.947998 -6.609861,-6.609861 V 47.319479 c 0,-3.661863 2.947998,-6.609861 6.609861,-6.609861 z"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
-         id="rect1656" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.39999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+         id="rect1656"
+         inkscape:connector-curvature="0" />
       <path
          d="m 76.449369,40.709618 h 16.591166 c 3.661863,0 6.609861,2.947998 6.609861,6.609861 v 16.591166 c 0,3.661863 -2.947998,6.609861 -6.609861,6.609861 H 76.449369 c -3.661863,0 -6.609861,-2.947998 -6.609861,-6.609861 V 47.319479 c 0,-3.661863 2.947998,-6.609861 6.609861,-6.609861 z"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
-         id="rect1658" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+         id="rect1658"
+         inkscape:connector-curvature="0" />
       <path
          d="m 76.449369,40.709618 h 16.591166 c 3.661863,0 6.609861,2.947998 6.609861,6.609861 v 16.591166 c 0,3.661863 -2.947998,6.609861 -6.609861,6.609861 H 76.449369 c -3.661863,0 -6.609861,-2.947998 -6.609861,-6.609861 V 47.319479 c 0,-3.661863 2.947998,-6.609861 6.609861,-6.609861 z"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
-         id="rect1660" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.79999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+         id="rect1660"
+         inkscape:connector-curvature="0" />
       <path
          d="m 76.449369,40.709618 h 16.591166 c 3.661863,0 6.609861,2.947998 6.609861,6.609861 v 16.591166 c 0,3.661863 -2.947998,6.609861 -6.609861,6.609861 H 76.449369 c -3.661863,0 -6.609861,-2.947998 -6.609861,-6.609861 V 47.319479 c 0,-3.661863 2.947998,-6.609861 6.609861,-6.609861 z"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
-         id="rect1662" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+         id="rect1662"
+         inkscape:connector-curvature="0" />
       <path
          d="m 76.449369,40.709618 h 16.591166 c 3.661863,0 6.609861,2.947998 6.609861,6.609861 v 16.591166 c 0,3.661863 -2.947998,6.609861 -6.609861,6.609861 H 76.449369 c -3.661863,0 -6.609861,-2.947998 -6.609861,-6.609861 V 47.319479 c 0,-3.661863 2.947998,-6.609861 6.609861,-6.609861 z"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
-         id="rect1664" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.20000005;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+         id="rect1664"
+         inkscape:connector-curvature="0" />
       <path
          d="m 76.449369,40.709618 h 16.591166 c 3.661863,0 6.609861,2.947998 6.609861,6.609861 v 16.591166 c 0,3.661863 -2.947998,6.609861 -6.609861,6.609861 H 76.449369 c -3.661863,0 -6.609861,-2.947998 -6.609861,-6.609861 V 47.319479 c 0,-3.661863 2.947998,-6.609861 6.609861,-6.609861 z"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
-         id="rect1666" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.5999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+         id="rect1666"
+         inkscape:connector-curvature="0" />
       <path
          d="m 76.449369,40.709618 h 16.591166 c 3.661863,0 6.609861,2.947998 6.609861,6.609861 v 16.591166 c 0,3.661863 -2.947998,6.609861 -6.609861,6.609861 H 76.449369 c -3.661863,0 -6.609861,-2.947998 -6.609861,-6.609861 V 47.319479 c 0,-3.661863 2.947998,-6.609861 6.609861,-6.609861 z"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
-         id="rect1668" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+         id="rect1668"
+         inkscape:connector-curvature="0" />
       <path
          d="m 76.449369,40.709618 h 16.591166 c 3.661863,0 6.609861,2.947998 6.609861,6.609861 v 16.591166 c 0,3.661863 -2.947998,6.609861 -6.609861,6.609861 H 76.449369 c -3.661863,0 -6.609861,-2.947998 -6.609861,-6.609861 V 47.319479 c 0,-3.661863 2.947998,-6.609861 6.609861,-6.609861 z"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3.4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
-         id="rect1670" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3.4000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+         id="rect1670"
+         inkscape:connector-curvature="0" />
       <path
          d="m 76.449369,40.709618 h 16.591166 c 3.661863,0 6.609861,2.947998 6.609861,6.609861 v 16.591166 c 0,3.661863 -2.947998,6.609861 -6.609861,6.609861 H 76.449369 c -3.661863,0 -6.609861,-2.947998 -6.609861,-6.609861 V 47.319479 c 0,-3.661863 2.947998,-6.609861 6.609861,-6.609861 z"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3.8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
-         id="rect1672" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3.79999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+         id="rect1672"
+         inkscape:connector-curvature="0" />
       <path
          d="m 76.449369,40.709618 h 16.591166 c 3.661863,0 6.609861,2.947998 6.609861,6.609861 v 16.591166 c 0,3.661863 -2.947998,6.609861 -6.609861,6.609861 H 76.449369 c -3.661863,0 -6.609861,-2.947998 -6.609861,-6.609861 V 47.319479 c 0,-3.661863 2.947998,-6.609861 6.609861,-6.609861 z"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:4.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
-         id="rect1674" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:4.19999981;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+         id="rect1674"
+         inkscape:connector-curvature="0" />
       <path
          d="m 76.449369,40.709618 h 16.591166 c 3.661863,0 6.609861,2.947998 6.609861,6.609861 v 16.591166 c 0,3.661863 -2.947998,6.609861 -6.609861,6.609861 H 76.449369 c -3.661863,0 -6.609861,-2.947998 -6.609861,-6.609861 V 47.319479 c 0,-3.661863 2.947998,-6.609861 6.609861,-6.609861 z"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:4.6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
-         id="rect1676" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:4.5999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+         id="rect1676"
+         inkscape:connector-curvature="0" />
       <path
          d="m 76.449369,40.709618 h 16.591166 c 3.661863,0 6.609861,2.947998 6.609861,6.609861 v 16.591166 c 0,3.661863 -2.947998,6.609861 -6.609861,6.609861 H 76.449369 c -3.661863,0 -6.609861,-2.947998 -6.609861,-6.609861 V 47.319479 c 0,-3.661863 2.947998,-6.609861 6.609861,-6.609861 z"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
-         id="rect1678" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+         id="rect1678"
+         inkscape:connector-curvature="0" />
     </g>
     <rect
        ry="6.4494534"
@@ -531,23 +590,25 @@
        height="29.087439"
        width="29.087439"
        id="rect849"
-       style="fill:#fcfcfe;fill-opacity:1;stroke-width:2.68768;stroke-linecap:round;stroke-linejoin:round" />
+       style="fill:url(#linearGradient943);fill-opacity:1;stroke-width:2.68768001;stroke-linecap:round;stroke-linejoin:round" />
     <path
-       style="color:#000000;fill:none;stroke-width:0.6"
+       style="color:#000000;fill:none;stroke-width:0.60000002"
        d="m 63.366089,-13.641431 -7.522293,-7.600555"
-       id="path6697" />
+       id="path6697"
+       inkscape:connector-curvature="0" />
     <path
-       style="color:#000000;fill:none;stroke-width:0.7"
+       style="color:#000000;fill:none;stroke-width:0.69999999"
        d="m 41.242367,-29.283552 8.855577,8.832529 c 1.749841,1.578263 2.915695,1.69766 4.709005,0.100743 l 11.968714,-11.16793"
-       id="path6691" />
+       id="path6691"
+       inkscape:connector-curvature="0" />
     <g
        transform="scale(0.26458333)"
        id="g13037" />
     <g
-       transform="translate(-4.9628964,-6.6822226)"
+       transform="translate(-4.9628964,-6.1349133)"
        id="g13956">
       <circle
-         style="opacity:1;fill:#4c6984;fill-opacity:1;stroke:none;stroke-width:1.78025;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.03"
+         style="opacity:1;fill:#0079fd;fill-opacity:1;stroke:none;stroke-width:1.78024995;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02999998"
          id="path13916"
          cx="13.561587"
          cy="15.60774"
@@ -557,19 +618,19 @@
          cy="15.60774"
          cx="13.561587"
          id="circle13918"
-         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.48537;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.03" />
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.48537004;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02999998" />
       <circle
-         style="opacity:1;fill:#4c6984;fill-opacity:1;stroke:none;stroke-width:1.10955;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.03"
+         style="opacity:1;fill:#0079fd;fill-opacity:1;stroke:none;stroke-width:1.10955;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02999998"
          id="circle13920"
          cx="13.561587"
          cy="15.60774"
          r="1.6656172" />
     </g>
     <g
-       transform="translate(-10.850236,1.0385621)"
+       transform="translate(-10.850236,-0.53079532)"
        id="g13951">
       <circle
-         style="opacity:1;fill:#bfa06d;fill-opacity:1;stroke:none;stroke-width:1.78025;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.03"
+         style="opacity:1;fill:#f78f00;fill-opacity:1;stroke:none;stroke-width:1.78024995;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02999998"
          id="circle13932"
          cx="19.448927"
          cy="24.924635"
@@ -579,25 +640,25 @@
          cy="24.924635"
          cx="19.448927"
          id="circle13934"
-         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.48537;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.03" />
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.48537004;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02999998" />
       <circle
-         style="opacity:1;fill:#bfa06d;fill-opacity:1;stroke:none;stroke-width:1.10955;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.03"
+         style="opacity:1;fill:#f78f00;fill-opacity:1;stroke:none;stroke-width:1.10955;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02999998"
          id="circle13936"
          cx="19.448927"
          cy="24.924635"
          r="1.6656172" />
     </g>
     <g
-       transform="translate(-20.936822,1.8366187)"
+       transform="translate(-20.936822,1.3255946)"
        id="g13941">
       <circle
          r="2.672447"
          cy="15.60774"
          cx="29.535513"
          id="circle13922"
-         style="opacity:1;fill:#9a5855;fill-opacity:1;stroke:none;stroke-width:1.78025;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.03" />
+         style="opacity:1;fill:#fb382d;fill-opacity:1;stroke:none;stroke-width:1.78024995;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02999998" />
       <circle
-         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.48537;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.03"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.48537004;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02999998"
          id="circle13924"
          cx="29.535513"
          cy="15.60774"
@@ -607,19 +668,22 @@
          cy="15.60774"
          cx="29.535513"
          id="circle13926"
-         style="opacity:1;fill:#9a5855;fill-opacity:1;stroke:none;stroke-width:1.10955;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.03" />
+         style="opacity:1;fill:#fb382d;fill-opacity:1;stroke:none;stroke-width:1.10955;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02999998" />
     </g>
     <path
        id="path13958"
-       d="M 13.721025,10.500405 H 27.981682"
-       style="fill:#4d4d4d;stroke:#929699;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
+       d="M 13.721025,9.4728271 H 27.981682"
+       style="fill:none;fill-opacity:1;stroke:#b9b9bc;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
     <path
-       style="fill:#4d4d4d;stroke:#929699;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 13.721025,19.546267 H 27.981682"
-       id="path13960" />
+       inkscape:connector-curvature="0"
+       style="fill:none;fill-opacity:1;stroke:#b9b9bc;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 13.721025,16.933335 H 27.981682"
+       id="path971" />
     <path
-       id="path13962"
-       d="M 13.721025,27.944082 H 27.981682"
-       style="fill:#4d4d4d;stroke:#929699;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       id="path975"
+       d="M 13.721025,24.393839 H 27.981682"
+       style="fill:none;fill-opacity:1;stroke:#b9b9bc;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
   </g>
 </svg>

--- a/128x128/apps/qtransmission.svg
+++ b/128x128/apps/qtransmission.svg
@@ -1,10 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-
-<!-- Artist: @KevDoy for Trenta.io -->
-
-<!-- Vector Conversion by @Genghis-Khanr -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -14,747 +8,683 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   version="1.1"
-   id="transmission"
-   x="0px"
-   y="0px"
-   viewBox="0 0 128 128"
-   xml:space="preserve"
-   sodipodi:docname="qtransmission.svg"
-   width="128"
    height="128"
-   inkscape:version="0.92.4 5da689c313, 2019-01-14"><metadata
-   id="metadata277"><rdf:RDF><cc:Work
-       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
-         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
-   id="defs275"><linearGradient
-     inkscape:collect="always"
-     xlink:href="#SVGID_13_"
-     id="linearGradient1103"
+   viewBox="0 0 33.867 33.867"
+   width="128"
+   version="1.1"
+   id="svg155"
+   sodipodi:docname="qtransmission.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <metadata
+     id="metadata161">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs159" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="480"
+     id="namedview157"
+     showgrid="false"
+     inkscape:zoom="1.84375"
+     inkscape:cx="-69.966102"
+     inkscape:cy="64"
+     inkscape:current-layer="svg155" />
+  <linearGradient
+     id="j"
      gradientUnits="userSpaceOnUse"
-     x1="237.54449"
-     y1="170.39661"
-     x2="313.54449"
-     y2="343.39661" /><linearGradient
-     inkscape:collect="always"
-     xlink:href="#SVGID_13_"
-     id="linearGradient1121"
-     x1="519.28363"
-     y1="70.750687"
-     x2="598.55902"
-     y2="208.05971"
-     gradientUnits="userSpaceOnUse" /></defs><sodipodi:namedview
-   pagecolor="#ffffff"
-   bordercolor="#666666"
-   borderopacity="1"
-   objecttolerance="10"
-   gridtolerance="10"
-   guidetolerance="10"
-   inkscape:pageopacity="0"
-   inkscape:pageshadow="2"
-   inkscape:window-width="1920"
-   inkscape:window-height="1031"
-   id="namedview273"
-   showgrid="false"
-   inkscape:zoom="1.3037281"
-   inkscape:cx="4.3389831"
-   inkscape:cy="60.129038"
-   inkscape:window-x="0"
-   inkscape:window-y="26"
-   inkscape:window-maximized="1"
-   inkscape:current-layer="transmission" />
-<style
-   type="text/css"
-   id="style2">
-	.st0{fill:url(#SVGID_1_);}
-	.st1{fill:#CDCDCD;}
-	.st2{fill:#1E1E1E;}
-	.st3{fill:url(#SVGID_2_);}
-	.st4{fill:#767676;}
-	.st5{fill:#4F4F4F;}
-	.st6{fill:url(#SVGID_3_);}
-	.st7{fill:url(#SVGID_4_);}
-	.st8{fill:url(#SVGID_5_);}
-	.st9{fill:url(#SVGID_6_);}
-	.st10{fill:url(#SVGID_7_);}
-	.st11{opacity:0.5;}
-	.st12{fill:url(#SVGID_8_);}
-	.st13{fill:#FFFFFF;}
-	.st14{fill:url(#SVGID_9_);}
-	.st15{fill:url(#SVGID_10_);}
-	.st16{fill:url(#SVGID_11_);}
-	.st17{fill:url(#SVGID_12_);}
-	.st18{fill:url(#SVGID_13_);}
-	.st19{fill:#4E4E4E;}
-	.st20{fill:url(#SVGID_14_);}
-</style>
-<g
-   id="g21"
-   transform="matrix(0.14063838,0,0,0.14063838,-7.4762709,-4.8126528)">
-	<linearGradient
-   id="SVGID_1_"
-   gradientUnits="userSpaceOnUse"
-   x1="261.27731"
-   y1="709.23438"
-   x2="770.24329"
-   y2="428.5831">
-		<stop
-   offset="0"
-   style="stop-color:#707070"
-   id="stop4" />
-		<stop
-   offset="0.1292"
-   style="stop-color:#8D8D8D"
-   id="stop6" />
-		<stop
-   offset="0.4081"
-   style="stop-color:#D8D8D8"
-   id="stop8" />
-		<stop
-   offset="0.5473"
-   style="stop-color:#FFFFFF"
-   id="stop10" />
-		<stop
-   offset="0.7223"
-   style="stop-color:#C3C3C3"
-   id="stop12" />
-		<stop
-   offset="0.9101"
-   style="stop-color:#878787"
-   id="stop14" />
-		<stop
-   offset="1"
-   style="stop-color:#707070"
-   id="stop16" />
-	</linearGradient>
-	<path
-   class="st0"
-   d="M 864.8,709 464.6,931.8 c -92.2,41.3 -116.7,-36.1 -132,-71 L 172.5,494.1 c -15.3,-34.9 0.8,-72.1 36.7,-90.8 L 566.3,246.1 c 44.4,-19.5 78.4,-4.7 110.1,45.3 l 206.3,315.4 c 21.8,29.7 19.6,80.7 -17.9,102.2 z"
-   id="path19"
-   inkscape:connector-curvature="0"
-   style="fill:url(#SVGID_1_)" />
-</g>
-<path
-   class="st1"
-   d="m 28.034918,63.650108 c -0.689123,-1.490766 -2.10957,-3.501895 -1.476698,-4.866089 0.506298,-1.11104 1.490765,-1.800169 2.686192,-2.348659 L 73.039208,36.084983 c 2.658064,-1.223549 6.075575,0.09845 7.650725,2.728386 l 26.665037,41.699277 c 0.74538,1.33607 0.70319,2.95341 0.3516,4.40199 -0.39379,1.57515 -2.01113,3.305 -3.24875,3.92381 2.3346,-1.1673 3.69879,-5.14737 2.15177,-7.88982 L 80.239892,39.629072 c -1.561089,-2.601811 -4.93641,-3.923807 -7.566346,-2.714318 L 29.441305,57.011977 c -2.629936,1.209488 -2.629936,3.966003 -1.406387,6.638131"
-   id="path23"
-   inkscape:connector-curvature="0"
-   style="fill:#cdcdcd;stroke-width:0.14063838" />
-<path
-   class="st2"
-   d="M 104.61252,88.824376 60.044218,112.62039 c -0.928211,0.49223 -1.912684,0.90008 -2.92528,1.15323 -4.092579,1.0126 -7.692921,-0.22502 -9.183686,-3.6566 L 26.895754,64.015769 c -1.223555,-2.658067 -0.08438,-5.794304 2.545551,-7.003792 L 72.673546,36.928815 c 2.629936,-1.209488 6.005257,0.112513 7.566346,2.714321 l 26.397818,41.30549 c 1.53296,2.72839 0.30941,6.70845 -2.02519,7.87575 z"
-   id="path25"
-   inkscape:connector-curvature="0"
-   style="fill:#1e1e1e;stroke-width:0.14063838" />
-<linearGradient
-   id="SVGID_2_"
-   gradientUnits="userSpaceOnUse"
-   x1="331.9451"
-   y1="668.69598"
-   x2="704.63232"
-   y2="464.67581"
-   gradientTransform="matrix(0.14063838,0,0,0.14063838,-7.4762709,-4.8126518)">
-	<stop
-   offset="0"
-   style="stop-color:#C8C6C8"
-   id="stop27" />
-	<stop
-   offset="0.1821"
-   style="stop-color:#DFDEDF"
-   id="stop29" />
-	<stop
-   offset="0.4139"
-   style="stop-color:#F6F6F6"
-   id="stop31" />
-	<stop
-   offset="0.5563"
-   style="stop-color:#FFFFFF"
-   id="stop33" />
-	<stop
-   offset="0.5584"
-   style="stop-color:#FFFFFF"
-   id="stop35" />
-	<stop
-   offset="0.8498"
-   style="stop-color:#D7D6D7"
-   id="stop37" />
-	<stop
-   offset="1"
-   style="stop-color:#C8C6C8"
-   id="stop39" />
-</linearGradient>
-<path
-   class="st3"
-   d="M 103.62805,89.386936 59.875448,112.69071 c -0.914144,0.49223 -1.870489,0.87196 -2.883085,1.12511 -4.008194,1.01259 -7.538218,-0.18284 -8.972732,-3.51597 L 27.627072,65.619046 c -1.181365,-2.573683 -0.05623,-5.639598 2.517423,-6.820963 L 73.475188,38.672729 c 2.573679,-1.18136 4.823891,0.253151 6.342791,2.784643 l 25.821201,40.264764 c 1.49077,2.64401 0.28128,6.51156 -2.01113,7.6648 z"
-   id="path42"
-   inkscape:connector-curvature="0"
-   style="fill:url(#SVGID_2_);stroke-width:0.14063838" />
-<path
-   class="st4"
-   d="M 48.033698,110.29985 28.752176,66.280044 c -1.167299,-2.545552 -0.02809,-5.569277 2.559617,-6.750642 L 73.461121,40.318201 c 2.573679,-1.181361 4.80983,0.22502 6.314663,2.700258 L 105.65325,81.694016 79.817979,41.443309 c -1.5189,-2.517429 -3.755045,-3.966001 -6.342791,-2.784641 L 30.144495,58.798083 c -2.573679,1.181365 -3.712856,4.24728 -2.517423,6.820963 l 20.406626,44.680804"
-   id="path44"
-   inkscape:connector-curvature="0"
-   style="fill:#767676;stroke-width:0.14063838" />
-<path
-   class="st1"
-   d="m 117.55126,91.355866 c -0.73132,1.42045 -1.85643,2.65807 -3.38939,3.54409 L 57.864323,126.23418 c -12.966859,5.80837 -16.412498,-5.07704 -18.56427,-9.98532 L 16.783851,64.676767 C 16.066594,63.0313 15.841573,61.343638 16.052532,59.740362 L 41.59246,119.41322 c 0,0 4.584816,11.92614 17.50948,4.71138 12.924666,-7.21474 58.44932,-32.768734 58.44932,-32.768734 z"
-   id="path46"
-   inkscape:connector-curvature="0"
-   style="fill:#cdcdcd;stroke-width:0.14063838" />
-<path
-   class="st5"
-   d="m 19.301279,53.735102 c 0.759447,-0.689129 1.645468,-1.307937 2.643997,-1.8283 L 72.167248,29.798448 c 6.244345,-2.742443 11.026047,-0.661 15.484282,6.37092 l 29.01371,44.357348 c 0.84383,1.15323 1.4345,2.53149 1.74391,3.99413 L 85.134107,33.975412 c 0,0 -4.992661,-6.792838 -11.504222,-4.050383 -6.525625,2.742443 -54.328606,23.810073 -54.328606,23.810073 z"
-   id="path48"
-   inkscape:connector-curvature="0"
-   style="fill:#4f4f4f;stroke-width:0.14063838" />
-<path
-   class="st5"
-   d="m 29.497561,57.011977 c -2.629941,1.209488 -4.697323,4.570748 -3.473773,7.228811 l 21.559868,47.184172 c 1.476705,3.44564 5.091108,4.68326 9.183687,3.6566 1.026657,-0.25315 1.997063,-0.64694 2.92528,-1.15324 L 104.62658,89.386936 c 2.33461,-1.1673 3.53003,-5.70992 1.98301,-8.45237 h 0.0141 c 1.54702,2.74245 0.32347,6.72251 -2.01113,7.88981 L 60.044236,112.62039 c -0.928211,0.49223 -1.912684,0.90008 -2.92528,1.15323 -4.092579,1.0126 -7.692921,-0.22502 -9.183686,-3.6566 L 26.895772,64.015769 c -1.223555,-2.658067 -0.08439,-5.794304 2.545551,-7.003792"
-   id="path50"
-   inkscape:connector-curvature="0"
-   style="fill:#4f4f4f;stroke-width:0.14063838" />
-<g
-   id="g137"
-   transform="matrix(0.14063838,0,0,0.14063838,-7.4762709,-4.8126528)">
-	<linearGradient
-   id="SVGID_3_"
-   gradientUnits="userSpaceOnUse"
-   x1="559.07819"
-   y1="492.8522"
-   x2="543.50531"
-   y2="695.30017">
-		<stop
-   offset="0.5259"
-   style="stop-color:#949494"
-   id="stop52" />
-		<stop
-   offset="0.6204"
-   style="stop-color:#8E8E8E"
-   id="stop54" />
-		<stop
-   offset="0.7419"
-   style="stop-color:#7E7E7E"
-   id="stop56" />
-		<stop
-   offset="0.8777"
-   style="stop-color:#646464"
-   id="stop58" />
-		<stop
-   offset="1"
-   style="stop-color:#464646"
-   id="stop60" />
-	</linearGradient>
-	<polygon
-   class="st6"
-   points="657.4,584.3 615.1,602 549,501.9 549,499 449.8,544.8 504.4,645.5 505.1,655.7 470.7,672.5 620.7,715 "
-   id="polygon63"
-   style="fill:url(#SVGID_3_)" />
-	<linearGradient
-   id="SVGID_4_"
-   gradientUnits="userSpaceOnUse"
-   x1="660.5"
-   y1="587.625"
-   x2="615.33331"
-   y2="587.625">
-		<stop
-   offset="0"
-   style="stop-color:#343636"
-   id="stop65" />
-		<stop
-   offset="0.2598"
-   style="stop-color:#373939"
-   id="stop67" />
-		<stop
-   offset="0.439"
-   style="stop-color:#404242"
-   id="stop69" />
-		<stop
-   offset="0.5942"
-   style="stop-color:#4F5151"
-   id="stop71" />
-		<stop
-   offset="0.7355"
-   style="stop-color:#656666"
-   id="stop73" />
-		<stop
-   offset="0.8674"
-   style="stop-color:#818282"
-   id="stop75" />
-		<stop
-   offset="0.9908"
-   style="stop-color:#A3A3A3"
-   id="stop77" />
-		<stop
-   offset="1"
-   style="stop-color:#A6A6A6"
-   id="stop79" />
-	</linearGradient>
-	<polygon
-   class="st7"
-   points="657.4,584.3 615.3,602 615.8,591.3 660.5,573.3 "
-   id="polygon82"
-   style="fill:url(#SVGID_4_)" />
-	<linearGradient
-   id="SVGID_5_"
-   gradientUnits="userSpaceOnUse"
-   x1="549"
-   y1="548.91632"
-   x2="615.75"
-   y2="548.91632">
-		<stop
-   offset="0"
-   style="stop-color:#343636"
-   id="stop84" />
-		<stop
-   offset="0.2598"
-   style="stop-color:#373939"
-   id="stop86" />
-		<stop
-   offset="0.439"
-   style="stop-color:#404242"
-   id="stop88" />
-		<stop
-   offset="0.5942"
-   style="stop-color:#4F5151"
-   id="stop90" />
-		<stop
-   offset="0.7355"
-   style="stop-color:#656666"
-   id="stop92" />
-		<stop
-   offset="0.8674"
-   style="stop-color:#818282"
-   id="stop94" />
-		<stop
-   offset="0.9908"
-   style="stop-color:#A3A3A3"
-   id="stop96" />
-		<stop
-   offset="1"
-   style="stop-color:#A6A6A6"
-   id="stop98" />
-	</linearGradient>
-	<polygon
-   class="st8"
-   points="549,501.9 549,499.1 556.4,495.8 615.8,591.3 615.3,602 "
-   id="polygon101"
-   style="fill:url(#SVGID_5_)" />
-	<linearGradient
-   id="SVGID_6_"
-   gradientUnits="userSpaceOnUse"
-   x1="458.5"
-   y1="658.98932"
-   x2="505.16669"
-   y2="658.98932">
-		<stop
-   offset="0"
-   style="stop-color:#343636"
-   id="stop103" />
-		<stop
-   offset="0.2598"
-   style="stop-color:#373939"
-   id="stop105" />
-		<stop
-   offset="0.439"
-   style="stop-color:#404242"
-   id="stop107" />
-		<stop
-   offset="0.5942"
-   style="stop-color:#4F5151"
-   id="stop109" />
-		<stop
-   offset="0.7355"
-   style="stop-color:#656666"
-   id="stop111" />
-		<stop
-   offset="0.8674"
-   style="stop-color:#818282"
-   id="stop113" />
-		<stop
-   offset="0.9908"
-   style="stop-color:#A3A3A3"
-   id="stop115" />
-		<stop
-   offset="1"
-   style="stop-color:#A6A6A6"
-   id="stop117" />
-	</linearGradient>
-	<polygon
-   class="st9"
-   points="470.8,672.5 505.2,655.7 504.5,645.5 458.5,669 "
-   id="polygon120"
-   style="fill:url(#SVGID_6_)" />
-	<polygon
-   points="378.5,532.7 421,426.3 571.3,452 539.2,470 450,544.8 430.3,509.2 "
-   id="polygon122" />
-	<linearGradient
-   id="SVGID_7_"
-   gradientUnits="userSpaceOnUse"
-   x1="657.38159"
-   y1="627.63898"
-   x2="554.80042"
-   y2="627.63898">
-		<stop
-   offset="0"
-   style="stop-color:#000000"
-   id="stop124" />
-		<stop
-   offset="0.294"
-   style="stop-color:#282828;stop-opacity:0.9265"
-   id="stop126" />
-		<stop
-   offset="0.5879"
-   style="stop-color:#484848;stop-opacity:0.853"
-   id="stop128" />
-		<stop
-   offset="0.8333"
-   style="stop-color:#5C5C5C;stop-opacity:0.7917"
-   id="stop130" />
-		<stop
-   offset="1"
-   style="stop-color:#636363;stop-opacity:0.75"
-   id="stop132" />
-	</linearGradient>
-	<path
-   class="st10"
-   d="m 554.8,550.3 c 0,0 41.9,84.8 18.6,151.2 l 47.3,13.4 36.7,-130.7 -42,17.7 -40.6,-61.7 z"
-   id="path135"
-   inkscape:connector-curvature="0"
-   style="fill:url(#SVGID_7_)" />
-</g>
-<polygon
-   class="st11"
-   points="403.7,469.7 355,411.5 355,396 353.2,392.7 325.6,352 385.8,325.5 417.8,434.3 "
-   id="polygon139"
-   style="opacity:0.5"
-   transform="matrix(0.14063838,0,0,0.14063838,-7.4762709,-4.8126528)" />
-<g
-   id="g233"
-   transform="matrix(0.14063838,0,0,0.14063838,-7.4762709,-4.8126528)">
-	<linearGradient
-   id="SVGID_8_"
-   gradientUnits="userSpaceOnUse"
-   x1="528.0459"
-   y1="61.673801"
-   x2="606.0459"
-   y2="213.6738"
-   xlink:href="#SVGID_13_">
-		<stop
-   offset="0"
-   style="stop-color:#BC1E1B"
-   id="stop141" />
-		<stop
-   offset="0.5531"
-   style="stop-color:#A61B19"
-   id="stop143" />
-		<stop
-   offset="0.6315"
-   style="stop-color:#991917"
-   id="stop145" />
-		<stop
-   offset="0.871"
-   style="stop-color:#761311"
-   id="stop147" />
-		<stop
-   offset="1"
-   style="stop-color:#69110F"
-   id="stop149" />
-	</linearGradient>
-	<path
-   class="st12"
-   d="m 517.7,252 c 132.7,-63.7 141.6,-93.7 141.6,-93.7 8,-86 -39,-97 -39,-97 -127.7,4.3 -165.1,27.6 -165.1,27.6 0,0 44.2,61.8 62.5,163.1 z"
-   id="path152"
-   inkscape:connector-curvature="0"
-   style="fill:url(#linearGradient1121);fill-opacity:1" />
-	<path
-   class="st13"
-   d="m 474.8,590.7 -24.8,-45.9 -4.7,-8.6 c 0,0 -29.6,-128.3 -71,-225.5 0,0 -58.6,-134.1 -52.3,-180.8 0.9,-4.8 5,-6.7 13.7,-10 8.8,-3.3 106.9,-35.3 110.9,-34.8 4,0.5 11.1,3.8 18,13.9 6.9,10.1 39.4,49 52.4,147.8 13,98.8 27.5,214.1 57.8,293.5 z"
-   id="path154"
-   inkscape:connector-curvature="0"
-   style="fill:#ffffff" />
-	<linearGradient
-   id="SVGID_9_"
-   gradientUnits="userSpaceOnUse"
-   x1="331.0936"
-   y1="119.7077"
-   x2="480.0936"
-   y2="591.70782">
-		<stop
-   offset="0.5341"
-   style="stop-color:#AEAEAE"
-   id="stop156" />
-		<stop
-   offset="0.595"
-   style="stop-color:#A5A5A5"
-   id="stop158" />
-		<stop
-   offset="0.6924"
-   style="stop-color:#8E8E8E"
-   id="stop160" />
-		<stop
-   offset="0.8142"
-   style="stop-color:#686868"
-   id="stop162" />
-		<stop
-   offset="0.9543"
-   style="stop-color:#343434"
-   id="stop164" />
-		<stop
-   offset="1"
-   style="stop-color:#212121"
-   id="stop166" />
-	</linearGradient>
-	<path
-   class="st14"
-   d="m 474.8,590.7 -24.8,-45.9 -4.7,-8.6 c 0,0 -29.6,-128.3 -71,-225.5 0,0 -58.6,-134.1 -52.3,-180.8 0.4,-2.3 1.6,-4 3.7,-5.4 0,0 34.5,12.4 65.5,112.4 31,100 80.5,321 83.6,353.8 z"
-   id="path169"
-   inkscape:connector-curvature="0"
-   style="fill:url(#SVGID_9_)" />
-	<linearGradient
-   id="SVGID_10_"
-   gradientUnits="userSpaceOnUse"
-   x1="330.7229"
-   y1="134.0479"
-   x2="430.7229"
-   y2="420.04791">
-		<stop
-   offset="0.5341"
-   style="stop-color:#343636"
-   id="stop171" />
-		<stop
-   offset="0.658"
-   style="stop-color:#424343"
-   id="stop173" />
-		<stop
-   offset="0.8144"
-   style="stop-color:#4D4D4D"
-   id="stop175" />
-		<stop
-   offset="1"
-   style="stop-color:#505050"
-   id="stop177" />
-	</linearGradient>
-	<path
-   class="st15"
-   d="m 411.2,412.8 c -10.5,-33.5 -23.1,-69.5 -36.9,-102.1 0,0 -53.6,-122.8 -52.7,-174.2 0,0 51.5,20.2 73.8,132.5 0,0 17.4,70.8 17.9,113 0,17.5 -2.1,30.8 -2.1,30.8 z"
-   id="path180"
-   inkscape:connector-curvature="0"
-   style="fill:url(#SVGID_10_)" />
-	<linearGradient
-   id="SVGID_11_"
-   gradientUnits="userSpaceOnUse"
-   x1="398.93341"
-   y1="97.163399"
-   x2="442.43341"
-   y2="232.66341">
-		<stop
-   offset="0"
-   style="stop-color:#6A6A6A"
-   id="stop182" />
-		<stop
-   offset="0.1257"
-   style="stop-color:#8E8E8E"
-   id="stop184" />
-		<stop
-   offset="0.4224"
-   style="stop-color:#DDDDDD"
-   id="stop186" />
-		<stop
-   offset="0.5586"
-   style="stop-color:#FDFDFD"
-   id="stop188" />
-		<stop
-   offset="1"
-   style="stop-color:#FEFEFE"
-   id="stop190" />
-	</linearGradient>
-	<path
-   class="st16"
-   d="M 509.5,204.2 C 494.3,136.4 470.4,107.5 464.6,99 c -6.9,-10.1 -14,-13.4 -18,-13.9 -4,-0.5 -102.1,31.5 -110.9,34.9 -2.6,1 -4.7,1.8 -6.5,2.7 0,0 32.5,9.4 69.3,126.4 z"
-   id="path193"
-   inkscape:connector-curvature="0"
-   style="fill:url(#SVGID_11_)" />
-	<linearGradient
-   id="SVGID_12_"
-   gradientUnits="userSpaceOnUse"
-   x1="409.84439"
-   y1="242.9539"
-   x2="573.40057"
-   y2="549.83893">
-		<stop
-   offset="0"
-   style="stop-color:#949494"
-   id="stop195" />
-		<stop
-   offset="5.532010e-02"
-   style="stop-color:#7C7C7C"
-   id="stop197" />
-		<stop
-   offset="0.1269"
-   style="stop-color:#646464"
-   id="stop199" />
-		<stop
-   offset="0.2027"
-   style="stop-color:#525252"
-   id="stop201" />
-		<stop
-   offset="0.2846"
-   style="stop-color:#484848"
-   id="stop203" />
-		<stop
-   offset="0.3838"
-   style="stop-color:#454545"
-   id="stop205" />
-		<stop
-   offset="0.5019"
-   style="stop-color:#6A6A6A"
-   id="stop207" />
-		<stop
-   offset="0.6903"
-   style="stop-color:#ADADAD"
-   id="stop209" />
-		<stop
-   offset="0.7655"
-   style="stop-color:#A4A4A4"
-   id="stop211" />
-		<stop
-   offset="0.8873"
-   style="stop-color:#8C8C8C"
-   id="stop213" />
-		<stop
-   offset="1"
-   style="stop-color:#707070"
-   id="stop215" />
-	</linearGradient>
-	<path
-   class="st17"
-   d="m 474.8,590.7 99.9,-50.4 C 544.5,460.9 530,345.5 517,246.8 514.9,231.1 512.4,217 509.5,204.2 l -111,44.8 c 0,0 55.7,168.4 76.3,341.7 z"
-   id="path218"
-   inkscape:connector-curvature="0"
-   style="fill:url(#SVGID_12_)" />
-	<linearGradient
-   id="SVGID_13_"
-   gradientUnits="userSpaceOnUse"
-   x1="237.54449"
-   y1="170.39661"
-   x2="313.54449"
-   y2="343.39661">
-		<stop
-   offset="0"
-   style="stop-color:#1b82bc;stop-opacity:1"
-   id="stop220" /><stop
-   id="stop1111"
-   style="stop-color:#5397db;stop-opacity:1;"
-   offset="0.28118265" /><stop
-   offset="0.36546224"
-   style="stop-color:#619ce3;stop-opacity:1;"
-   id="stop1113" /><stop
-   id="stop1105"
-   style="stop-color:#6ea1eb;stop-opacity:1"
-   offset="0.52290887" /><stop
-   offset="0.64972925"
-   style="stop-color:#5d8bde;stop-opacity:1;"
-   id="stop1109" /><stop
-   offset="0.80217332"
-   style="stop-color:#2b4bb9;stop-opacity:1;"
-   id="stop1107" />
-		
-		
-		
-		<stop
-   offset="1"
-   style="stop-color:#1933ac;stop-opacity:1"
-   id="stop228" />
-	</linearGradient>
-	<path
-   class="st18"
-   d="m 393.7,301.7 c 0,0 -62.3,38.3 -183,50.3 0,0 -42.4,-63.1 -51.4,-103.8 0,0 73.1,-72.4 165,-107.3 0,0.1 49.7,31.1 69.4,160.8 z"
-   id="path231"
-   inkscape:connector-curvature="0"
-   style="fill:url(#linearGradient1103);fill-opacity:1" />
-</g>
-<g
-   id="g270"
-   transform="matrix(0.14063838,0,0,0.14063838,-7.4762709,-4.8126528)">
-	<path
-   class="st19"
-   d="m 120.2,293.5 c 3.7,16.7 26.5,56.1 30.5,57.8 4,1.7 52,-11.8 52,-11.8 -11.9,-19.1 -33.8,-56.4 -41.9,-85.3 -0.1,0 -43.6,30 -40.6,39.3 z"
-   id="path235"
-   inkscape:connector-curvature="0"
-   style="fill:#4e4e4e" />
-	<linearGradient
-   id="SVGID_14_"
-   gradientUnits="userSpaceOnUse"
-   x1="137.2758"
-   y1="273.2998"
-   x2="179.89"
-   y2="347.10989">
-		<stop
-   offset="7.356948e-02"
-   style="stop-color:#A3A3A3"
-   id="stop237" />
-		<stop
-   offset="9.450606e-02"
-   style="stop-color:#ACACAC"
-   id="stop239" />
-		<stop
-   offset="0.1731"
-   style="stop-color:#CACACA"
-   id="stop241" />
-		<stop
-   offset="0.2565"
-   style="stop-color:#E1E1E1"
-   id="stop243" />
-		<stop
-   offset="0.3459"
-   style="stop-color:#F1F1F1"
-   id="stop245" />
-		<stop
-   offset="0.4453"
-   style="stop-color:#FBFBFB"
-   id="stop247" />
-		<stop
-   offset="0.5749"
-   style="stop-color:#FEFEFE"
-   id="stop249" />
-		<stop
-   offset="0.5995"
-   style="stop-color:#E3E3E3"
-   id="stop251" />
-		<stop
-   offset="0.6414"
-   style="stop-color:#BBBBBB"
-   id="stop253" />
-		<stop
-   offset="0.6862"
-   style="stop-color:#999999"
-   id="stop255" />
-		<stop
-   offset="0.7334"
-   style="stop-color:#7D7D7D"
-   id="stop257" />
-		<stop
-   offset="0.7842"
-   style="stop-color:#676767"
-   id="stop259" />
-		<stop
-   offset="0.84"
-   style="stop-color:#585858"
-   id="stop261" />
-		<stop
-   offset="0.9049"
-   style="stop-color:#4F4F4F"
-   id="stop263" />
-		<stop
-   offset="1"
-   style="stop-color:#4C4C4C"
-   id="stop265" />
-	</linearGradient>
-	<path
-   class="st20"
-   d="m 124.5,293.5 c 3.5,16.7 24.1,52.2 27.9,53.9 3.1,1.4 31.9,-6 42.4,-8.9 1.6,-0.5 2.2,-2.4 1.2,-3.7 -14.4,-17.7 -29.1,-44.9 -35.2,-71.8 -0.3,-1.5 -2,-2.1 -3.3,-1.3 -8.6,5.6 -35.4,24 -33,31.8 z"
-   id="path268"
-   inkscape:connector-curvature="0"
-   style="fill:url(#SVGID_14_)" />
-</g>
+     spreadMethod="pad"
+     x1="-47.703"
+     x2="-44.01"
+     y1="68.741"
+     y2="32.945">
+    <stop
+       offset="0"
+       stop-color="#0d2944"
+       id="stop2" />
+    <stop
+       offset=".311"
+       stop-color="#0c4c8c"
+       id="stop4" />
+    <stop
+       offset="1"
+       stop-color="#176fc6"
+       stop-opacity="0"
+       id="stop6" />
+  </linearGradient>
+  <linearGradient
+     id="i"
+     gradientUnits="userSpaceOnUse"
+     spreadMethod="pad"
+     x1="-49.511"
+     x2="-43.106"
+     y1="23.182"
+     y2="47.77">
+    <stop
+       offset="0"
+       stop-color="#1764b2"
+       stop-opacity=".996"
+       id="stop9" />
+    <stop
+       offset=".087"
+       stop-color="#1d78d3"
+       id="stop11" />
+    <stop
+       offset="1"
+       stop-color="#176fc6"
+       id="stop13" />
+  </linearGradient>
+  <linearGradient
+     id="h"
+     gradientUnits="userSpaceOnUse"
+     x1="98.436"
+     x2="67.627"
+     xlink:href="#a"
+     y1="50.305"
+     y2="50.305" />
+  <linearGradient
+     id="g"
+     gradientUnits="userSpaceOnUse"
+     x1="66.082"
+     x2="66.082"
+     y1="59.254"
+     y2="37.905">
+    <stop
+       offset="0"
+       stop-color="#464747"
+       id="stop17" />
+    <stop
+       offset="1"
+       stop-color="#7f8082"
+       id="stop19" />
+  </linearGradient>
+  <linearGradient
+     id="f"
+     gradientUnits="userSpaceOnUse"
+     x1="69.045"
+     x2="69.045"
+     y1="35.604"
+     y2="63.345">
+    <stop
+       offset="0"
+       stop-color="#eee"
+       id="stop22" />
+    <stop
+       offset=".468"
+       stop-color="#cacaca"
+       id="stop24" />
+    <stop
+       offset=".505"
+       stop-color="#b3b3b3"
+       id="stop26" />
+    <stop
+       offset=".578"
+       stop-color="#b0b0b0"
+       id="stop28" />
+    <stop
+       offset="1"
+       stop-color="#454646"
+       id="stop30" />
+  </linearGradient>
+  <linearGradient
+     id="o"
+     gradientUnits="userSpaceOnUse"
+     x1="16.819"
+     x2="16.819"
+     y1="1.004"
+     y2="17.97">
+    <stop
+       offset="0"
+       stop-color="#c3c3c3"
+       stop-opacity=".996"
+       id="stop33" />
+    <stop
+       offset=".042"
+       stop-color="#c4c4c4"
+       id="stop35" />
+    <stop
+       offset=".085"
+       stop-color="#999"
+       id="stop37" />
+    <stop
+       offset=".139"
+       stop-color="#9f9f9f"
+       id="stop39" />
+    <stop
+       offset=".201"
+       stop-color="#dedede"
+       id="stop41" />
+    <stop
+       offset=".23"
+       stop-color="#e9e9e9"
+       id="stop43" />
+    <stop
+       offset=".275"
+       stop-color="#bebdbd"
+       id="stop45" />
+    <stop
+       offset=".309"
+       stop-color="#888686"
+       id="stop47" />
+    <stop
+       offset=".456"
+       stop-color="#545353"
+       id="stop49" />
+    <stop
+       offset=".535"
+       stop-color="#4e4e4e"
+       id="stop51" />
+    <stop
+       offset=".857"
+       stop-color="#a1a1a1"
+       id="stop53" />
+    <stop
+       offset="1"
+       stop-color="#737373"
+       id="stop55" />
+  </linearGradient>
+  <linearGradient
+     id="a">
+    <stop
+       offset="0"
+       id="stop58" />
+    <stop
+       offset="1"
+       stop-opacity="0"
+       id="stop60" />
+  </linearGradient>
+  <linearGradient
+     id="n"
+     gradientUnits="userSpaceOnUse"
+     x1="17.192"
+     x2="17.192"
+     y1="16.337"
+     y2="20.445">
+    <stop
+       offset="0"
+       stop-color="#0d0d0d"
+       id="stop63" />
+    <stop
+       offset="1"
+       stop-color="#2c2c2c"
+       stop-opacity="0"
+       id="stop65" />
+  </linearGradient>
+  <linearGradient
+     id="m"
+     gradientUnits="userSpaceOnUse"
+     x1="-.155"
+     x2="-26.654"
+     y1="45.781"
+     y2="42.527">
+    <stop
+       offset="0"
+       stop-color="#0d2944"
+       id="stop68" />
+    <stop
+       offset="1"
+       stop-color="#0d2944"
+       stop-opacity="0"
+       id="stop70" />
+  </linearGradient>
+  <linearGradient
+     id="k"
+     gradientUnits="userSpaceOnUse"
+     x1="-94.708"
+     x2="-75.286"
+     y1="46.143"
+     y2="46.143">
+    <stop
+       offset="0"
+       stop-color="#0d2944"
+       id="stop73" />
+    <stop
+       offset="1"
+       stop-color="#0d2944"
+       stop-opacity="0"
+       id="stop75" />
+  </linearGradient>
+  <linearGradient
+     id="c"
+     gradientUnits="userSpaceOnUse"
+     x1="17.751"
+     x2="17.751"
+     y1="4.29"
+     y2="28.983">
+    <stop
+       offset="0"
+       stop-color="#bbbfc3"
+       id="stop78" />
+    <stop
+       offset="1"
+       stop-color="#f1f3f6"
+       stop-opacity=".941"
+       id="stop80" />
+  </linearGradient>
+  <linearGradient
+     id="b"
+     gradientUnits="userSpaceOnUse"
+     x1="16.938"
+     x2="16.938"
+     y1="5.627"
+     y2="30.152">
+    <stop
+       offset="0"
+       stop-color="#a2acb0"
+       id="stop83" />
+    <stop
+       offset="1"
+       stop-color="#9cabb7"
+       id="stop85" />
+  </linearGradient>
+  <radialGradient
+     id="l"
+     cx="3.512"
+     cy="47.23"
+     gradientTransform="matrix(2.54236 0 0 1.47905 -60.842 -28.344)"
+     gradientUnits="userSpaceOnUse"
+     r="12.017"
+     spreadMethod="pad">
+    <stop
+       offset="0"
+       stop-color="#1766b5"
+       stop-opacity=".118"
+       id="stop88" />
+    <stop
+       offset=".82"
+       stop-color="#1764b2"
+       stop-opacity="0"
+       id="stop90" />
+    <stop
+       offset="1"
+       stop-color="#0f4a84"
+       id="stop92" />
+  </radialGradient>
+  <radialGradient
+     id="d"
+     cx="16.994"
+     cy="4.308"
+     gradientTransform="matrix(3.77953 0 0 9.2084 0 -23.39)"
+     gradientUnits="userSpaceOnUse"
+     r="6.579"
+     xlink:href="#a" />
+  <radialGradient
+     id="e"
+     cx="16.993"
+     cy="1.557"
+     gradientTransform="matrix(2.81492 0 0 1.19422 14.815 14.385)"
+     gradientUnits="userSpaceOnUse"
+     r="19.382">
+    <stop
+       offset="0"
+       stop-color="#2a76c1"
+       id="stop96" />
+    <stop
+       offset="1"
+       stop-color="#2a76c1"
+       stop-opacity="0"
+       id="stop98" />
+  </radialGradient>
+  <g
+     id="g1702"
+     transform="matrix(0.97574166,0,0,0.97574166,-65.75568,-37.332433)"
+     style="opacity:0.29676508">
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+       id="rect1634"
+       width="29.810888"
+       height="29.810888"
+       x="69.839508"
+       y="40.709618"
+       rx="6.6098609"
+       ry="6.6098609" />
+    <rect
+       ry="6.6098609"
+       rx="6.6098609"
+       y="40.709618"
+       x="69.839508"
+       height="29.810888"
+       width="29.810888"
+       id="rect1638"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.30000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+       id="rect1640"
+       width="29.810888"
+       height="29.810888"
+       x="69.839508"
+       y="40.709618"
+       rx="6.6098609"
+       ry="6.6098609" />
+    <rect
+       ry="6.6098609"
+       rx="6.6098609"
+       y="40.709618"
+       x="69.839508"
+       height="29.810888"
+       width="29.810888"
+       id="rect1642"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.40000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+       id="rect1644"
+       width="29.810888"
+       height="29.810888"
+       x="69.839508"
+       y="40.709618"
+       rx="6.6098609"
+       ry="6.6098609" />
+    <rect
+       ry="6.6098609"
+       rx="6.6098609"
+       y="40.709618"
+       x="69.839508"
+       height="29.810888"
+       width="29.810888"
+       id="rect1646"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.69999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+       id="rect1648"
+       width="29.810888"
+       height="29.810888"
+       x="69.839508"
+       y="40.709618"
+       rx="6.6098609"
+       ry="6.6098609" />
+    <rect
+       ry="6.6098609"
+       rx="6.6098609"
+       y="40.709618"
+       x="69.839508"
+       height="29.810888"
+       width="29.810888"
+       id="rect1650"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.80000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+       id="rect1652"
+       width="29.810888"
+       height="29.810888"
+       x="69.839508"
+       y="40.709618"
+       rx="6.6098609"
+       ry="6.6098609" />
+    <rect
+       ry="6.6098609"
+       rx="6.6098609"
+       y="40.709618"
+       x="69.839508"
+       height="29.810888"
+       width="29.810888"
+       id="rect1654"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.20000005;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.39999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+       id="rect1656"
+       width="29.810888"
+       height="29.810888"
+       x="69.839508"
+       y="40.709618"
+       rx="6.6098609"
+       ry="6.6098609" />
+    <rect
+       ry="6.6098609"
+       rx="6.6098609"
+       y="40.709618"
+       x="69.839508"
+       height="29.810888"
+       width="29.810888"
+       id="rect1658"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.79999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+       id="rect1660"
+       width="29.810888"
+       height="29.810888"
+       x="69.839508"
+       y="40.709618"
+       rx="6.6098609"
+       ry="6.6098609" />
+    <rect
+       ry="6.6098609"
+       rx="6.6098609"
+       y="40.709618"
+       x="69.839508"
+       height="29.810888"
+       width="29.810888"
+       id="rect1662"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.20000005;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+       id="rect1664"
+       width="29.810888"
+       height="29.810888"
+       x="69.839508"
+       y="40.709618"
+       rx="6.6098609"
+       ry="6.6098609" />
+    <rect
+       ry="6.6098609"
+       rx="6.6098609"
+       y="40.709618"
+       x="69.839508"
+       height="29.810888"
+       width="29.810888"
+       id="rect1666"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.5999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+       id="rect1668"
+       width="29.810888"
+       height="29.810888"
+       x="69.839508"
+       y="40.709618"
+       rx="6.6098609"
+       ry="6.6098609" />
+    <rect
+       ry="6.6098609"
+       rx="6.6098609"
+       y="40.709618"
+       x="69.839508"
+       height="29.810888"
+       width="29.810888"
+       id="rect1670"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3.4000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3.79999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+       id="rect1672"
+       width="29.810888"
+       height="29.810888"
+       x="69.839508"
+       y="40.709618"
+       rx="6.6098609"
+       ry="6.6098609" />
+    <rect
+       ry="6.6098609"
+       rx="6.6098609"
+       y="40.709618"
+       x="69.839508"
+       height="29.810888"
+       width="29.810888"
+       id="rect1674"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:4.19999981;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:4.5999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
+       id="rect1676"
+       width="29.810888"
+       height="29.810888"
+       x="69.839508"
+       y="40.709618"
+       rx="6.6098609"
+       ry="6.6098609" />
+    <rect
+       ry="6.6098609"
+       rx="6.6098609"
+       y="40.709618"
+       x="69.839508"
+       height="29.810888"
+       width="29.810888"
+       id="rect1678"
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
+  </g>
+  <rect
+     fill="url(#b)"
+     height="29.087"
+     rx="6.449"
+     width="29.087"
+     x="2.396"
+     y="2.519"
+     id="rect101" />
+  <rect
+     fill="url(#c)"
+     height="26.285"
+     rx="5.567"
+     width="26.314"
+     x="3.783"
+     y="3.92"
+     id="rect103" />
+  <path
+     d="M16.95 7.127a.639.639 0 00-.443.185l-4.51 4.318c-.497.477-.35.922 0 .932h1.777v9.855h-1.776c-.35.01-.498.456 0 .932l4.509 4.319a.639.639 0 00.443.185.639.639 0 00.443-.185l4.509-4.319c.497-.476.35-.921 0-.932h-1.776v-9.855h1.776c.35-.01.497-.455 0-.932l-4.509-4.318a.639.639 0 00-.443-.185z"
+     fill="#fff"
+     id="path105" />
+  <path
+     d="M16.95 7.127a.639.639 0 00-.443.185l-4.51 4.318c-.497.477-.35.922 0 .932h1.777v9.855h-1.776c-.35.01-.498.456 0 .932l4.509 4.319a.639.639 0 00.443.185.639.639 0 00.443-.185l4.509-4.319c.497-.476.35-.921 0-.932h-1.776v-9.855h1.776c.35-.01.497-.455 0-.932l-4.509-4.318a.639.639 0 00-.443-.185z"
+     fill="#484848"
+     id="path107" />
+  <path
+     d="M39.531 9.52a24.867 60.586 0 00-.168 6.763A24.867 60.586 0 0064.23 76.87a24.867 60.586 0 0024.867-60.586 24.867 60.586 0 00-.184-6.763h-49.38z"
+     fill="url(#d)"
+     opacity=".735"
+     transform="scale(.26458)"
+     id="path109" />
+  <path
+     d="M16.95 7.127a.639.639 0 00-.443.185l-4.51 4.318c-.497.477-.35.922 0 .932h1.777v9.855h-1.776c-.351.01-.498.456 0 .932l4.509 4.319a.639.639 0 00.443.185.639.639 0 00.443-.185l4.509-4.319c.497-.476.35-.921 0-.932h-1.776v-9.855h1.776c.35-.01.497-.455 0-.932l-4.51-4.318a.639.639 0 00-.442-.185zm0 .863l3.942 3.776h-.766a.796.796 0 00-.796.796v9.855a.796.796 0 00.796.796h.766L16.95 26.99l-3.943-3.777h.767a.796.796 0 00.796-.796v-9.855a.796.796 0 00-.796-.796h-.767z"
+     fill-opacity=".128"
+     id="path111" />
+  <path
+     d="M33.434 9.52A24.323 24.323 0 009.057 33.895v5.585a92.84 23.46 0 0053.972 4.397 92.84 23.46 0 0055.965-4.768v-5.214A24.323 24.323 0 0094.617 9.52z"
+     fill="url(#e)"
+     opacity=".747"
+     transform="scale(.26458)"
+     id="path113" />
+  <g
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g119">
+    <path
+       d="M58.934 41.056l15.98-7.042c.98-.432 1.917.906 1.917 2.032v25.459c0 1.125-.926 2.434-1.918 2.031l-15.98-6.5c-.991-.404-1.917-.906-1.917-2.031V43.087c0-1.125.937-1.599 1.918-2.03z"
+       fill="url(#f)"
+       stroke="url(#g)"
+       transform="translate(-1.264 -.89) scale(.10616)"
+       id="path115" />
+    <path
+       d="M58.934 41.056l15.98-7.042c.98-.432 1.917.906 1.917 2.032v25.459c0 1.125-.926 2.434-1.918 2.031l-15.98-6.5c-.991-.404-1.917-.906-1.917-2.031V43.087c0-1.125.937-1.599 1.918-2.03z"
+       fill="url(#h)"
+       opacity=".654"
+       transform="translate(-1.264 -.89) scale(.10616)"
+       id="path117" />
+  </g>
+  <path
+     d="M13.218 7.204c-2.095-.09-4.208-.487-6.287-1.135-.275-.09-.523-.217-.573-.561a15.274 15.274 0 01-.014-2.649c.034-.264.317-.366.558-.442 2.123-.652 4.323-1.113 6.75-1.157z"
+     fill="#186ac7"
+     id="path121" />
+  <path
+     d="M-16.643 74.14c-19.733-.845-39.643-4.587-59.227-10.692-2.582-.858-4.924-2.05-5.395-5.288-.776-7.678-.797-17.273-.128-24.95.32-2.487 2.984-3.45 5.252-4.166 20-6.145 40.723-10.485 63.589-10.898z"
+     fill="url(#i)"
+     transform="translate(14.985 -.666) scale(.10616)"
+     id="path123" />
+  <path
+     d="M-16.643 74.14c-19.733-.845-39.643-4.587-59.227-10.692-2.582-.858-4.924-2.05-5.395-5.288-.776-7.678-.797-17.273-.128-24.95.32-2.487 2.984-3.45 5.252-4.166 20-6.145 40.723-10.485 63.589-10.898z"
+     fill="url(#j)"
+     transform="translate(14.985 -.666) scale(.10616)"
+     id="path125" />
+  <path
+     d="M-16.643 74.14c-19.733-.845-39.643-4.587-59.227-10.692-2.582-.858-4.924-2.05-5.395-5.288-.776-7.678-.797-17.273-.128-24.95.32-2.487 2.984-3.45 5.252-4.166 20-6.145 40.723-10.485 63.589-10.898z"
+     fill="url(#k)"
+     transform="translate(14.985 -.666) scale(.10616)"
+     id="path127" />
+  <path
+     d="M-67.578 26.548a310.687 310.687 0 00-8.563 2.496c-2.268.716-4.932 1.68-5.252 4.166-.336 3.863-.497 8.21-.476 12.555a12.017 12.017 0 006.433 1.883 12.017 12.017 0 0012.018-12.016 12.017 12.017 0 00-4.16-9.084z"
+     fill="url(#l)"
+     opacity=".392"
+     transform="translate(14.985 -.666) scale(.10616)"
+     id="path129" />
+  <path
+     d="M-16.643 74.14c-19.733-.845-39.643-4.587-59.227-10.692-2.582-.858-4.924-2.05-5.395-5.288-.776-7.678-.797-17.273-.128-24.95.32-2.487 2.984-3.45 5.252-4.166 20-6.145 40.723-10.485 63.589-10.898z"
+     fill="url(#m)"
+     opacity=".315"
+     transform="translate(14.985 -.666) scale(.10616)"
+     id="path131" />
+  <g
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g137">
+    <path
+       d="M58.934 41.056l15.98-7.042c.98-.432 1.917.906 1.917 2.032v25.459c0 1.125-.926 2.434-1.918 2.031l-15.98-6.5c-.991-.404-1.917-.906-1.917-2.031V43.087c0-1.125.937-1.599 1.918-2.03z"
+       fill="url(#f)"
+       stroke="url(#g)"
+       transform="matrix(-.10616 0 0 .10616 35.042 -.89)"
+       id="path133" />
+    <path
+       d="M58.934 41.056l15.98-7.042c.98-.432 1.917.906 1.917 2.032v25.459c0 1.125-.926 2.434-1.918 2.031l-15.98-6.5c-.991-.404-1.917-.906-1.917-2.031V43.087c0-1.125.937-1.599 1.918-2.03z"
+       fill="url(#h)"
+       opacity=".654"
+       transform="matrix(-.10616 0 0 .10616 35.042 -.89)"
+       id="path135" />
+  </g>
+  <path
+     d="M20.56 7.204c2.095-.09 4.208-.487 6.287-1.135.275-.09.523-.217.573-.561.083-.815.085-1.834.014-2.649-.034-.264-.317-.366-.558-.442-2.123-.652-4.323-1.113-6.75-1.157z"
+     fill="#186ac7"
+     id="path139" />
+  <path
+     d="M-16.643 74.14c-19.733-.845-39.643-4.587-59.227-10.692-2.582-.858-4.924-2.05-5.395-5.288-.776-7.678-.797-17.273-.128-24.95.32-2.487 2.984-3.45 5.252-4.166 20-6.145 40.723-10.485 63.589-10.898z"
+     fill="url(#i)"
+     transform="matrix(-.10616 0 0 .10616 18.793 -.666)"
+     id="path141" />
+  <path
+     d="M-16.643 74.14c-19.733-.845-39.643-4.587-59.227-10.692-2.582-.858-4.924-2.05-5.395-5.288-.776-7.678-.797-17.273-.128-24.95.32-2.487 2.984-3.45 5.252-4.166 20-6.145 40.723-10.485 63.589-10.898z"
+     fill="url(#j)"
+     transform="matrix(-.10616 0 0 .10616 18.793 -.666)"
+     id="path143" />
+  <path
+     d="M-16.643 74.14c-19.733-.845-39.643-4.587-59.227-10.692-2.582-.858-4.924-2.05-5.395-5.288-.776-7.678-.797-17.273-.128-24.95.32-2.487 2.984-3.45 5.252-4.166 20-6.145 40.723-10.485 63.589-10.898z"
+     fill="url(#k)"
+     transform="matrix(-.10616 0 0 .10616 18.793 -.666)"
+     id="path145" />
+  <path
+     d="M-67.578 26.548a310.687 310.687 0 00-8.563 2.496c-2.268.716-4.932 1.68-5.252 4.166-.336 3.863-.497 8.21-.476 12.555a12.017 12.017 0 006.433 1.883 12.017 12.017 0 0012.018-12.016 12.017 12.017 0 00-4.16-9.084z"
+     fill="url(#l)"
+     opacity=".392"
+     transform="matrix(-.10616 0 0 .10616 18.793 -.666)"
+     id="path147" />
+  <path
+     d="M-16.643 74.14c-19.733-.845-39.643-4.587-59.227-10.692-2.582-.858-4.924-2.05-5.395-5.288-.776-7.678-.797-17.273-.128-24.95.32-2.487 2.984-3.45 5.252-4.166 20-6.145 40.723-10.485 63.589-10.898z"
+     fill="url(#m)"
+     opacity=".315"
+     transform="matrix(-.10616 0 0 .10616 18.793 -.666)"
+     id="path149" />
+  <path
+     d="M13.774 15.748v6.67h-1.776c-.351.01-.498.455 0 .931l4.509 4.319a.639.639 0 00.443.185.639.639 0 00.443-.185l4.509-4.319c.497-.476.35-.921 0-.932h-1.776v-6.67z"
+     fill="url(#n)"
+     id="path151" />
+  <path
+     d="M13.818.953c-1.63.553-.43 8.888-.108 14.518v2.067c0 .226.181.407.407.407h5.537a.406.406 0 00.407-.407v-1.737c-.04-2.994 1.82-14.33-.217-14.848z"
+     fill="url(#o)"
+     id="path153" />
 </svg>

--- a/128x128/apps/shotwell.svg
+++ b/128x128/apps/shotwell.svg
@@ -19,413 +19,6 @@
    sodipodi:docname="shotwell.svg">
   <defs
      id="defs2338">
-    <radialGradient
-       gradientTransform="matrix(0.06212992,0,0,0.06517044,-24.612461,1.0441432)"
-       gradientUnits="userSpaceOnUse"
-       r="104.62651"
-       fy="379.7356"
-       fx="780.45435"
-       cy="379.7356"
-       cx="780.45435"
-       id="radialGradient1363"
-       xlink:href="#linearGradient1361"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient1361"
-       inkscape:collect="always">
-      <stop
-         id="stop1357"
-         offset="0"
-         style="stop-color:#31302e;stop-opacity:1;" />
-      <stop
-         style="stop-color:#0a0a0a;stop-opacity:0.75274724"
-         offset="0.77777755"
-         id="stop1365" />
-      <stop
-         id="stop1359"
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.06517044,0,0,0.06517044,-22.493909,-2.8646972)"
-       gradientUnits="userSpaceOnUse"
-       y2="429.16064"
-       x2="860.60889"
-       y1="429.16064"
-       x1="516.21191"
-       id="linearGradient825"
-       xlink:href="#linearGradient823"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient823"
-       inkscape:collect="always">
-      <stop
-         id="stop819"
-         offset="0"
-         style="stop-color:#bbbbbc;stop-opacity:1" />
-      <stop
-         style="stop-color:#f1f1f1;stop-opacity:1"
-         offset="0.01559022"
-         id="stop827" />
-      <stop
-         id="stop829"
-         offset="0.08908688"
-         style="stop-color:#9d9c9d;stop-opacity:1" />
-      <stop
-         style="stop-color:#aaaaab;stop-opacity:1"
-         offset="0.23162584"
-         id="stop831" />
-      <stop
-         id="stop835"
-         offset="0.91378081"
-         style="stop-color:#999a9a;stop-opacity:1" />
-      <stop
-         id="stop833"
-         offset="0.98150742"
-         style="stop-color:#e3e3e3;stop-opacity:1" />
-      <stop
-         id="stop821"
-         offset="1"
-         style="stop-color:#6d6c6d;stop-opacity:0.86274511" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.06517044,0,0,0.06517044,-3.053235,1.094131)"
-       gradientUnits="userSpaceOnUse"
-       y2="258.96423"
-       x2="296.07416"
-       y1="258.96423"
-       x1="236.91394"
-       id="linearGradient886"
-       xlink:href="#linearGradient884"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient884"
-       inkscape:collect="always">
-      <stop
-         id="stop880"
-         offset="0"
-         style="stop-color:#e4e8e9;stop-opacity:1" />
-      <stop
-         style="stop-color:#8e8e8d;stop-opacity:1"
-         offset="0.08918367"
-         id="stop892" />
-      <stop
-         id="stop894"
-         offset="0.19290622"
-         style="stop-color:#cfcfd0;stop-opacity:1" />
-      <stop
-         style="stop-color:#ededed;stop-opacity:1"
-         offset="0.4975912"
-         id="stop896" />
-      <stop
-         style="stop-color:#d7d8d9;stop-opacity:1"
-         offset="0.76662159"
-         id="stop890" />
-      <stop
-         style="stop-color:#9b9b9a;stop-opacity:1"
-         offset="0.90275741"
-         id="stop888" />
-      <stop
-         id="stop882"
-         offset="1"
-         style="stop-color:#e0e1e2;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.06517044,0,0,0.06517044,-3.053235,1.094131)"
-       gradientUnits="userSpaceOnUse"
-       y2="262.61246"
-       x2="296.07401"
-       y1="262.61246"
-       x1="237.0126"
-       id="linearGradient855"
-       xlink:href="#linearGradient853"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient853"
-       inkscape:collect="always">
-      <stop
-         id="stop849"
-         offset="0"
-         style="stop-color:#807f7d;stop-opacity:1;" />
-      <stop
-         style="stop-color:#f1f3f5;stop-opacity:1"
-         offset="0.52272725"
-         id="stop867" />
-      <stop
-         style="stop-color:#7c7c7b;stop-opacity:1"
-         offset="0.79870123"
-         id="stop865" />
-      <stop
-         style="stop-color:#5c5b5a;stop-opacity:1"
-         offset="0.8506493"
-         id="stop863" />
-      <stop
-         style="stop-color:#706f6e;stop-opacity:1"
-         offset="0.87012976"
-         id="stop861" />
-      <stop
-         style="stop-color:#494949;stop-opacity:1"
-         offset="0.88961029"
-         id="stop859" />
-      <stop
-         style="stop-color:#989896;stop-opacity:1;"
-         offset="0.91883105"
-         id="stop857" />
-      <stop
-         id="stop851"
-         offset="1"
-         style="stop-color:#9b9b99;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.06517044,0,0,0.06517044,-8.7100158,-6.1117315)"
-       gradientUnits="userSpaceOnUse"
-       y2="540.47455"
-       x2="550.61615"
-       y1="426.57626"
-       x1="452.77371"
-       id="linearGradient1028"
-       xlink:href="#linearGradient1026"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient1026"
-       inkscape:collect="always">
-      <stop
-         id="stop1022"
-         offset="0"
-         style="stop-color:#302f2e;stop-opacity:1;" />
-      <stop
-         style="stop-color:#292928;stop-opacity:1"
-         offset="0.48099521"
-         id="stop1030" />
-      <stop
-         id="stop1024"
-         offset="1"
-         style="stop-color:#52504f;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.06517044,0,0,0.06517044,-6.4478256,0.44507559)"
-       gradientUnits="userSpaceOnUse"
-       y2="433.08478"
-       x2="512.37885"
-       y1="338.4407"
-       x1="420.77371"
-       id="linearGradient1040"
-       xlink:href="#linearGradient1038"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient1038"
-       inkscape:collect="always">
-      <stop
-         id="stop1034"
-         offset="0"
-         style="stop-color:#353231;stop-opacity:1;" />
-      <stop
-         style="stop-color:#1e1c1c;stop-opacity:1"
-         offset="0.50596666"
-         id="stop1042" />
-      <stop
-         id="stop1036"
-         offset="1"
-         style="stop-color:#393636;stop-opacity:1" />
-    </linearGradient>
-    <radialGradient
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.06517044,0,0,0.06548226,-10.856798,-1.1252272)"
-       r="56.677963"
-       fy="407.77139"
-       fx="532.73767"
-       cy="407.77139"
-       cx="532.73767"
-       id="radialGradient918"
-       xlink:href="#linearGradient916"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient916"
-       inkscape:collect="always">
-      <stop
-         id="stop912"
-         offset="0"
-         style="stop-color:#7e7987;stop-opacity:1" />
-      <stop
-         style="stop-color:#5a7084;stop-opacity:1"
-         offset="0.92641002"
-         id="stop920" />
-      <stop
-         id="stop914"
-         offset="1"
-         style="stop-color:#758397;stop-opacity:0" />
-    </linearGradient>
-    <linearGradient
-       y2="518.06909"
-       x2="542.28455"
-       y1="447.88571"
-       x1="472.64935"
-       gradientTransform="matrix(0.06517044,0,0,0.06517044,-8.7100158,-6.1117315)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient2180"
-       xlink:href="#linearGradient1065"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient1065"
-       inkscape:collect="always">
-      <stop
-         id="stop1061"
-         offset="0"
-         style="stop-color:#0d1928;stop-opacity:1" />
-      <stop
-         id="stop1063"
-         offset="1"
-         style="stop-color:#182d47;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.06517044,0,0,0.06517044,-10.856798,-0.99807564)"
-       gradientUnits="userSpaceOnUse"
-       y2="411.93222"
-       x2="541.55927"
-       y1="447.72882"
-       x1="531.52539"
-       id="linearGradient1003"
-       xlink:href="#linearGradient1001"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient1001"
-       inkscape:collect="always">
-      <stop
-         id="stop997"
-         offset="0"
-         style="stop-color:#c9c4d8;stop-opacity:1" />
-      <stop
-         id="stop999"
-         offset="1"
-         style="stop-color:#ececed;stop-opacity:0" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.06517044,0,0,0.06517044,-10.856798,-0.99807564)"
-       gradientUnits="userSpaceOnUse"
-       y2="444.20535"
-       x2="558.73438"
-       y1="332.98587"
-       x1="458.80151"
-       id="linearGradient974"
-       xlink:href="#linearGradient972-0"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient972-0"
-       inkscape:collect="always">
-      <stop
-         id="stop968"
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1;" />
-      <stop
-         style="stop-color:#5a9bb5;stop-opacity:0"
-         offset="0.90098494"
-         id="stop976" />
-      <stop
-         id="stop970"
-         offset="1"
-         style="stop-color:#65adc9;stop-opacity:0.15934066" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.06517044,0,0,0.06517044,-8.7100158,-6.1117315)"
-       gradientUnits="userSpaceOnUse"
-       y2="465.05533"
-       x2="501.77155"
-       y1="448.56415"
-       x1="499.85397"
-       id="linearGradient1077"
-       xlink:href="#linearGradient1075"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient1075"
-       inkscape:collect="always">
-      <stop
-         id="stop1071"
-         offset="0"
-         style="stop-color:#b3a6b5;stop-opacity:1" />
-      <stop
-         id="stop1073"
-         offset="1"
-         style="stop-color:#adabb0;stop-opacity:0" />
-    </linearGradient>
-    <radialGradient
-       gradientTransform="matrix(0.06517044,0,0,0.06517044,-10.856798,-0.99807564)"
-       gradientUnits="userSpaceOnUse"
-       r="43.337254"
-       fy="372.78387"
-       fx="527.33392"
-       cy="372.78387"
-       cx="527.33392"
-       id="radialGradient930"
-       xlink:href="#linearGradient928"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient928"
-       inkscape:collect="always">
-      <stop
-         id="stop924"
-         offset="0"
-         style="stop-color:#6f7685;stop-opacity:1" />
-      <stop
-         id="stop926"
-         offset="1"
-         style="stop-color:#6b7482;stop-opacity:0" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.06517044,0,0,0.06517044,-10.856798,-0.99807564)"
-       gradientUnits="userSpaceOnUse"
-       y2="434.34766"
-       x2="550.90717"
-       y1="458.79303"
-       x1="567.82654"
-       id="linearGradient993"
-       xlink:href="#linearGradient991"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient991"
-       inkscape:collect="always">
-      <stop
-         id="stop987"
-         offset="0"
-         style="stop-color:#9297c4;stop-opacity:1" />
-      <stop
-         id="stop989"
-         offset="1"
-         style="stop-color:#878787;stop-opacity:0" />
-    </linearGradient>
-    <radialGradient
-       gradientTransform="matrix(0.0646458,0.00825266,-0.00692076,0.05421257,-7.4955281,-0.51826584)"
-       r="43.337254"
-       fy="445.26831"
-       fx="533.08667"
-       cy="445.26831"
-       cx="533.08667"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient934"
-       xlink:href="#linearGradient940"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient940">
-      <stop
-         style="stop-color:#92a2b0;stop-opacity:1"
-         offset="0"
-         id="stop936" />
-      <stop
-         style="stop-color:#575a68;stop-opacity:0"
-         offset="1"
-         id="stop938" />
-    </linearGradient>
-    <radialGradient
-       gradientTransform="matrix(0.10778188,0,0,0.10778188,-34.385648,-19.486141)"
-       gradientUnits="userSpaceOnUse"
-       r="4.985702"
-       fy="432.99579"
-       fx="551.87885"
-       cy="432.99579"
-       cx="551.87885"
-       id="radialGradient954"
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       inkscape:collect="always" />
     <linearGradient
        id="linearGradient8265-821-176-38-919-66-249-7-7">
       <stop
@@ -438,650 +31,561 @@
          id="stop2689-5-4" />
     </linearGradient>
     <linearGradient
+       id="b"
        gradientUnits="userSpaceOnUse"
-       y2="254.76938"
-       x2="475.52808"
-       y1="254.76938"
-       x1="414.88409"
-       id="linearGradient1462"
-       xlink:href="#linearGradient1460"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient1460"
-       inkscape:collect="always">
+       x1="13.902"
+       x2="38.285"
+       y1="25.030001"
+       y2="25.030001">
       <stop
-         id="stop1456"
          offset="0"
-         style="stop-color:#888a8b;stop-opacity:1" />
+         stop-color="#a6a5a6"
+         id="stop118" />
       <stop
-         id="stop1458"
+         offset=".02"
+         stop-color="#eeedee"
+         id="stop120" />
+      <stop
+         offset=".089"
+         stop-color="#adadaf"
+         id="stop122" />
+      <stop
+         offset=".499"
+         stop-color="#c7c7c8"
+         id="stop124" />
+      <stop
+         offset=".914"
+         stop-color="#b4b3b4"
+         id="stop126" />
+      <stop
+         offset=".971"
+         stop-color="#e4e4e5"
+         id="stop128" />
+      <stop
          offset="1"
-         style="stop-color:#bfc0c1;stop-opacity:1" />
+         stop-color="#808181"
+         stop-opacity=".992"
+         id="stop130" />
     </linearGradient>
     <linearGradient
-       gradientTransform="translate(-82.711865,0.27118609)"
+       id="c"
        gradientUnits="userSpaceOnUse"
-       y2="260.69882"
-       x2="558.78217"
-       y1="260.69882"
-       x1="498.18668"
-       id="linearGradient1386"
-       xlink:href="#linearGradient1384"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient1384"
-       inkscape:collect="always">
+       x1="21.724001"
+       x2="21.724001"
+       y1="18.042999"
+       y2="32.342999">
       <stop
-         id="stop1380"
          offset="0"
-         style="stop-color:#e7e8e7;stop-opacity:1;" />
+         stop-color="#efefed"
+         id="stop133" />
       <stop
-         style="stop-color:#888885;stop-opacity:1"
-         offset="0.0379749"
-         id="stop1388" />
+         offset=".026"
+         stop-color="#fdfdff"
+         stop-opacity=".22"
+         id="stop135" />
       <stop
-         id="stop1390"
-         offset="0.06329134"
-         style="stop-color:#e6e7e6;stop-opacity:1" />
+         offset=".979"
+         stop-opacity=".42"
+         id="stop137" />
       <stop
-         style="stop-color:#999996;stop-opacity:1"
-         offset="0.08860778"
-         id="stop1392" />
-      <stop
-         id="stop1394"
-         offset="0.10759512"
-         style="stop-color:#e2e4e3;stop-opacity:1" />
-      <stop
-         style="stop-color:#b3b3b1;stop-opacity:1"
-         offset="0.12658244"
-         id="stop1396" />
-      <stop
-         id="stop1398"
-         offset="0.15189889"
-         style="stop-color:#adadaa;stop-opacity:1" />
-      <stop
-         style="stop-color:#e7e8e7;stop-opacity:1"
-         offset="0.18354444"
-         id="stop1400" />
-      <stop
-         id="stop1402"
-         offset="0.21835455"
-         style="stop-color:#c0c1bf;stop-opacity:1" />
-      <stop
-         style="stop-color:#e0e1e0;stop-opacity:1"
-         offset="0.25000009"
-         id="stop1404" />
-      <stop
-         id="stop1406"
-         offset="0.27215198"
-         style="stop-color:#adaeab;stop-opacity:1" />
-      <stop
-         style="stop-color:#dededd;stop-opacity:1"
-         offset="0.29746842"
-         id="stop1408" />
-      <stop
-         id="stop1410"
-         offset="0.32278487"
-         style="stop-color:#cbcbc9;stop-opacity:1" />
-      <stop
-         style="stop-color:#ececeb;stop-opacity:1"
-         offset="0.35759497"
-         id="stop1412" />
-      <stop
-         id="stop1414"
-         offset="0.38607597"
-         style="stop-color:#c6c6c3;stop-opacity:1" />
-      <stop
-         style="stop-color:#e2e2e1;stop-opacity:1"
-         offset="0.42721519"
-         id="stop1416" />
-      <stop
-         id="stop1418"
-         offset="0.4683544"
-         style="stop-color:#c7c7c5;stop-opacity:1" />
-      <stop
-         style="stop-color:#c5c5c3;stop-opacity:1"
-         offset="0.52215183"
-         id="stop1420" />
-      <stop
-         id="stop1422"
-         offset="0.55696195"
-         style="stop-color:#cfcfcd;stop-opacity:1" />
-      <stop
-         style="stop-color:#b4b4b0;stop-opacity:1"
-         offset="0.58227837"
-         id="stop1424" />
-      <stop
-         id="stop1426"
-         offset="0.61075938"
-         style="stop-color:#dcdcda;stop-opacity:1" />
-      <stop
-         style="stop-color:#bdbdba;stop-opacity:1"
-         offset="0.63291126"
-         id="stop1428" />
-      <stop
-         id="stop1430"
-         offset="0.6645568"
-         style="stop-color:#dededc;stop-opacity:1" />
-      <stop
-         style="stop-color:#aaada9;stop-opacity:1"
-         offset="0.69936693"
-         id="stop1432" />
-      <stop
-         id="stop1434"
-         offset="0.73101246"
-         style="stop-color:#cfd1ce;stop-opacity:1" />
-      <stop
-         style="stop-color:#babdba;stop-opacity:1"
-         offset="0.75316435"
-         id="stop1436" />
-      <stop
-         id="stop1438"
-         offset="0.78164536"
-         style="stop-color:#e1e2e1;stop-opacity:1" />
-      <stop
-         style="stop-color:#aaacaa;stop-opacity:1"
-         offset="0.80696183"
-         id="stop1440" />
-      <stop
-         id="stop1442"
-         offset="0.83544278"
-         style="stop-color:#d7d8d7;stop-opacity:1" />
-      <stop
-         style="stop-color:#787c78;stop-opacity:1"
-         offset="0.86392379"
-         id="stop1444" />
-      <stop
-         id="stop1446"
-         offset="0.89556938"
-         style="stop-color:#dcdddc;stop-opacity:1" />
-      <stop
-         style="stop-color:#828682;stop-opacity:1"
-         offset="0.9208858"
-         id="stop1448" />
-      <stop
-         id="stop1450"
-         offset="0.95569593"
-         style="stop-color:#d7d9d7;stop-opacity:1" />
-      <stop
-         style="stop-color:#939993;stop-opacity:1"
-         offset="0.97784781"
-         id="stop1452" />
-      <stop
-         id="stop1382"
          offset="1"
-         style="stop-color:#e7e8e7;stop-opacity:1" />
+         stop-opacity=".522"
+         id="stop139" />
     </linearGradient>
     <linearGradient
-       y2="-56.98069"
-       x2="-34.043579"
-       y1="-60.740406"
-       x1="-34.043579"
-       gradientTransform="translate(0.23665,-0.0290376)"
+       id="d"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient2034"
-       xlink:href="#linearGradient1658"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient1658"
-       inkscape:collect="always">
+       x1="13.903"
+       x2="38.276001"
+       y1="17.827"
+       y2="17.827">
       <stop
-         id="stop1654"
          offset="0"
-         style="stop-color:#606060;stop-opacity:1" />
+         stop-color="#c4c4c4"
+         id="stop142" />
       <stop
-         id="stop1656"
+         offset=".5"
+         stop-color="#c4c4c4"
+         id="stop144" />
+      <stop
          offset="1"
-         style="stop-color:#424242;stop-opacity:0.98812938" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(2.283609,0,0,2.283609,52.537625,119.21049)"
-       y2="-41.729069"
-       x2="17.78685"
-       y1="-42.061676"
-       x1="17.78685"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient2004"
-       xlink:href="#linearGradient1912"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient1912">
-      <stop
-         style="stop-color:#777777;stop-opacity:1"
-         offset="0"
-         id="stop1908" />
-      <stop
-         style="stop-color:#646464;stop-opacity:1"
-         offset="1"
-         id="stop1910" />
-    </linearGradient>
-    <linearGradient
-       y2="-35.335289"
-       x2="-1.2817074"
-       y1="-37.576065"
-       x1="-3.3311813"
-       gradientTransform="translate(19.061069,0.24368881)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient2006"
-       xlink:href="#linearGradient2082"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient2082">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop2078" />
-      <stop
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         offset="1"
-         id="stop2080" />
-    </linearGradient>
-    <linearGradient
-       y2="-36.872868"
-       x2="-2.5833058"
-       y1="-36.536373"
-       x1="-3.1661334"
-       gradientTransform="translate(19.061069,0.24368881)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient2008"
-       xlink:href="#linearGradient2092"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient2092">
-      <stop
-         style="stop-color:#777777;stop-opacity:1;"
-         offset="0"
-         id="stop2088" />
-      <stop
-         style="stop-color:#777777;stop-opacity:0;"
-         offset="1"
-         id="stop2090" />
+         stop-color="#c2c2c3"
+         id="stop146" />
     </linearGradient>
     <radialGradient
-       r="2.947299"
-       fy="-32.108704"
-       fx="-2.2243273"
-       cy="-32.108704"
-       cx="-2.2243273"
-       gradientTransform="matrix(0.86709332,-0.12489137,0.01809145,0.12560498,19.346334,-31.954258)"
+       id="e"
+       cx="27.805"
+       cy="26.004999"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient2010"
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="-35.571022"
-       x2="0.048382148"
-       y1="-35.88295"
-       x1="1.1191089"
-       gradientTransform="translate(19.061069,0.24368881)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient2012"
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="-35.804062"
-       x2="0.3418664"
-       y1="-36.816315"
-       x1="-0.31529626"
-       gradientTransform="translate(19.061069,0.24368881)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient2014"
-       xlink:href="#linearGradient2114"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient2114">
+       r="7.1560001">
       <stop
-         style="stop-color:#c3c3c3;stop-opacity:1"
          offset="0"
-         id="stop2110" />
+         stop-color="#25060b"
+         id="stop188" />
       <stop
-         id="stop2120"
-         offset="0.18044075"
-         style="stop-color:#ffffff;stop-opacity:1" />
+         offset=".874"
+         stop-opacity=".508"
+         id="stop190" />
       <stop
-         style="stop-color:#acacac;stop-opacity:1"
          offset="1"
-         id="stop2112" />
+         stop-opacity="0"
+         id="stop192" />
+    </radialGradient>
+    <linearGradient
+       id="f"
+       gradientUnits="userSpaceOnUse"
+       x1="21.204"
+       x2="34.598999"
+       y1="23.636"
+       y2="23.636">
+      <stop
+         offset="0"
+         stop-color="#464647"
+         id="stop154" />
+      <stop
+         offset=".5"
+         stop-color="#babab7"
+         id="stop156" />
+      <stop
+         offset="1"
+         stop-color="#333"
+         id="stop158" />
+    </linearGradient>
+    <linearGradient
+       id="g"
+       gradientUnits="userSpaceOnUse"
+       x1="21.204"
+       x2="34.598999"
+       y1="23.847"
+       y2="23.847">
+      <stop
+         offset="0"
+         stop-color="#888684"
+         id="stop161" />
+      <stop
+         offset=".5"
+         stop-color="#fff"
+         id="stop163" />
+      <stop
+         offset="1"
+         stop-color="#888684"
+         id="stop165" />
+    </linearGradient>
+    <linearGradient
+       id="h"
+       gradientUnits="userSpaceOnUse"
+       x1="28.447001"
+       x2="28.447001"
+       y1="18.801001"
+       y2="32.376999">
+      <stop
+         offset="0"
+         stop-color="#dfdfdd"
+         id="stop149" />
+      <stop
+         offset="1"
+         stop-color="#f1f1f1"
+         id="stop151" />
+    </linearGradient>
+    <linearGradient
+       id="i"
+       gradientUnits="userSpaceOnUse"
+       x1="23.621"
+       x2="31.24"
+       y1="29.229"
+       y2="21.149">
+      <stop
+         offset="0"
+         stop-color="#30302f"
+         id="stop168" />
+      <stop
+         offset=".26"
+         stop-color="#535150"
+         id="stop170" />
+      <stop
+         offset="1"
+         stop-color="#222220"
+         id="stop172" />
     </linearGradient>
     <radialGradient
+       id="j"
+       cx="27.875"
+       cy="25.580999"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.23579816,0,0,0.43704626,19.566134,296.16686)"
-       r="6.2407994"
-       fy="-57.707745"
-       fx="-46.093536"
-       cy="-57.707745"
-       cx="-46.093536"
-       id="radialGradient1874"
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       inkscape:collect="always" />
+       r="4.448">
+      <stop
+         offset="0"
+         stop-color="#3f464d"
+         id="stop176" />
+      <stop
+         offset="1"
+         stop-color="#1f2124"
+         id="stop178" />
+    </radialGradient>
     <radialGradient
-       r="2.947299"
-       fy="-32.108704"
-       fx="-2.2243273"
-       cy="-32.108704"
-       cx="-2.2243273"
-       gradientTransform="matrix(0.86709332,-0.12489137,0.01809145,0.12560498,19.346334,-31.954258)"
+       id="k"
+       cx="-2.089"
+       cy="64.330002"
+       gradientTransform="matrix(-0.54919,0.07492,-0.04932,-0.36152,29.468,45.778)"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient1787"
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       inkscape:collect="always" />
-    <radialGradient
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6042049,0,0,0.43704626,36.547304,296.16686)"
-       r="6.2407994"
-       fy="-57.707745"
-       fx="-46.093536"
-       cy="-57.707745"
-       cx="-46.093536"
-       id="radialGradient1861"
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       inkscape:collect="always" />
+       r="4.0009999"
+       xlink:href="#a" />
     <linearGradient
-       gradientTransform="matrix(0.6042049,0,0,0.6042049,-27.566825,300.87183)"
-       y2="-53.906643"
-       x2="59.878899"
-       y1="-45.072689"
-       x1="59.878899"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient1803"
-       xlink:href="#linearGradient1799"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient1799"
-       inkscape:collect="always">
+       id="a">
       <stop
-         id="stop1795"
          offset="0"
-         style="stop-color:#7f7f7f;stop-opacity:1" />
+         stop-color="#9bbcde"
+         stop-opacity=".875"
+         id="stop2" />
       <stop
-         style="stop-color:#828282;stop-opacity:1;"
-         offset="0.51354694"
-         id="stop1805" />
-      <stop
-         id="stop1807"
-         offset="0.51354694"
-         style="stop-color:#a8a8a8;stop-opacity:1;" />
-      <stop
-         id="stop1797"
          offset="1"
-         style="stop-color:#adadad;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(1.1500205,0.1892688,-0.1892688,1.1500205,82.765648,-604.57179)"
-       gradientUnits="userSpaceOnUse"
-       y2="293.20868"
-       x2="44.474987"
-       y1="295.85452"
-       x1="28.494473"
-       id="linearGradient1113"
-       xlink:href="#linearGradient1111"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient1111"
-       inkscape:collect="always">
-      <stop
-         id="stop1107"
-         offset="0"
-         style="stop-color:#c7c7c7;stop-opacity:1" />
-      <stop
-         id="stop1109"
-         offset="1"
-         style="stop-color:#cecece;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(1.1500205,0.1892688,-0.1892688,1.1500205,-11.254369,-591.38026)"
-       gradientUnits="userSpaceOnUse"
-       y2="252.27599"
-       x2="136.20906"
-       y1="283.19275"
-       x1="141.50327"
-       id="linearGradient1218"
-       xlink:href="#linearGradient1216"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient1216"
-       inkscape:collect="always">
-      <stop
-         id="stop1212"
-         offset="0"
-         style="stop-color:#7e7e7e;stop-opacity:1" />
-      <stop
-         id="stop1214"
-         offset="1"
-         style="stop-color:#a6a6a6;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.30427623,0.05007738,-0.05007738,0.30427623,-71.420005,-309.84429)"
-       gradientUnits="userSpaceOnUse"
-       y2="79.25"
-       x2="545.375"
-       y1="88.861115"
-       x1="520.34894"
-       id="linearGradient1319"
-       xlink:href="#linearGradient1317"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient1317"
-       inkscape:collect="always">
-      <stop
-         id="stop1313"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1" />
-      <stop
-         id="stop1315"
-         offset="1"
-         style="stop-color:#c8c8c8;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.30427625,0.05007737,-0.05007737,0.30427625,-5.7195175,-162.04485)"
-       gradientUnits="userSpaceOnUse"
-       y2="279.09134"
-       x2="150.33063"
-       y1="279.09134"
-       x1="136.85519"
-       id="linearGradient1422"
-       xlink:href="#linearGradient1420"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient1420"
-       inkscape:collect="always">
-      <stop
-         id="stop1416-7"
-         offset="0"
-         style="stop-color:#efefef;stop-opacity:1" />
-      <stop
-         id="stop1418-9"
-         offset="1"
-         style="stop-color:#efefef;stop-opacity:0" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient2243"
-       id="linearGradient2245"
-       x1="27.160204"
-       y1="-46.235176"
-       x2="27.160204"
-       y2="-54.856945"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient2243">
-      <stop
-         style="stop-color:#777777;stop-opacity:1"
-         offset="0"
-         id="stop2239" />
-      <stop
-         id="stop2249"
-         offset="0.51793307"
-         style="stop-color:#828282;stop-opacity:1" />
-      <stop
-         id="stop2247"
-         offset="0.51793307"
-         style="stop-color:#b8b8b8;stop-opacity:1" />
-      <stop
-         style="stop-color:#c8c8c8;stop-opacity:1"
-         offset="1"
-         id="stop2241" />
+         stop-color="#9bbcde"
+         stop-opacity="0"
+         id="stop4" />
     </linearGradient>
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient2299"
-       id="radialGradient2301"
-       cx="27.141945"
-       cy="-50.418606"
-       fx="27.141945"
-       fy="-50.418606"
-       r="6.2407994"
-       gradientTransform="matrix(1,0,0,0.72334113,0,-13.948754)"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient2299">
+       id="l"
+       cx="-2.2"
+       cy="64.282997"
+       gradientTransform="matrix(-0.94041,0.09304,-0.04644,-0.46938,-30.78,6.259)"
+       gradientUnits="userSpaceOnUse"
+       r="4.0009999">
       <stop
-         style="stop-color:#d9d9d9;stop-opacity:1;"
          offset="0"
-         id="stop2295" />
+         stop-color="#afc8e5"
+         stop-opacity=".875"
+         id="stop181" />
       <stop
-         style="stop-color:#d9d9d9;stop-opacity:0;"
          offset="1"
-         id="stop2297" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1912"
-       id="linearGradient1914"
-       x1="17.78685"
-       y1="-42.061676"
-       x2="17.78685"
-       y2="-41.729069"
-       gradientUnits="userSpaceOnUse" />
+         stop-color="#9bbcde"
+         stop-opacity="0"
+         id="stop183" />
+    </radialGradient>
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="radialGradient2106"
-       cx="-2.2243273"
-       cy="-32.108704"
-       fx="-2.2243273"
-       fy="-32.108704"
-       r="2.947299"
-       gradientTransform="matrix(0.86709332,-0.12489137,0.01809145,0.12560498,19.346334,-31.954258)"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       gradientTransform="translate(0.00526744,262.96607)"
+       id="m"
+       cx="-2.3239999"
+       cy="62.916"
+       gradientTransform="matrix(-0.46207,0.0752,-0.04165,-0.25597,33.087,34.555)"
        gradientUnits="userSpaceOnUse"
-       y2="28.95187"
-       x2="4.9738135"
-       y1="6.4081883"
-       x1="26.124226"
-       id="linearGradient2042"
-       xlink:href="#linearGradient2040"
-       inkscape:collect="always" />
+       r="4.0009999"
+       xlink:href="#a" />
+    <radialGradient
+       id="n"
+       cx="-2.46"
+       cy="64.407997"
+       gradientTransform="matrix(-0.5521,0.06271,-0.04227,-0.37208,-23.212,-6.984)"
+       gradientUnits="userSpaceOnUse"
+       r="4.0009999"
+       xlink:href="#a" />
     <linearGradient
-       id="linearGradient2040"
-       inkscape:collect="always">
+       id="o"
+       gradientTransform="matrix(1.0822,0,0,1.35411,1.434,-7.139)"
+       gradientUnits="userSpaceOnUse"
+       x1="12.387"
+       x2="16.242001"
+       y1="17.971001"
+       y2="17.971001">
       <stop
-         id="stop2057"
          offset="0"
-         style="stop-color:#000000;stop-opacity:1" />
+         stop-color="#e4e8e9"
+         id="stop98" />
       <stop
-         id="stop2038"
+         offset=".089"
+         stop-color="#8e8e8d"
+         id="stop100" />
+      <stop
+         offset=".193"
+         stop-color="#cfcfd0"
+         id="stop102" />
+      <stop
+         offset=".498"
+         stop-color="#ededed"
+         id="stop104" />
+      <stop
+         offset=".767"
+         stop-color="#d7d8d9"
+         id="stop106" />
+      <stop
+         offset=".903"
+         stop-color="#9b9b9a"
+         id="stop108" />
+      <stop
          offset="1"
-         style="stop-color:#000000;stop-opacity:1" />
+         stop-color="#e0e1e2"
+         id="stop110" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient2082"
-       id="linearGradient3878"
+       id="p"
+       gradientTransform="matrix(1.0822,0,0,1.35411,1.434,-7.139)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(19.061069,0.24368881)"
-       x1="-3.3311813"
-       y1="-37.576065"
-       x2="-1.2817074"
-       y2="-35.335289" />
+       x1="12.393"
+       x2="16.242001"
+       y1="18.208"
+       y2="18.208">
+      <stop
+         offset="0"
+         stop-color="#807f7d"
+         id="stop7" />
+      <stop
+         offset=".523"
+         stop-color="#f1f3f5"
+         id="stop9" />
+      <stop
+         offset=".799"
+         stop-color="#7c7c7b"
+         id="stop11" />
+      <stop
+         offset=".851"
+         stop-color="#5c5b5a"
+         id="stop13" />
+      <stop
+         offset=".87"
+         stop-color="#706f6e"
+         id="stop15" />
+      <stop
+         offset=".89"
+         stop-color="#494949"
+         id="stop17" />
+      <stop
+         offset=".919"
+         stop-color="#989896"
+         id="stop19" />
+      <stop
+         offset="1"
+         stop-color="#9b9b99"
+         id="stop21" />
+    </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient2092"
-       id="linearGradient3880"
+       id="q"
+       gradientTransform="matrix(0.06706,0,0,0.06426,0.073,-41.245)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(19.061069,0.24368881)"
-       x1="-3.1661334"
-       y1="-36.536373"
-       x2="-2.5833058"
-       y2="-36.872868" />
+       x1="414.565"
+       x2="476.07001"
+       y1="260.91101"
+       y2="260.97">
+      <stop
+         offset="0"
+         stop-color="#e7e8e7"
+         id="stop24" />
+      <stop
+         offset=".038"
+         stop-color="#9ea09e"
+         id="stop26" />
+      <stop
+         offset=".063"
+         stop-color="#e6e7e6"
+         id="stop28" />
+      <stop
+         offset=".089"
+         stop-color="#9e9f9d"
+         id="stop30" />
+      <stop
+         offset=".108"
+         stop-color="#e2e4e3"
+         id="stop32" />
+      <stop
+         offset=".127"
+         stop-color="#b3b3b1"
+         id="stop34" />
+      <stop
+         offset=".152"
+         stop-color="#747471"
+         id="stop36" />
+      <stop
+         offset=".184"
+         stop-color="#e7e8e7"
+         id="stop38" />
+      <stop
+         offset=".218"
+         stop-color="#666764"
+         id="stop40" />
+      <stop
+         offset=".25"
+         stop-color="#e0e1e0"
+         id="stop42" />
+      <stop
+         offset=".272"
+         stop-color="#7d7f7b"
+         id="stop44" />
+      <stop
+         offset=".297"
+         stop-color="#dededd"
+         id="stop46" />
+      <stop
+         offset=".323"
+         stop-color="#90918d"
+         id="stop48" />
+      <stop
+         offset=".358"
+         stop-color="#ececeb"
+         id="stop50" />
+      <stop
+         offset=".386"
+         stop-color="#9e9e9b"
+         id="stop52" />
+      <stop
+         offset=".427"
+         stop-color="#edeeed"
+         id="stop54" />
+      <stop
+         offset=".468"
+         stop-color="#a2a39e"
+         id="stop56" />
+      <stop
+         offset=".533"
+         stop-color="#eeefef"
+         id="stop58" />
+      <stop
+         offset=".582"
+         stop-color="#b4b4b0"
+         id="stop60" />
+      <stop
+         offset=".611"
+         stop-color="#eaebea"
+         id="stop62" />
+      <stop
+         offset=".633"
+         stop-color="#bdbdba"
+         id="stop64" />
+      <stop
+         offset=".665"
+         stop-color="#f3f5f5"
+         id="stop66" />
+      <stop
+         offset=".699"
+         stop-color="#aaada9"
+         id="stop68" />
+      <stop
+         offset=".731"
+         stop-color="#f1f3f3"
+         id="stop70" />
+      <stop
+         offset=".753"
+         stop-color="#babdba"
+         id="stop72" />
+      <stop
+         offset=".782"
+         stop-color="#f9fafa"
+         id="stop74" />
+      <stop
+         offset=".807"
+         stop-color="#aaacaa"
+         id="stop76" />
+      <stop
+         offset=".835"
+         stop-color="#f6f8f7"
+         id="stop78" />
+      <stop
+         offset=".864"
+         stop-color="#787c78"
+         id="stop80" />
+      <stop
+         offset=".896"
+         stop-color="#fafbfb"
+         id="stop82" />
+      <stop
+         offset=".921"
+         stop-color="#828682"
+         id="stop84" />
+      <stop
+         offset=".956"
+         stop-color="#dddedd"
+         id="stop86" />
+      <stop
+         offset=".978"
+         stop-color="#939993"
+         id="stop88" />
+      <stop
+         offset="1"
+         stop-color="#c3c3c0"
+         id="stop90" />
+    </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3882"
+       id="r"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(19.061069,0.24368881)"
-       x1="1.1191089"
-       y1="-35.88295"
-       x2="0.048382148"
-       y2="-35.571022" />
+       x1="30.195999"
+       x2="30.195999"
+       y1="-24.75"
+       y2="-25.056">
+      <stop
+         offset="0"
+         stop-color="#cfd2d4"
+         id="stop93" />
+      <stop
+         offset="1"
+         stop-color="#a2a7a9"
+         id="stop95" />
+    </linearGradient>
+    <radialGradient
+       id="s"
+       cx="28.881001"
+       cy="27.1"
+       gradientUnits="userSpaceOnUse"
+       r="0.55299997">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         id="stop113" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop115" />
+    </radialGradient>
+    <radialGradient
+       id="t"
+       cx="17.737"
+       cy="12.757"
+       gradientTransform="matrix(0.93680008,-0.79603516,0.18432391,0.21692026,-18.106868,23.093853)"
+       gradientUnits="userSpaceOnUse"
+       r="1.372">
+      <stop
+         offset="0"
+         stop-color="#2e2e2e"
+         id="stop195" />
+      <stop
+         offset="1"
+         stop-color="#afafaf"
+         id="stop197" />
+    </radialGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient2114"
-       id="linearGradient3884"
+       gradientTransform="matrix(0.97186496,0,0,0.97186496,-13.796647,-0.15024157)"
+       id="u"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(19.061069,0.24368881)"
-       x1="-0.31529626"
-       y1="-36.816315"
-       x2="0.3418664"
-       y2="-35.804062" />
+       x1="7.1440001"
+       x2="8.2950001"
+       y1="12.436"
+       y2="14.177">
+      <stop
+         offset="0"
+         stop-color="#d0d0d0"
+         id="stop200" />
+      <stop
+         offset=".5"
+         stop-color="#e3e3e3"
+         id="stop202" />
+      <stop
+         offset="1"
+         stop-color="#3e3e3e"
+         id="stop204" />
+    </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1658"
-       id="linearGradient3886"
+       gradientTransform="matrix(0.97186496,0,0,0.97186496,-13.796647,-0.15024157)"
+       id="v"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0.23665,-0.0290376)"
-       x1="-34.043579"
-       y1="-60.740406"
-       x2="-34.043579"
-       y2="-56.98069" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient2082"
-       id="linearGradient3888"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(19.061069,0.24368881)"
-       x1="-3.3311813"
-       y1="-37.576065"
-       x2="-1.2817074"
-       y2="-35.335289" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient2092"
-       id="linearGradient3890"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(19.061069,0.24368881)"
-       x1="-3.1661334"
-       y1="-36.536373"
-       x2="-2.5833058"
-       y2="-36.872868" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3892"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(19.061069,0.24368881)"
-       x1="1.1191089"
-       y1="-35.88295"
-       x2="0.048382148"
-       y2="-35.571022" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient2114"
-       id="linearGradient3894"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(19.061069,0.24368881)"
-       x1="-0.31529626"
-       y1="-36.816315"
-       x2="0.3418664"
-       y2="-35.804062" />
+       x1="8.467"
+       x2="8.0869999"
+       y1="13.324"
+       y2="14.288">
+      <stop
+         offset="0"
+         stop-color="#2e2e2e"
+         id="stop207" />
+      <stop
+         offset="1"
+         stop-color="#696969"
+         id="stop209" />
+    </linearGradient>
   </defs>
   <sodipodi:namedview
      id="base"
@@ -1090,9 +594,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="2.8"
-     inkscape:cx="72.857143"
-     inkscape:cy="97.142857"
+     inkscape:zoom="1.979899"
+     inkscape:cx="-179.47242"
+     inkscape:cy="172.5567"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      showgrid="false"
@@ -1110,7 +614,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -1121,7 +625,7 @@
      transform="translate(0,-263.13332)">
     <g
        style="opacity:0.29500002"
-       transform="matrix(0.97573206,0,0,0.97573206,-65.743118,225.76297)"
+       transform="matrix(0.97573206,0,0,0.97573206,-65.743121,225.76297)"
        id="g1702">
       <rect
          ry="6.6098609"
@@ -1322,1661 +826,234 @@
          rx="6.6098609"
          ry="6.6098609" />
     </g>
-    <rect
-       ry="6.4494534"
-       rx="6.4494534"
-       y="265.48468"
-       x="2.4015315"
-       height="29.08744"
-       width="29.08744"
-       id="rect849"
-       style="fill:url(#linearGradient2042);fill-opacity:1;stroke-width:2.6880002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
     <g
-       id="g2209"
-       transform="matrix(0.60420488,0,0,0.60420488,-2.3659336,300.57034)">
+       transform="matrix(1.0289394,0,0,1.0289394,15.250484,263.10848)"
+       id="g3128">
       <rect
-         ry="0.96645641"
-         rx="0.96645641"
-         y="-43.527683"
-         x="11.898496"
-         height="9.0284538"
-         width="12.481598"
-         id="rect1900"
-         style="fill:#adadad;fill-opacity:1;stroke:none;stroke-width:0.40000001;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:1" />
+         style="fill:#606060;stroke-width:0.971865"
+         height="28.268637"
+         rx="6.2675571"
+         width="28.268637"
+         x="-12.496291"
+         y="2.2978861"
+         id="rect212" />
       <path
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="csssscc"
-         d="m 24.380094,-41.96681 v 6.501124 c 0,0.535417 -0.43104,0.966457 -0.966457,0.966457 H 12.864952 c -0.535417,0 -0.966456,-0.43104 -0.966456,-0.966457 v -6.501124 z"
-         style="fill:url(#linearGradient1914);fill-opacity:1;stroke:none;stroke-width:0.40000001;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:1"
-         id="rect1905" />
+         style="fill:#bbbbbb;stroke-width:0.971865"
+         d="M -9.4251984,4.9928677 -2.4821945,4.7353235 V 5.5652963 C -0.22455254,5.4311788 2.0214275,5.2737368 4.4608085,5.5069845 4.8145675,5.3028928 5.1829045,5.1065758 5.7465855,4.991896 V 3.7080623 H -9.4251984 Z m -1.2857776,5.2713953 h 7.9712365 v 1.15652 h -7.9712365 z"
+         id="path218" />
       <path
          inkscape:connector-curvature="0"
-         style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.424254;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         d="m 17.294018,-41.408957 1.091924,-0.08294 1.218358,0.06163 -1.180483,0.08341 z"
-         id="path1937"
-         sodipodi:nodetypes="ccccc" />
+         style="fill:#929292;stroke-width:0.971865"
+         d="m -2.4821945,19.649564 c 0,0 -7.0265842,0.04471 -8.0295485,0.484961 0.05831,2.60071 5.0206543,2.946694 2.8864388,8.772052 h 5.1431097 z"
+         id="path222" />
       <path
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc"
-         id="path1939"
-         d="m 14.983736,-41.387647 1.091924,-0.08294 1.218358,0.06163 -1.180483,0.08341 z"
-         style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.424254;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
+         style="fill:#afafaf;stroke-width:0.971865"
+         d="m -3.1207105,5.0317424 c -0.545216,0.5209197 -1.1701251,0.5248072 -1.8066966,0.5218914 -0.518976,0.098159 -1.1944222,0.3974929 -0.2779533,0.4781575 0.5908938,-0.5568786 1.5899709,-0.087468 2.1536529,-0.2692066 0.100102,-0.1963167 0.178823,-0.6093592 -0.068031,-0.7308423 z m -3.5278696,0.1263423 c -0.2332474,0.2750378 0.1107926,0.1788233 0,0 z m 1.4121199,0 c -0.4305361,0.2536568 0.4927356,0.2536568 0,0 z M -5.9294,5.1726617 c -0.1914573,0.1360609 0.4558047,0.019437 0,0 z m 0.3615339,0.00486 c -0.2818408,0.3080814 0.055396,0.3595902 0,0 z m -1.2585651,0.2351917 c -0.7133489,0.3129406 0.3051656,0.2390789 0,0 z m 0.3498712,0.061228 c -0.2089508,0.1953447 0.223529,0.13023 0,0 z m -0.7813793,0.1797947 c -0.063171,0.3401525 0.3780555,0.2662909 0,0 z m -2.1730903,0.1020457 c -0.5034259,0.1982604 0.1185676,0.4626076 0,0 z m 8.63696406,0.016521 C -1.1876705,6.0113817 -1.8563135,6.2582355 -2.1381545,6.2698977 c 0.486904,0.3236312 1.19636596,0 1.67549496,-0.1185673 0.07775,-0.1963168 -0.152583,-0.3906897 -0.330434,-0.3790276 z m -6.00320996,0.0622 c -0.1603574,0.2760096 0.1924295,0.094271 0,0 z m -1.4548818,0.012633 c -0.4791292,0.1720202 0.122455,0.1632735 0,0 z m 3.7854141,0.05734 c -0.9981052,0.012633 -0.4305362,0.3644494 0,0 z m -2.5871045,0.074834 c -0.3314059,0.089412 0.3129405,0.165217 0.064143,0.014577 z m 5.1197842,0.4713546 c -0.61519,0.036931 0.08747,0.2235287 0,0 z M -8.5194202,6.7966491 C -8.8965037,7.0697432 -8.1919015,7.026981 -8.5855069,7.2757786 -8.0684747,7.2660586 -6.9624924,7.0551653 -8.10249,6.998797 -8.2560448,6.9589506 -8.3600342,6.8180302 -8.5203919,6.7966491 Z m 1.7590757,0.077749 c -0.7949855,0.2779533 -0.052481,0.4130425 0,0 z m 0.8358039,0.067058 c -1.4412756,0.2847565 0.8105354,0.3634776 0,0 z m -4.4686354,0.093299 -0.05831,0.2011762 -0.02527,0.1001019 c 0.02624,-0.1137081 0.05442,-0.2254725 0.08358,-0.3012781 z m -0.08358,0.3012781 -0.0049,0.021381 z m -0.0049,0.021381 -0.01944,0.082609 c -0.101074,0.6239378 -0.05831,0.2692071 0.01944,-0.082609 z m 5.215028,0.2157547 c -0.4140145,0.1331454 1.0914045,0.2478255 0.2245008,0.019437 z m -1.0029646,0.029156 c -0.2400506,0.279897 1.0447548,0.1603577 0.194373,0.02624 z m -3.1313489,0.00972 c -0.4723266,0.08358 -0.3984647,0.345012 -0.2419944,0.6074155 0.030128,0.1069051 0.093299,0.2089511 0.186598,0.2896157 0.1613295,0.2410226 0.2410224,0.417902 -0.2400506,0.3411246 -0.3809715,0.00583 -1.7260325,-0.00389 -0.6249095,0.1554985 l 0.03207,-0.00583 c 0.08261,0.013605 0.182711,0.010689 0.188542,-0.02624 0.08941,-0.00583 0.1749357,-0.00389 0.2594878,0.0068 -9.771e-4,0.052481 0.102046,0.059284 0.2060354,0.047621 0.5014822,0.1418945 0.9281308,0.51995 1.4257257,0.714323 0.3352933,-0.0622 0.9767243,0.1593857 1.0593327,-0.1506391 C -7.203515,9.3769496 -7.5582457,9.295313 -7.9061733,9.2535228 a 2.6901222,2.6901222 0 0 0 -0.5092572,-0.063171 l -0.039847,0.011661 c -0.2167255,-0.025269 -0.2497687,-0.063171 0.1827111,-0.1963163 0.06803,-0.0068 0.1389767,-0.00486 0.2099229,-0.00292 0.075805,0.00583 0.1525828,0.00875 0.2303319,0.011661 0.6958553,0.069003 1.46946,0.3352936 1.9855202,-0.1992322 -1.123476,0.00972 0.9252155,-0.345984 0.7716607,0.2789253 0.5597943,0.1603575 0.4878764,-0.2293602 0.2594879,-0.3887462 0.4091553,0.069974 1.2012253,0.2390789 1.6356493,0.080665 0.100102,-0.00972 0.164245,-0.036931 0.160357,-0.087468 0.159386,-0.13023 0.204092,-0.3566745 0.03693,-0.7366737 -0.8707898,-0.3450076 -1.8834731,0.1020504 -2.8145198,-0.072885 -1.0253175,0.025269 -2.0457757,-0.064143 -3.058459,-0.2011759 l -0.030128,-0.014577 a 1.360611,1.360611 0 0 0 -0.2206135,-0.019437 c -0.097186,-0.014577 -0.1963167,-0.02624 -0.2944749,-0.040818 z m 6.360856,0.2497693 c -0.232276,0.1243987 0.404296,0.033043 0,0 z m 4.23636,0.2108946 c -0.30711004,0.077749 0.22936,0.1360611 0,0 z m -2.453959,0.028184 c -0.571457,-0.00195 -1.017543,0.1496673 -0.884398,0.7522236 0.930075,0.2526847 1.94372996,0.1486953 2.90393296,0.1418924 0.56562504,-0.1739639 1.11472904,0.194373 1.03309204,0.4956511 0.976725,0.062199 1.956365,0.1516108 2.922398,0.2721221 1.051598,0.240048 1.004949,-1.3285415 0.250782,-1.455856 C 5.7329795,8.0960314 4.5764605,8.1582306 4.2246455,8.1329623 2.9340085,8.047438 1.6424005,8.7034469 0.37606046,8.2641641 0.00966646,8.2554161 -0.68618854,8.1018626 -1.2566735,8.1008906 Z m 9.285198,0.2585162 c -0.377084,0.2653192 -2.367464,0.9786681 -0.853298,0.9116094 0.223529,-0.195345 1.082658,-0.6249091 0.853298,-0.9116094 z m 3.0234715,0.1438359 c -0.884398,0.5306383 -0.131202,0.5228634 0,0 z m -2.7571815,0.016521 c -0.200204,0.1457796 0.167161,0.1535546 0,0 z m 3.9972805,0.1720202 c -0.45872,0.2079789 0.06803,0.4830167 0,0 z m -1.971914,0.017493 c -0.4276195,0.2381072 -0.215754,0.5607661 0,0 z m -17.9056398,0.013606 c 0.3712526,0.2283882 -0.5189759,0.073862 0,0 z m -0.576316,0.038875 c 0.6628121,0.077749 -0.3702803,0.050537 0,0 z M 9.2326655,8.8842127 c -0.6356,0.1943729 -0.411099,0.3654211 0,0 z m -12.31936,0.035959 c -0.379028,0.059284 -0.02333,0.2040917 0,0 z M 10.54857,9.0008367 c -0.6511485,0.224501 0.456777,0.4247052 0,0 z m -12.6828375,0.038875 c -0.291559,0.3401529 0.461636,0.1263425 0,0 z m 1.34311796,0.0311 c -0.44317096,0.1098206 -0.03596,0.2011759 0.0243,0.011661 z M -9.4213109,9.1796596 c -0.8474661,0.1263422 0.1768796,0.5325818 0.159386,0.1749356 0.00292,-0.00972 0,-0.019437 -0.00486,-0.0311 a 0.41790195,0.41790195 0 0 0 -0.050537,-0.1350889 z m 19.5121329,0.035959 c -0.1904855,0.373196 0.410127,0.1924292 0,0 z m 1.569562,0.074834 c -0.758055,-0.00972 -0.233248,0.5520192 0,0 z m -13.7956235,0.1253705 0.06997,0.084552 z m 3.184802,0.012633 c -1.39948604,0.2322757 0.550075,0.1214833 0,0 z m -4.649402,0.058312 c -0.6200499,-0.00875 -2.0292541,0.1088489 -2.1186657,0.1273142 0.741533,-0.022353 1.8844463,0.166189 2.3888437,-0.097186 l -0.10982,-0.019437 z m 3.24991596,0.00583 c -0.558822,0.00875 -1.82710596,0.3304339 -0.612274,0.259488 0.485932,0.013605 2.11866504,0.084552 0.865931,-0.2390789 l -0.127314,-0.016521 z m 9.87317704,0.050537 c -0.466496,0.1836825 0.5043975,0.129258 0,0 z m -1.395599,0.00972 c -0.487876,0.1972887 0.362506,0.095243 0,0 z m -14.3233454,0.040818 c -0.6880804,-0.015549 0.066087,0.1263423 0,0 z M 9.0392645,12.253667 c -0.182711,-0.0068 -0.310997,0.05831 -0.340153,0.117596 -0.06414,0.02624 -0.05442,0.03693 -0.0087,0.03888 0.01944,0.04276 0.11954,0.06706 0.339181,0.02332 0.373196,0.0097 0.798873,-0.171048 0.182711,-0.151611 a 0.7463923,0.7463923 0 0 0 -0.172992,-0.02818 z m -1.096264,0.0865 c -0.236163,0.168132 0.71918,0.06803 0,0 z m 0.381943,0.215753 c -0.417902,0.155499 0.252685,0.124399 0,0 z m 0.181739,0.177852 c -0.173964,0.186598 0.544244,0.09621 0,0 z m 3.1051085,0.04276 c -0.424705,0.179795 0.694883,9.77e-4 0,0 z m -3.7358495,0.01069 c -0.223528,0.150639 0.472327,0 0,0 z m -0.774576,0.06803 c -0.741533,0.176879 0.254629,0.405267 0,0 z m -0.735702,0.106905 c -0.283784,0.01069 0.107877,0.199232 0.07095,0.518004 0.423733,-0.0865 0.343068,-0.318772 0.09427,-0.510229 a 1.4354446,1.4354446 0 0 0 -0.165218,-0.0068 z m 2.648333,0.07678 c -0.226445,0.242967 0.325574,0.340153 0,0 z m -1.014627,0.373196 c -0.675447,0.09913 1.362554,0.304194 0.958258,0.133146 0.0058,-0.02332 -0.04082,-0.05151 -0.191457,-0.08164 -0.01749,0.0068 -0.01944,0.0097 -0.03402,0.01652 -0.04665,-0.01263 -0.06026,-0.02041 -0.122455,-0.03499 a 3.663931,3.663931 0 0 0 -0.610331,-0.03304 z m -0.509258,0.09719 c -0.181739,0.304194 0.546188,0.19826 0,0 z m 2.8242395,0.0311 c -0.9961615,0.09038 0.592837,0.04179 0.621993,0.233247 0.431508,0.01749 1.648283,-0.174935 0.488848,-0.204091 -0.369308,-0.03402 -0.740561,-0.03304 -1.110841,-0.02916 z m -0.8892565,0.0029 c -0.122455,0.29739 0.6258805,0.130229 0,0 z m -2.959328,0 c -0.363478,0.247825 0.235191,0.277953 0,0 z m 7.1626445,0.13606 c -0.374169,0.133146 0.432479,0.03887 0,0 z m -7.3910335,0.09524 c -0.408183,0.310997 0.464552,0.148696 0,0 z m 5.1120095,0.08941 c -0.314884,0.20312 0.361534,0.120511 0,0 z M 6.2373775,14.02925 c -0.01166,0.313912 0.617134,0.0097 0,0 z m 5.0196825,0.06997 c -0.72404,0.08941 0.582147,0.327519 0.138977,0.03887 z m -0.698771,0.04665 c 0.15647,0.295447 0.460664,0.06025 0,0 z m -3.8058225,0.101074 c -0.459692,-0.0078 -0.696827,0.54716 -0.069,0.21381 0.05054,-0.0097 0.728899,-0.170076 0.277954,-0.17202 a 0.60255627,0.60255627 0 0 0 -0.208951,-0.04179 z m 1.304243,0.04859 c -0.197289,0.149667 0.164245,0.160358 0,0 z m 4.9769195,0.128286 c -0.457748,0.04276 -1.528743,0.167161 -1.56859,0.468439 0.31294,0.272122 -0.808592,0.03207 -0.298363,-0.21381 -0.386802,0.0049 -1.8523735,-0.03304 -0.71918,0.204091 0.47913,0.276982 -1.2478735,0.472327 -1.0573885,0.11954 -0.650178,0.487876 -1.470431,0.155498 -2.19933,-0.267263 -0.485933,-0.216726 -1.491813,0.242966 -0.573401,0.456776 0.247826,-0.617134 1.128336,-0.138976 1.341174,0.49468 0.515089,0.389718 1.228437,0.230332 1.843628,0.262403 0.6229645,-0.06317 1.2410715,-0.03207 1.5977455,-0.303222 0.591866,0.322659 1.360611,0.430537 1.992323,0.163274 0.139949,-0.03887 0.238108,-0.07969 0.161331,-0.107877 0.122453,-0.24491 0.07775,-0.436368 0.209923,-0.617135 l -0.03402,-0.01361 c 0.0058,-0.02041 -0.0622,-0.04859 -0.212836,-0.08164 -0.385831,-0.146751 -0.302251,-0.13023 0.17202,-0.291559 0.07095,-0.312941 -0.481074,-0.254629 -0.655038,-0.273094 z m -4.4122665,0.106905 c -0.217698,0.08358 0.246854,0.05345 0,0 z m 4.0458735,0.165217 c 0.14578,0.180767 -0.2867,0.05151 0,0 z m -4.1935965,0.03888 c -1.177901,-0.01944 1.083629,0.45872 0.28184,0.02041 l -0.137033,-0.01361 z m 3.9117555,0.06123 c 0.112736,0.0087 -0.233248,0.183683 0.272122,0.210895 0.484961,0.05443 1.155548,0.349872 0.254629,0.292531 a 0.29058762,0.29058762 0 0 1 -0.08358,0.0068 c -0.01944,-0.0078 -0.02235,-0.01166 -0.04471,-0.02041 -0.0243,0.0029 -0.02916,0.0058 -0.04859,0.0097 -0.420817,-0.06803 -1.209971,-0.464552 -0.429564,-0.492736 a 0.37125241,0.37125241 0 0 1 0.07969,-0.0068 z m -4.1207065,0.123427 c -0.353759,0.04762 0.02624,0.209923 0,0 z m -1.272172,0.252685 c -0.794013,0.189513 0.208951,0.518976 0.06123,0.0049 z m 3.2606065,0.01166 c 0.791098,-0.03596 -0.07192,0.453861 -0.166189,0.03693 z m 0.687109,0.138977 c 0.293503,0.04179 0.0097,0.230332 0,0 z m -2.4461835,0.01555 a 0.29155949,0.29155949 0 0 1 0.106905,0.01361 c -0.09913,0.08358 -0.381943,0.06317 -0.231304,0.353759 -0.437339,-0.06414 -0.135089,-0.355703 0.124399,-0.367365 z m -1.277031,0.121483 c -0.340153,0.195345 0.387774,0.194373 0,0 z m -0.887313,0.02721 c -0.559794,0.02624 -0.227416,0.519948 0.392634,0.466495 0.295447,0.08747 1.406288,-0.147723 0.492735,-0.139948 -0.20895,0.02235 -1.09432,0.02138 -0.58895,-0.306138 a 1.504447,1.504447 0 0 0 -0.296419,-0.01944 z m 6.4240275,0.0049 c 0.319743,0 0.535499,0.103989 0.395549,0.172992 a 2.3577444,2.3577444 0 0 0 -0.6356,0.07289 c -0.254628,-0.04859 -0.478157,-0.269207 0.03207,-0.230332 0.07289,-0.0097 0.141892,-0.01458 0.207979,-0.01555 z m -22.1351964,1.208005 c -0.5160602,0.502454 0.6074157,0.206035 0,0 z m 0.9436811,0.191457 c -0.518976,0.46358 1.0719671,0.309054 0,0 z m 0.5549349,0.03888 c -0.5267509,0.165217 0.4412265,0.226445 0,0 z m -0.994218,0.04373 c -0.5665973,0.380971 0.8863408,0.299334 0,0 z m -0.8231695,0.02138 c -0.00778,0.0078 -0.00972,0.01749 -0.014577,0.02624 -0.1088489,0.03887 -0.078721,0.07289 -0.00972,0.09719 0.1039897,0.334322 1.181788,0.949513 0.73473,0.152583 A 1.1341664,1.1341664 0 0 0 -9.7002359,16.9954 Z m -0.6608681,0.170076 c -0.313913,0.222557 0.5704845,0.103018 0,0 z m 2.2382049,0.17202 c -0.044706,0.321687 0.6122747,0.207979 0,0 z m -0.5870066,0.06997 c 0.015549,0.277954 0.4567767,0.13023 0,0 z m 0.077749,0.248798 c -0.4567767,0.142864 0.3984646,0.322659 0,0 z m 1.3644983,1.82905 c -1.0049084,0.10982 -2.6191762,0.553963 -3.1906326,0.8601 0.8785657,0.352787 2.2032178,-0.02721 2.4092532,0.393606 0.4606643,-0.170072 2.6833196,-0.239074 1.1438854,-0.623933 -0.2818408,-0.08455 -0.3605619,-0.369309 -0.3625056,-0.629768 z m 1.2750867,0.552991 c -0.9174403,0.06026 -0.287672,0.259488 0,0 z m -3.8923188,0.248802 c 0.3207155,0.17688 -0.5345255,0.08455 0,0 z m 1.1915067,0.349872 c -0.6074158,-0.02916 -1.8193312,0.700714 -0.4762141,0.378055 0.077749,9.77e-4 0.8095637,-0.322659 0.4762141,-0.379027 z m 1.1545754,0.09913 c -0.6608681,0.24491 -1.3061865,0.887313 -1.9660828,0.84941 0.4839887,-0.0039 1.8640371,0.680305 1.6677204,0.214782 -0.5840909,-0.482045 1.5851118,-0.341125 0.2206133,-0.548132 -0.5539632,-0.612275 1.6716079,-0.356674 0.2594879,-0.496623 z m -2.7464906,0.01749 c -0.761942,0.250741 0.9893589,0.08261 0,0 z m 3.5453636,0.207008 c -0.6666993,0.378055 1.1565194,0.103017 0,0 z m -3.1945201,0.402355 c -0.4110985,0.174936 0.4004082,0.153554 0,0 z m -0.3897175,0.01944 c -0.189514,0.270179 0.4966225,0.182711 0,0 z m 3.3918083,0.350843 c -0.4217894,0.07581 -0.2167258,0.17688 0,0 z m -2.0117604,0.123427 c -0.483017,0.126343 0.4723263,0.107877 0,0 z m 1.8961086,0.136061 c -0.2002042,0.158414 0.2789253,0.07775 0,0 z m -2.556005,0.03304 c -0.2876719,0.153554 0.4985669,0.0087 0,0 z m 1.6239866,0.968949 c -0.4315082,0.208951 0.6394869,0.820254 0.6210216,1.321737 0.5267509,0.519947 0.8008167,1.623014 0.2497693,1.746441 0.1457798,0.762914 1.3178489,1.232325 0.5879784,0.155498 -0.3343217,-0.572428 0.417902,-0.460664 -0.079693,-1.017542 -0.4247049,-0.962147 1.0544738,-1.491813 -0.2993344,-1.945674 -0.3401525,-0.146752 -0.7065457,-0.254629 -1.07877,-0.26046 z m 1.236212,1.468488 c 0.2070074,0.233248 -0.380971,0.165217 0,0 z m 0.3080814,2.713447 c -0.7531954,0.173964 0.53161,0.207979 0,0 z m -0.2721222,0.230332 c -0.5811754,0.155499 -0.6375435,0.459692 0,0 z m 0.086496,0.176879 c -0.8688472,-0.06025 -0.2332477,1.286749 0.058312,0.639487 -0.1399486,-0.221585 0.603528,-0.613246 0.1360609,-0.608387 a 1.1613786,1.1613786 0 0 0 -0.1943729,-0.0311 z m -0.6744742,0.657952 c -0.3041939,0.125373 0.6151904,0.131202 0,0 z"
+         id="path224" />
       <path
          inkscape:connector-curvature="0"
-         style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.424254;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         d="m 12.253068,-41.729055 1.091924,-0.08294 1.218358,0.06163 -1.180483,0.08341 z"
-         id="path1941"
-         sodipodi:nodetypes="ccccc" />
+         style="fill:#2e2e2e;stroke-width:0.971865"
+         d="M 6.1295005,5.753838 C 6.8321595,4.8286226 8.3939465,5.7373167 9.4425885,5.2601306 10.00627,5.272764 11.737161,5.0783918 10.265757,4.9044279 8.9780375,5.2834555 7.8535895,4.4865261 6.6222365,4.4350173 6.3423395,3.5894947 6.0031585,4.221207 6.1295005,5.753838 Z m 1.502503,-1.5384622 c -0.431507,0.1593858 0.362506,0.1554984 0,0 z M 6.8933865,4.602178 c 0.391662,0.1214832 -0.16133,0.1593859 0,0 z m 0.388746,0.1846544 c 0.310025,0.065115 -0.215754,0.2196415 0,0 z m -0.756111,0.042762 c 0.240051,0.3207156 0.446086,0.208951 0.70363,0.2798972 -0.122454,0.3712523 -1.208028,-0.1088489 -0.70363,-0.2798972 z M -4.8768703,4.869441 C -5.9886838,4.8655535 -5.0197344,5.1921002 -4.5386612,5.1882127 -4.1557464,5.0074456 -4.7330341,4.8344538 -4.8768703,4.869441 Z m 1.0068524,0.028184 c -0.8017887,0.4975948 1.0729384,0.4975948 0,0 z m -2.5365676,0.011661 c -0.5792317,0.4558046 0.6472619,0.2944752 0,0 z m 0.2624034,0.00389 c -0.02624,0.279897 0.4898199,0.2089508 0.09913,0.033043 z m 13.7888206,0.00389 c 1.534575,0.1127364 -0.793042,0.4771858 0,0 z m -1.419895,0.00486 c 0.395549,0.1623015 -0.342096,0.1797951 0,0 z M -6.6194241,4.936499 c -0.6637838,0.2760096 0.3761118,0.1098206 0,0 z m -2.1390747,0.00778 c -0.9631182,0.2964186 -1.3042432,1.560815 -1.1195885,2.0214791 0.2944749,0.7736044 0.075805,1.720201 -0.6278247,1.1633224 0.0088,0.5646536 1.1720689,0.6705867 0.7774918,-0.09913 0.4344238,-1.0709954 1.7396383,-0.1729922 2.6191762,-0.4596922 1.2109437,-0.048593 2.4296624,0.1341172 3.6221405,0.08358 0.670587,0.1972884 0.685165,1.2857774 0.660868,0.179795 0.08747,-0.5267508 -0.01263,0.7308423 0.04179,-2.0350852 -0.807619,0.8921722 -2.4024496,-0.2847564 -3.2878186,0.5831191 -0.011661,0.3226592 0.2225572,-1.3664423 -0.3654212,-0.5082855 -0.0622,0.7201521 -0.4140145,0.7697172 -0.8241415,0.1807671 -0.2381069,0.1943729 0.048593,0.9815835 0.2021479,0.8173383 0.6832211,0.3032219 0.770689,0.1389766 0.5520194,-0.483017 0.1117644,0.5248072 1.4519661,-0.085524 1.1856752,0.2478256 -0.417902,0.4655233 1.4121197,0.3479278 0.1720202,0.726955 -1.3227084,-0.011661 -2.7756465,0.068031 -4.0147743,-0.1749356 -0.2760096,-0.2750378 0.8163666,-0.011661 0.00972,-0.3751398 -0.5957533,0.062199 0.3032219,-0.3518152 -0.074834,-0.762914 0.7677733,-0.8785661 0.1904855,1.6337049 0.8669035,0.6462902 0.2585162,-0.034987 -0.5005103,-0.612275 -0.4276204,-0.965062 -0.2225573,-0.3051656 0.7823511,-0.820254 0.032072,-0.7872105 z M 6.9789105,4.9608 c 0.178823,0.1107926 -0.379027,0.1865981 0,0 z m 4.6882765,0.011661 c -0.570485,0.1166238 0.310997,0.097187 0,0 z m -19.3857902,0.00972 c -0.9514561,0.4305361 1.4723752,0.015549 0,0 z M 8.5368105,5.040493 c 0.558822,0.2040917 -0.570485,0.2138104 0,0 z m 0.460664,0.071918 c 0.316828,0.1613297 -0.548132,0.065115 0,0 z M -7.0421853,5.136709 c -0.4985668,0.3945772 0.5908939,0.2429661 0,0 z M 8.1101615,5.20474 c 0.441227,0.1321737 -0.402352,0.2206132 0,0 z m -0.685165,0.0068 c 0.800817,0.081637 -0.544244,0.2915598 0,0 z M 0.96209446,5.4097977 c -1.122504,0.1166239 -1.4957,1.7814285 -2.93114496,1.1924784 -0.145779,-0.2070071 -0.386802,-1.7610193 -0.323631,-0.6025563 l 0.06026,2.332476 c 0.816367,-0.7813794 1.97094196,-0.1039894 2.96515996,-0.2760096 1.27119904,0.054424 2.57738604,0.223529 3.81554204,-0.1117646 0.903834,0.1535548 1.038924,1.433501 0.963118,0.07289 V 5.7849378 C 5.0274055,6.0463695 3.7396845,4.991896 4.5939535,5.9015616 4.6017295,6.2494891 4.0983025,6.1474434 4.3169725,6.5323019 3.5006065,6.4292842 4.3023955,6.7655496 3.8864365,7.0114314 3.0700695,6.6878002 4.4549775,5.4622786 3.1322695,5.4583911 2.0428085,5.2999771 2.0943175,6.2747577 2.1778975,6.9181324 2.1390235,7.6353685 0.75800346,6.9132724 1.7638835,6.6907159 2.2051095,6.5060616 0.98250346,6.7286186 1.4334495,6.078441 1.7590235,5.2853992 1.6404565,6.8627361 1.9417345,5.9870857 1.9057755,5.5478026 1.3100225,5.4408975 0.96306646,5.4097977 Z m -8.76427826,0.086496 c -0.6725305,0.3100251 -0.1389767,0.5481319 0.2556005,0.1389767 l -0.080665,-0.093299 z m 7.66509926,0.00389 c -0.106905,0.3595902 0.355703,0.1156518 0,0 z m -9.21619566,0.037901 c 0.5734003,0.5286946 -0.9096658,2.1808651 -0.150639,0.9116093 -0.6355998,-0.4159582 0.4548326,0.159386 0.014577,-0.4344236 -0.5277228,0.1001023 -0.018465,-0.4587201 0.136062,-0.4771857 z m 12.0589007,0.00195 c 0.04179,0.2818407 -0.410127,0.1817388 0,0 z m -4.10613,0.016521 c -0.84941,0.5034261 1.10501096,0.3741678 0,0 z m 4.772829,0.074833 c 0.17202,0.3440403 -0.549103,0.084552 0,0 z m 4.73687,0.3780556 c -0.256572,0.2760095 0.774577,0.1360611 0,0 z m -10.341615,0.1059384 c 0.02041,0.4888479 0.11468,1.1905344 0.473298,1.1458287 -0.520919,-0.1049614 -0.480101,0.7444485 -0.473298,-0.071918 z m 3.41319,0.021381 c 0.303222,0.678362 -1.02240204,0.295447 0,0 z m -0.56368204,0.011661 c 0.08164,0.3770835 -0.515088,0.1127364 0,0 z m 4.79226604,0.00486 c 0.355703,0.4198454 -0.468439,0.8192821 0,0 z m -2.597795,0.058312 c 0.315856,0.6045 -0.654065,0.7444486 -0.143836,0.093299 z M 13.587592,6.0211115 C 14.24263,6.6664299 12.66432,7.8287803 12.599205,7.1941525 13.059869,6.4458164 12.183247,6.4011107 12.329999,7.1990125 11.563197,7.9084739 10.269645,6.7101646 9.5728185,7.8695995 8.8594695,8.2010054 9.3871925,7.4759941 9.7574725,7.325355 9.4416165,6.9968646 9.0674485,7.1523631 9.2268345,6.6333872 c -0.452889,0.1739639 -0.860101,1.2119155 -0.770689,0.417902 -0.980612,0.2060354 0.857185,1.554012 -0.492735,1.8251624 -0.687109,0.3722243 -2.153653,0.9310467 -0.712378,0.7901261 0.702659,0.07289 1.380049,-0.136061 2.003014,-0.4412266 -1.087517,-0.2565725 0.9174405,-0.4577484 1.2848055,-0.6122749 0.306137,-0.4247049 0.736673,-0.706546 0.826085,0.015549 0.05054,-0.7774921 0.843579,-0.8338602 0.543272,-0.1904855 -0.320715,-0.3673651 -0.381943,0.6705868 0.132174,0.221585 0.780408,-0.1175955 -0.722096,1.4189233 -1.304243,0.8775942 -0.466495,-0.294475 -1.5481805,0.090383 -0.477185,0.1010739 0.91744,-0.095243 -0.08164,0.1069052 -0.5063415,0.028184 1.2313525,-0.011661 2.4646485,0.023325 3.6940575,-0.017493 C 14.618741,9.4197236 12.525344,7.609139 13.868461,8.2350201 13.999662,7.6703665 14.396183,5.0006535 13.58662,6.0211117 Z M 0.08644446,6.2174282 c 0.476214,0.1166238 -0.345984,0.2419943 0,0 z m -4.24705006,0.058301 c 0.6239371,-0.00778 -0.2808691,0.3595902 0,0 z m 0.4956511,0.012633 c -0.04568,0.6219936 -0.4013804,0.6161624 0,0 z m -0.1428642,0.2215853 0.034987,0.015549 z M 11.322175,6.359309 c -0.26046,0.080665 0.155498,0.1914572 0,0 z M -8.2414666,6.4846795 c 0.1934009,0.5976968 0.6919678,0.1428641 0,0 z m 17.8823151,0.050537 c -0.485932,0.5520194 0.8863405,0.4674671 0,0 z m -4.830168,0.00778 c 0.623937,0.1613298 -0.459693,0.7872109 0.411098,1.051558 0.642403,0.640459 -0.717236,0.2040917 -0.76097,0.1263426 C 3.6055675,7.85793 4.3947185,6.5148125 4.8106805,6.5429965 Z M 10.863455,6.669339 c -0.166189,0.2672629 0.779435,0.1457799 0,0 z M 8.7204925,6.733482 c -0.14578,0.2351914 0.334322,0.096215 0,0 z m -5.428838,0.029156 c 0.202148,0.8669037 -0.623937,0.5150884 0,0 z m -4.934158,0.00292 c 0.459692,0.1603574 -0.395549,0.1360609 0,0 z m 0.405268,0.056368 c 0.0243,0.259488 -0.401381,0.165217 0,0 z m -3.2090984,0.027212 c 0.3984646,0.136061 -0.2565725,0.2332475 0,0 z m 0.8251134,0.02624 c 0.742505,0.2400506 -0.5296665,0.4985669 0,0 z M 10.657419,6.890927 c -0.340153,0.1846543 0.461636,0.2828128 0,0 z m 0.954372,0.015549 c -0.04471,0.2274162 0.387774,0.1418921 0,0 z M -4.0255164,6.92785 c 0.3109969,0.2070074 -0.287672,0.2915597 0,0 z m 2.3937039,0.042762 c 0.279897,0.092327 -0.596726,0.2497693 0,0 z m 0.248797,0.014577 c 0.272122,0.2517131 -0.181739,0.3061376 0,0 z m -4.0176899,0.131203 c -0.2371352,0.2167258 0.2760096,0.091355 0,0 z M 4.4928805,7.15721 c -0.19243,0.4081833 0.390689,0.1175958 0,0 z m 1.63662,0.096215 c 0.197289,1.3275676 0.774577,0.9339621 0,1.3129894 V 8.1193575 c 0.04859,0.4315078 -0.211866,1.4752909 0.442199,0.6472619 0.425677,-0.7531953 1.004908,-0.1681327 1.455854,-0.8260853 -0.629769,0.060256 -0.76583,0.2682349 -0.60936,-0.2993344 C 6.5804465,7.4390518 6.9827985,8.0270302 6.8914425,7.9172096 6.6513925,7.6538341 6.2247435,7.6732715 6.1295005,7.253425 Z m -11.9898981,0.00389 c -0.9427091,0.046649 0.5034261,0.1681326 0,0 z m 3.9234191,0.02624 c 0.262403,0.077749 -0.154527,0.1914575 0,0 z m -1.706595,0.00195 c 0.181739,0.2118666 -0.279897,0.2575443 0,0 z m 2.466593,0.063171 c 0.54327296,0.1049614 -0.386802,0.3625056 0,0 z m 2.410226,0.00972 c 0.06803,0.6997427 -0.87273504,0.2439381 0,0 z m -2.783422,0.00972 c 0.217698,0.2157538 -0.285728,0.1710481 0,0 z m -0.44317,0.044706 c 0.01166,0.3207155 -0.497595,0.3673651 0,0 z m 4.05462,0.1234268 c 0.848439,0.2342196 0.519948,0.5559069 -0.202148,0.37514 -0.92813104,-0.1632734 -0.186598,-0.1418923 0.202148,-0.37514 z m -2.55989204,0.00583 c 0.736674,0.3255749 -0.248797,0.2138103 0,0 z M 12.640996,7.5906721 c 0.494679,0.2798971 -0.48982,0.3731961 0,0 z m -13.8850345,0.066087 c 0.160357,0.1312017 -0.21867,0.2624037 0,0 z M 11.491279,7.8414134 c 0.236164,0.3236312 -0.301278,0.2546287 0,0 z m -7.6582955,0.012633 c 0.746393,0.044706 -0.372224,0.1214831 0,0 z m 5.754413,0.1467516 c 0.369308,0.1963167 -0.297391,0.2925312 0,0 z m -6.888579,0.012633 c 0.508285,0.039846 -0.21867,0.096215 0,0 z m -1.213859,0.2283887 c -0.95048404,0.2390789 0.6045,0.2497696 0,0 z m 9.6865775,0.048593 c -0.220614,0.1457798 0.154526,0.194373 0,0 z m -10.30371254,0.00778 c -0.462607,0.046649 0.31099704,0.1535545 0,0 z m 9.81875154,0.020409 c 0.116624,0.2342194 -0.254629,0.071918 0,0 z M 9.3502615,8.5304683 c 0.151611,0.2040916 -0.381943,0.2021479 0,0 z M -10.002486,8.7209418 c -1.079742,-0.128286 -0.680306,1.1059823 0.062199,0.9456245 -0.824141,-0.3129403 -0.326546,-1.3120177 0.4179022,-0.8416349 -0.065115,-0.2410226 -0.3479276,0.014578 -0.4801012,-0.1039896 z m 4.3821391,0.081637 c -0.2624035,0.3770838 0.8824535,0.1963169 0,0 z M 12.518541,9.0212482 c -0.01944,0.3100248 -0.38,0.1953447 0,0 z m -1.221635,0 c -0.587978,0.4839887 0.706546,0.2040916 0,0 z m -21.2877297,0.095243 c -0.7230673,0.038874 0.4441423,0.13023 0,0 z m 23.8592847,0.04179 c -0.02139,0.1331454 0.0039,0.0068 0,0 z m -1.681326,0.087468 c 0.02624,0.4723263 -0.524807,0.2361631 0,0 z m -5.5814205,0.036931 c -0.300306,0.3372371 0.468439,0.1331454 0,0 z m 5.7923145,0.049565 c 0.22936,0.063171 -0.305165,0.279897 0,0 z M 6.0031585,10.235107 c 0,0 0.05831,1.062249 0,1.626903 0.852325,0.663783 2.695953,0.166189 3.877741,0.43248 0.5345255,0.04859 1.8280775,0.352787 1.8912485,0.534525 -0.534525,0.180767 -2.3266445,-0.103017 -0.931046,0.162302 0.859128,0.20312 2.370378,-0.200204 2.835901,0.04859 -0.838719,0.472326 -3.153701,0.256572 -3.203266,0.460664 0.981583,0.172992 2.279023,-0.287672 3.065261,-0.06123 -0.647261,-0.0078 0.825114,0.580203 -0.245882,0.682249 -0.72987,-0.04373 -0.962145,0.194373 -0.06997,0.190485 0.686136,0.112737 0.673503,1.22941 0.65115,0.14578 -0.02916,-1.254678 0.100102,-4.322856 0.100102,-4.322856 z m 4.7446445,0.146752 c 0.653093,-0.232276 1.950533,0.624909 0.61519,0.340153 -0.399436,-0.01361 -1.7396375,-0.141893 -0.61519,-0.340153 z m -1.2614805,0.07386 c 0.9378485,0.134117 0.14578,0.571456 -0.133146,0.04859 z m 3.4170765,0.08164 c 0.582147,0.204092 -1.158463,0.261432 -0.275038,0.02916 z m -5.5182485,0.149667 c 0.224501,0.248798 -0.586035,0.120511 0,0 z m -0.569513,0.06609 c 0.335293,0.184654 -0.485933,0.190486 0,0 z m 4.0497605,1.52194 c 0.482045,0.114681 -0.330434,0.153555 0,0 z m 0.276982,0.0243 c 0.430536,0.206035 -0.09427,0.343068 0,0 z m -1.4373885,0.03887 c -1.493756,-0.06123 0.3809715,1.389767 0.287673,0.222557 -0.02819,-0.128286 -0.151611,-0.235191 -0.287673,-0.222557 z m -3.328637,0.04957 c -0.761942,0.190485 0.491764,0.291559 0,0 z m 0.759027,0.05442 c -1.040868,0.468439 1.759075,0.403324 0.41207,0.04956 l -0.211866,-0.0379 z m 3.4724725,0.217698 c -0.17202,0.150639 0.32849,0.111764 0,0 z m -2.1808645,0.17202 c -0.855241,0.176879 0.595753,0.309053 0,0 z m -0.728899,0.0622 c -0.184654,0.270179 0.349872,0.184655 0,0 z m 1.496672,0.122455 c 0.01944,0.267263 0.481074,0.196317 0.09524,0.03207 z m 1.1944225,0.08164 c -0.256573,0.325575 0.671558,0.09233 0,0 z m 0.80276,0.08747 c -0.471355,0.09524 0.393605,0.159386 0,0 z m -2.8038305,0.01166 c -0.194373,0.255601 0.960203,-0.02624 0,0 z m 1.020459,0.204092 c -1.274115,0.04859 0.6968265,0.216726 0,0 z m 3.3548775,0.112736 c -0.646291,0.142864 0.42762,0.21867 0,0 z m -5.4113445,0.138005 c -0.499538,0.09233 0.328491,0.597697 0.580204,0.250741 a 0.89800323,0.89800323 0 0 0 -0.580204,-0.250741 z m -0.170076,0.211866 -0.0039,-0.04568 z m -0.614219,-0.07386 c -0.165217,0.166189 0.369309,0.155498 0,0 z m 2.546287,0.204091 c -1.012684,0.204092 1.2235775,0.616163 1.7318625,0.586035 0.616162,0.21867 1.528744,-0.119539 0.349871,-0.181739 -0.93299,-0.02624 -1.2974385,-0.03887 -2.0807615,-0.403324 z m 2.8747755,0.156471 c -0.701686,0.147723 0.5734,0.07289 0,0 z m -4.9944135,0.349871 c -0.07969,0.324603 0.773605,0.07095 0,0 z m 0.851354,0.0097 c -0.481073,0.258516 0.461636,0.09719 0,0 z m -1.286749,0.03402 c -0.354731,0.207008 0.319743,0.166189 0,0 z m 2.786336,0.180767 c -0.245881,0.0622 0.174936,0.197289 0,0 z m -19.2545886,1.92236 c 0.077749,-0.0622 -1.1885909,0.668643 -0.1613299,0.636572 -0.925215,-0.06609 -0.497595,1.302299 0,1.350892 -0.07483,0.462608 -0.587978,0.9534 -0.524807,1.203169 0,-0.83872 0.0019,-1.678411 0,-2.51713 v 3.057487 c 0.262404,-0.931047 2.370379,0.132173 1.4626571,-1.288693 -0.2215853,-0.519948 -0.00292,-0.644347 -0.4392831,-0.612275 -0.055396,-0.6045 0.2721224,-1.15166 -0.624909,-1.355752 -0.303222,-0.565625 1.3363142,-0.558822 1.7853159,-0.332377 0.3032219,0.06317 0.8309445,-0.175908 0.1836826,-0.129259 0.6015843,0.05443 1.6667484,-0.103017 2.0049573,0.05831 -0.6569806,0.20312 -1.8047531,-0.351815 -1.5374905,0.93785 0.4149865,0.468439 -1.0826575,-0.803732 -0.6219933,0.21381 -0.325575,0.184655 -0.3041939,0.67739 0.2283882,1.034065 0.048593,0.945624 1.4092042,0.209923 1.5433216,1.137082 1.6677202,0.291559 1.5054187,-1.613296 0.7211236,-2.487003 -0.5588223,-0.393605 -0.1953447,-0.942709 0.1525828,-0.90675 z m 0.6453185,1.738667 0.071918,-0.184655 z m -1.3207644,-1.285779 c -0.03887,0.480101 0.0058,-0.04373 0,0 z m 4.3646455,0.303222 c 0.3207155,0.21381 -0.439283,0.210895 0,0 z m -3.8029075,0.182711 c 0.5209195,0.42762 -0.174936,0.840663 -0.295447,0.204091 0.6171341,0.284756 0.09913,0.05637 0.295447,-0.204091 z m 1.1837313,0.964089 c 0.039846,0.240051 0.3323779,0.111765 0,0 z m 1.4179511,0.294476 c 0.4742701,0.259488 -0.3032218,0.211866 0,0 z m -2.0506351,0.135089 c 0.5063415,0.493707 -0.034987,0.991302 -0.075805,0.13023 l 0.020409,-0.103018 0.054424,-0.02721 z m 1.7551882,0.02527 c 0.2944749,0.109821 -0.2692066,0.204092 0,0 z m 1.2284371,0.14578 c 0.3430683,0.0078 -0.1341172,0.262403 0,0 z m -3.3286374,0.04762 c 0.2653192,0.312941 -0.2381072,0.272123 0,0 z m 3.3908369,0.160358 c 0.22936,0.381943 -0.2293602,0.415958 0,0 z m -3.4083305,1.512221 c -0.2857286,0.117596 -0.8960596,0.04373 -0.2526846,0.186598 -1.254678,0.362506 0.4723261,0.758055 0.199232,1.007824 -0.21381,0.340153 -0.00486,0.131202 0.5500757,0.233248 0.6385153,0.06414 1.2187185,0.06511 0.2011759,-0.09719 -0.5646535,-0.104958 -0.6832211,0.03888 -0.2283882,-0.320712 -0.2594879,-0.551048 -1.7969784,-0.04373 -0.6822494,-0.753195 -0.06317,0.01458 0.4567767,-0.269207 0.2128386,-0.256573 z m 2.4073096,0.08552 c -0.5374415,0.426649 1.0087959,0.281841 0,0 z M -9.1375261,21.0578 c -0.7872108,0.01749 -0.7327863,0.414015 0.00583,0.311969 0.7123771,0.07872 0.6579526,-0.305166 -0.00583,-0.310997 z m 3.0108376,0.738618 c -0.2206135,0.138004 0.5772878,0.03013 0,0 z m -5.0984035,0.682249 V 27.6208 l 3.857332,1.285777 c -1.2857774,0 1.1584629,-1.895136 0.165217,-2.870888 0.8056759,-0.690025 -0.2682347,-1.793091 -0.6608684,-1.393655 0.5724286,-0.528694 0.2264448,-0.725011 -0.2070071,-0.893144 -0.439283,-0.586034 -1.1108418,-0.134117 -0.4305361,0.259488 -0.6871086,-0.02235 -1.181788,0.631712 -1.5899714,0.730843 0.5102294,-0.790127 -0.637543,-0.0068 -0.296419,-0.903835 0.6968277,-0.873706 1.9631675,-0.196316 2.4228597,-0.898975 0.8688474,-0.188542 1.3985138,0.67739 2.2158524,0.76583 1.1176447,0.225473 0.856213,-1.160407 -0.09913,-0.767774 z m 2.3363632,0.490792 c 0.6142187,0.145779 -0.453861,0.162301 0,0 z m -0.5073135,0.04471 c 0.6725304,0.180767 -0.3644494,0.227417 0,0 z m 0.1185675,0.513145 c -0.9300752,-0.07581 -0.4616358,0.713349 0.060256,0.182711 0.1749358,-0.03207 0.063171,-0.24977 -0.060256,-0.182711 z m 0.8892566,0.194373 c 0.279897,0.06609 -0.1681327,0.217698 0,0 z m -1.1302792,0.30711 c -0.4655232,0.269206 -0.2487973,0.311968 0,0 z m 1.0253177,0.138976 c 0.2624035,0.07775 -0.1545265,0.191457 0,0 z m -0.3178,0.01166 c 0.1030177,0.205063 -0.3790272,0.242966 -0.082608,0.04373 z m -0.4149862,0.165217 c 0.2303319,0.367364 -0.548132,0.204091 0,0 z m 0.351815,0.09719 c 0.540357,0.221585 0.309053,0.540357 0,0 z m -0.7036303,0.266291 c 0.4859327,0.23422 -0.4509448,0.108849 0,0 z m -0.7716608,0.248797 c 0.332378,0.163274 -0.208951,0.3178 0,0 z m 2.6259793,0.03596 c 0.052481,0.26046 -0.3663931,0.32266 -0.071918,0.0554 z m 0.1457799,0.07386 c 0.4694105,0.644347 -0.2915595,1.166238 -0.1030177,0.14578 l 0.043734,-0.112736 z m -0.6861369,0.177851 c -0.021381,0.590894 -0.4558047,0.389718 0,0 z m -0.9009187,0.193402 c 0.1457796,0.143836 -0.2419943,0.10982 0,0 z m 0.9650619,0.171048 c 0.1399484,0.162301 -0.1166238,0.310025 0,0 z m -0.5238354,0.0311 c 0.6035283,0.40138 -0.4227611,0.635599 0,0 z m 0.9145251,0.05054 c 0.194373,0.07095 -0.1350892,0.384859 -0.048593,0.0622 z m 0.2449098,0.250742 c 0.2361635,0.09427 -0.1895135,0.220613 0,0 z m -1.6754951,0.141892 c 0.1963168,0.402352 -0.5461882,0.106905 0,0 z m 1.6191271,0.05248 c 0.4033241,0.2556 -0.2293602,0.304193 0,0 z m -1.9456737,0.111764 c 0.2293602,0.598669 -0.7211243,0.272122 0,0 z m 0.1438361,0.07095 c 0.6219936,0.585063 -0.2789253,0.510229 0,0 z m 0.381943,0.07386 c 0.2633752,0.267263 -0.1292583,0.266291 0,0 z m -0.476214,0.40138 c 0.2643474,0.267263 -0.2915595,0.147724 0,0 z"
+         id="path226" />
       <path
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc"
-         id="path1943"
-         d="m 11.884711,-41.026371 1.091924,-0.08294 1.218358,0.06163 -1.180483,0.08341 z"
-         style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.424254;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
+         style="fill:#050505;stroke-width:0.971865"
+         d="m 14.047285,8.272912 c 0.05345,-0.2556005 -1.147773,-0.3498712 -1.483067,0.068031 0.192429,1.3586671 -0.657952,1.3256236 0.741534,1.3256236 0.313911,0 0.701686,-0.2002041 0.704602,-0.5131447 0.0136,-0.2857282 0.02624,-0.6132467 0.03596,-0.8805096 z M 6.8924145,4.602178 c -0.02527,0 -0.03887,0.019437 -0.01652,0.078721 0.285728,0.1117645 0.0933,-0.077749 0.01652,-0.077749 z m -0.367365,0.2274164 c -0.178823,-0.01555 -0.287672,0.201176 0.24977,0.3936053 0.444142,0.1603577 0.758054,-0.4431704 0.02235,-0.058312 -0.03304,-0.2332475 -0.165214,-0.3265465 -0.27212,-0.3352933 z m 1.118617,0.087468 c -0.129258,0.011661 -0.221585,0.066087 -0.171048,0.1914573 l 0.204091,0.05734 c 0.769717,-0.029156 0.427621,-0.2176975 0.106905,-0.2468535 a 0.95825886,0.95825886 0 0 0 -0.139948,-0.00195 z m -2.133244,0.056368 c -0.31294,0.097187 -0.259488,0.2672629 -0.695855,0.2857282 -0.527723,0.5218917 0.26046,0.3119689 0.707518,0.6822495 0.06026,-0.3722244 0.06803,-0.6608684 -0.01166,-0.9679777 z m 3.025416,0.068031 c -0.06123,0.00486 -0.13023,0.043734 -0.184655,0.1409204 0.495652,0.1185676 0.370281,-0.159386 0.184655,-0.1418924 z m 0.460664,0.070946 a 0.27600966,0.27600966 0 0 0 -0.172992,0.05734 c 0.29156,0.1195396 0.304194,-0.046649 0.172992,-0.058312 z m -17.988249,0.7075174 c -0.2011759,-0.033043 -0.3955489,0.3926336 -0.1234268,0.7599985 -0.6540651,0.4567764 -0.1282862,0 0.2526848,0.4023521 0.1603577,0.2449101 0.2410226,-0.7522236 0.1059334,-0.7823514 -0.051509,-0.2546285 -0.1438361,-0.3644494 -0.2351914,-0.3790273 z m -0.8056759,0.029156 a 4.2489937,4.2489937 0 0 0 -0.7998446,2.4296624 v 0.6861366 c 0.04179,-0.1593857 0.21381,-0.2711501 0.592837,-0.243938 1.1779004,0.075806 -0.0243,-0.2526848 -0.447058,-0.2575443 -0.2867,-1.2595368 0.6268533,0.678362 0.6841933,-0.5354975 0.04179,-0.669615 -0.3751403,-1.467516 -0.029156,-2.0778472 z M 3.2450055,5.912252 c -0.163273,0.013605 -0.137033,0.4616359 0.165217,0.835804 0.0865,0.2449098 -0.07775,-0.5267509 0.167161,-0.5374413 C 3.4335475,5.9900012 3.3198385,5.9064208 3.2459775,5.912252 Z m -6.097481,0.1603578 c -0.281841,0.3722243 -1.2634245,0.4140145 -0.398465,0.8348319 0.19243,0.13023 0.388746,0.4247049 0.46358,0.7279268 z m -3.4404019,0.013605 a 0.06025563,0.06025563 0 0 0 -0.029156,0.00195 c -0.1341172,0.038879 -0.2633755,0.5666019 -0.1409204,0.8124838 0.050537,0.058312 0.1166238,0.043734 0.1943729,0.02624 0.077749,-0.018465 0.1807669,-0.1671604 0.2351915,-0.2138101 -0.090384,0.048593 -0.1982605,0.067059 -0.1904856,-0.1273142 0.038874,-0.3459841 -0.00486,-0.4859325 -0.069002,-0.4995386 z m 4.0594799,0.029156 v 1.5578999 c 0.05054,-0.1739639 0.116624,-0.3323779 0.200204,-0.4538609 1.018515,0.1516108 -0.481073,-0.020409 -0.11468,-0.4412268 0.05831,0.058312 -0.01749,-0.2410226 -0.08552,-0.6628118 z m -2.769815,0.085525 c -0.032071,0.00972 0.04179,0.055396 0.3411245,0.1691044 0.4548327,0.02527 -0.074834,-0.1389764 -0.2769815,-0.1661887 a 0.21866962,0.21866962 0 0 0 -0.063171,-0.00292 z m -4.6746706,0.021381 c -0.048593,-0.0068 -0.064143,0.044706 0.022353,0.2186698 0.3401529,0.095243 0.082609,-0.2040917 -0.022353,-0.2186698 z m 1.3450612,0.1963169 c -0.032072,-0.00195 -0.038875,0.048593 0.017493,0.2011759 0.4120708,0.296419 0.079693,-0.1943729 -0.017493,-0.2011759 z m 8.99946936,0.054424 c 0.07678,0.3129406 -1.092376,0.9106374 -0.908694,0.012633 -0.06997,0.1827108 -0.687108,0.3372374 -0.93784896,0.4859327 0.118567,0.7541671 1.26731196,0.3304339 1.53554596,0.6666993 C 0.74925646,7.6110707 1.1525805,7.2786928 1.2672605,6.9113276 1.5539605,5.879207 0.65790046,7.6382827 0.66567546,6.4739883 Z m -7.48141626,0.079694 c -0.025269,0.00486 -0.077749,0.038875 -0.1681327,0.1195396 -0.1146801,0.3877739 0.2769816,-0.1389769 0.1681327,-0.1195396 z M 12.607952,6.6673916 c -0.03207,0.00972 -0.08164,0.065115 -0.146751,0.2021479 0.190485,0.1554986 0.242966,-0.2303319 0.145779,-0.2021479 z M -4.3501194,6.682941 c -0.3148843,-0.018465 -0.8746784,0.098158 -0.6258811,0.251713 0.4732983,0.2526848 0.085524,-0.4519172 0.7016868,-0.049565 0.214782,-0.13023 0.1137081,-0.1904855 -0.075806,-0.202148 z m 7.2530279,0.012633 c -0.08455,-0.016521 -0.160357,0.1078771 -0.07095,0.4674671 l 0.101074,0.090383 c 0.200204,-0.2837845 0.07775,-0.5364696 -0.02916,-0.5578506 z m -0.42762,0.1166238 c -0.01944,9.771e-4 -0.05151,0.0311 -0.100102,0.1117646 0.09719,0.1302298 0.158414,-0.1166238 0.100102,-0.1127363 z M -10.132716,7.0114314 a 0.04276206,0.04276206 0 0 1 0.02527,0 c 0.03596,0.018465 0.02916,0.1195393 -0.07678,0.3693086 -0.507313,0.2662909 -0.0933,-0.3372371 0.05151,-0.3702806 z m 6.8769165,0.1156519 c -0.03402,-0.00778 -0.08358,0.035959 -0.134117,0.1904855 0.21381,0.098158 0.209923,-0.1720202 0.134117,-0.1904855 z m 5.842852,0.050537 c -0.07483,-0.00195 -0.126342,0.058312 -0.07483,0.2371348 0.507313,0.061228 0.238107,-0.2332476 0.07483,-0.2371348 z m 1.025318,0.00778 c -0.198261,-0.00486 -0.422761,0.2138104 0.150639,0.3216875 0.07775,-0.2351914 -0.03207,-0.3187717 -0.150639,-0.3207155 z M 10.245348,7.318546 c -0.01944,0.00972 -0.06317,0.090383 -0.145779,0.2983624 0.0311,0.2818408 0.202148,-0.3275184 0.145779,-0.2983624 z M -0.89805454,7.5031963 c -0.02527,0.00778 -0.06706,0.052481 -0.12925796,0.1642453 0.12925796,0.1273142 0.20409096,-0.1875701 0.12925796,-0.1652173 z m 12.64104654,0.00875 c -0.02527,-0.00583 -0.06025,0.048593 -0.100102,0.2147823 0.17688,0.352787 0.177852,-0.1982604 0.100102,-0.2147823 z m -0.538413,0.1467516 c -0.05637,-0.00972 -0.157442,0.051509 -0.301278,0.259488 0.334322,0.122455 0.425677,-0.2381069 0.301278,-0.259488 z m -5.0760505,0.045675 v 1.001019 C 6.2422375,8.4624258 6.5075565,8.2991523 6.9419795,8.4167481 6.9487835,7.7889233 6.4239755,8.0979764 6.1994755,8.2904056 6.1071475,7.8822223 6.4929785,7.8598695 6.1285285,7.704371 Z m 0.521892,0.00195 c -0.0097,0.00389 0.04957,0.059284 0.24005,0.2108948 0.430537,0.2371349 -0.212838,-0.2225573 -0.24005,-0.2108948 z m 5.5950255,0.2429663 c -0.107876,-0.00583 -0.210894,0.09913 0.0097,0.2750378 l 0.01166,0.1175956 C 12.46701,8.073688 12.354276,7.9560921 12.245426,7.9492892 Z m -4.4443375,0.029156 c -0.01944,0.00778 -0.02818,0.035959 -0.0068,0.101074 0.223529,0.046649 0.06414,-0.1234271 0.0068,-0.101074 z m -5.103263,0.035959 a 0.21964149,0.21964149 0 0 0 -0.07386,0.019437 c 0.451917,0.1137081 0.252685,-0.036931 0.07386,-0.019437 z m 7.240394,0.056368 c -0.01749,0.00195 -0.02916,0.025269 -0.0243,0.084552 0.1681315,0.085524 0.07386,-0.091355 0.0243,-0.084552 z m 3.3364115,0.024297 c 0.02916,0.00972 0.04859,0.07289 0.03402,0.2254727 -0.310996,0.1710484 -0.123426,-0.258516 -0.03402,-0.2254727 z m -3.5375875,0.095243 c -0.0311,0.00195 -0.08066,0.034987 -0.14578,0.1195393 0.190486,0.1312017 0.242967,-0.1263425 0.14578,-0.1195393 z m 3.0030625,0.2235287 c 0.01555,-0.00875 0.05345,0.010689 0.126342,0.079693 0.170077,0.5345255 -0.192429,-0.040818 -0.126342,-0.079693 z M 8.4736395,8.7316324 c -0.549104,-0.054425 -0.721124,0.7211239 -1.18276,0.9349339 h 0.467467 c 0.07192,-0.089412 0.518004,-0.2837845 0.612275,-0.5811752 0.0554,0.5908939 0.325575,0.2410227 0.440255,-0.2351914 A 0.86690355,0.86690355 0 0 0 8.4736395,8.7316324 Z M 7.2685265,9.353626 c -0.07386,0.00195 -0.189514,0.060256 -0.278925,0.2215851 0.414014,-0.077749 0.403324,-0.2274163 0.278925,-0.222557 z m 3.2314505,0.1827106 c -0.190486,-0.034987 -0.172992,0.2449098 -0.6025555,0.061228 -0.01944,-0.034987 -0.210895,0.015549 -0.449002,0.06803 h 1.2818895 a 0.64240276,0.64240276 0 0 0 -0.230332,-0.129258 z m 2.993345,1.7270044 c 0,0 -0.929104,-0.08941 -1.137083,-0.06997 -0.6045,0.389717 -1.337286,-0.04276 -1.581224,-0.387774 -0.276982,0.208951 -1.8766715,0.09038 -0.8843965,0.214782 -0.86496,0.384858 1.1467995,0.134117 -0.04568,0.456776 1.0700225,0.09719 0.3246025,0.272122 -0.278925,0.158414 0.9699205,0.44803 -0.770689,0.132174 -1.215803,0.06026 1.209,-0.0049 -0.202148,-0.126343 -0.592838,-0.101074 -1.340202,0.138977 0.602556,-0.04179 0.804704,0.377084 0.83386,0.104961 1.7619915,0.282812 2.2566705,-0.08844 0.14092,0.157442 1.195394,0.206035 0.530638,0.0049 0.962146,0.07678 0.134117,-0.387774 1.091404,-0.3178 0.933963,-0.129258 0.410127,0.186598 -0.171048,0.167161 0.388746,0.05734 0.450945,0.249769 -0.142864,0.167161 -0.341125,0.226444 1.290637,-0.02235 1.216776,0.184654 0.552019,-0.142864 -0.05637,0.05734 0.430535,0.162301 0.01165,0.366394 0.06123,0.783323 0.100103,1.210944 V 10.909582 Z M 8.9566565,10.855157 c -0.08164,-0.0029 -0.241995,0.02138 -0.512173,0.100103 0.29739,0.170076 0.758054,-0.09136 0.512173,-0.100103 z m 2.5414255,0.02721 c -0.04082,-0.01166 -0.06414,0.03887 -0.02138,0.225473 0.281841,0.13023 0.110793,-0.200204 0.02138,-0.225473 z m -3.5162065,0.0097 c -0.06512,0 -0.112736,0.04859 -0.09913,0.180767 0.644346,0.230333 0.292531,-0.18271 0.09913,-0.180767 z m 5.2422395,0.123427 a 0.70265839,0.70265839 0 0 0 -0.356675,0.136061 c 0.59964,0.147724 0.62491,-0.144808 0.356675,-0.136061 z m -3.047769,0.0068 a 0.25948794,0.25948794 0 0 1 0.07289,9.77e-4 0.34987138,0.34987138 0 0 1 0.218669,0.150639 c -0.4713535,0.05151 -0.444142,-0.129253 -0.291559,-0.151606 z m 1.924293,0.04276 c -0.05831,-0.0068 -0.148696,0.03207 -0.22936,0.171049 l 0.06123,0.01944 c 0.273094,-0.03596 0.265319,-0.178823 0.168133,-0.190486 z m -1.392683,0.0088 c 0.06414,-0.01555 0.301278,0.111765 0.511201,0.30711 0.182711,0.103017 -0.297391,0.29739 -0.249769,0.01944 -0.256573,-0.217699 -0.310997,-0.314886 -0.262404,-0.326548 z m -1.4218375,0.0311 c -0.05151,-0.002 -0.11468,0.02721 -0.180767,0.111765 0.37028,0.171048 0.333349,-0.106905 0.180767,-0.111765 z m -0.779436,0.002 c -0.06026,0.0068 -0.07483,0.04568 0.02138,0.143836 0.753196,0.113708 0.159386,-0.163273 -0.02138,-0.143836 z m -1.119588,0.08358 c -0.184655,-0.0049 -0.254629,0.02818 0.165217,0.14578 0.773604,-0.02041 0.142864,-0.138005 -0.165217,-0.14578 z m 0.858156,0.162302 a 1.1769285,1.1769285 0 0 0 -0.113708,0.01263 c 0.342097,0.07775 0.346956,-0.0243 0.113708,-0.01263 z m 5.0410645,0.27115 c 0.09427,0.0029 0.27698,0.05831 0.498567,0.213811 -0.565627,-0.07581 -0.655038,-0.21867 -0.498567,-0.213811 z m -5.2694525,0.43248 c -0.112736,-0.0029 -0.13023,0.0243 0.197289,0.118568 0.440254,-0.02041 -0.0097,-0.112737 -0.197289,-0.118568 z m 3.2751845,0.04471 c -0.04373,9.77e-4 -0.09038,0.02916 -0.122455,0.109821 0.361534,0.135089 0.254629,-0.111765 0.122455,-0.109821 z m 2.200303,0.299335 c -0.241994,-0.0049 -0.72404,0.06706 -0.113708,0.111764 0.316827,-0.07872 0.258515,-0.108849 0.113708,-0.111764 z m -1.021431,0.06706 c -0.103989,-0.01361 -0.29739,-0.0058 -0.266291,0.06123 0.385831,-0.01458 0.371253,-0.04859 0.266291,-0.06123 z m -22.497702,4.179007 a 0.56659728,0.56659728 0 0 0 -0.568541,0.567569 v 2.691094 a 0.84552252,0.84552252 0 0 1 0.135089,-0.215754 c -0.200204,-0.29739 0.03888,-0.415958 0.221586,-0.617134 -0.06317,-0.06414 -0.174936,-0.435395 0.02916,-0.148695 a 0.76291402,0.76291402 0 0 1 0.0039,0.11468 c 0.112733,-0.136061 0.187567,-0.312941 0.09427,-0.601585 -0.394577,0.201176 -0.467467,-0.09136 -0.478158,-0.80762 -0.01944,-0.608387 0.279898,-0.876622 0.7220961,-0.981583 z m -0.178823,2.39176 c -0.0097,0.01263 -0.02235,0.02235 -0.03304,0.03402 0.01749,0.01749 0.02916,0.01166 0.03304,-0.03402 z m 1.8630654,-2.390788 c 0.4985666,0.04859 0.9825553,0.09719 1.3295113,0.02916 0.4937074,0.468439 0.3022499,0.06026 0.8532973,-0.02916 z m 1.4558536,1.016571 c -0.1146801,0.0078 -0.2128383,0.07289 -0.1846543,0.237135 l 0.05734,0.06512 c 0.7201519,-0.06512 0.380971,-0.320716 0.1273143,-0.30225 z m -0.2196415,0.793041 c -0.035959,0.0029 -0.051509,0.0243 0.025269,0.07872 0.1535548,-0.03499 0.034987,-0.08358 -0.025269,-0.07872 z m 0.3430685,0.08067 c -0.016521,0.0049 -0.040818,0.03596 -0.070946,0.113708 0.1107927,0.09524 0.1234268,-0.127314 0.070946,-0.113708 z m -3.832064,2.107004 v 1.039895 c 0,0.314884 0.253657,0.567569 0.568541,0.567569 h 0.2342198 c -0.1846544,-0.04665 -0.2167258,-0.135094 0.052481,-0.295452 -0.00292,-0.13023 -1.5996898,-0.369308 -0.3469558,-0.900919 -0.200205,0.04665 -0.403324,-0.142864 -0.508286,-0.411098 z"
+         id="path228" />
       <path
          inkscape:connector-curvature="0"
-         style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.424254;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         d="m 19.288268,-41.13937 1.091924,-0.08294 1.218358,0.06163 -1.180483,0.08341 z"
-         id="path1945"
-         sodipodi:nodetypes="ccccc" />
+         style="fill:#afafaf;stroke-width:0.971865"
+         d="m -2.4821945,10.264263 h 7.971236 v 2.956414 h -7.971236 z"
+         id="path230" />
       <path
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc"
-         id="path1947"
-         d="m 20.23096,-41.596687 1.091924,-0.08294 1.218358,0.06163 -1.180483,0.08341 z"
-         style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.424254;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
+         style="fill:#cecece;stroke-width:0.971865"
+         d="M 11.172508,4.3057592 C 10.331844,3.9636628 8.3074505,3.9899031 7.8477575,4.0705679 c 0.487877,0.2546286 1.473348,0.7084896 2.2936015,0.6093593 0.332378,-0.070946 1.441276,-0.3770836 1.031149,-0.374168 z M -7.68556,4.5137383 c -0.4975948,-0.048593 -1.4548818,0.7531953 -0.2546285,0.3712525 l 0.2390786,-0.015549 c 0.7940138,-0.0311 2.5433708,-0.155499 0.899947,-0.1486959 C -6.9644361,4.7158862 -7.2491927,4.4389047 -7.4455094,4.7081113 -7.4795246,4.5817689 -7.5708799,4.5254007 -7.68556,4.5137383 Z m 18.706457,0.2167259 c -0.09233,0.00583 -0.02721,0.1214831 0.147723,0.040818 a 0.30613747,0.30613747 0 0 0 -0.147723,-0.040818 z m 0.711405,0.4004085 C 11.401868,5.1114353 11.047137,5.2027906 10.686575,5.4311788 9.7506695,5.2844272 7.5931295,5.6197206 7.3696005,6.0317913 6.5726715,5.9151675 6.4307785,6.9832471 6.1858685,6.4817648 c -0.235191,1.0855733 0.597697,0.7872108 1.601634,1.1652661 l 0.08941,0.038875 0.06026,-0.098159 c 0.05054,-0.8008167 0.845523,-1.6929887 1.66772,-1.430585 0.367365,-0.3450123 0.8756505,-0.4480297 1.3333985,-0.015549 0.66184,-0.727927 1.839741,0.129258 2.384958,0.4713546 C 13.061813,5.7596697 12.458285,5.1746071 11.732302,5.1308727 Z M 8.1033585,5.9404361 c 0.435396,0.021381 1.011712,0.2624037 0.01652,0.3304341 l -0.278925,-0.047621 c -0.209923,-0.2293602 0,-0.2954469 0.262403,-0.2818407 z m 2.4714525,0.3693088 c -0.104962,0.021381 -0.08552,0.1972885 0.143836,0.049565 -0.05928,-0.045678 -0.108849,-0.055396 -0.143836,-0.048593 z M 6.5318525,6.6528132 c 0.07289,0.00778 0.09233,0.1642452 -0.08552,0.058312 0.0311,-0.046649 0.06123,-0.060256 0.08552,-0.058312 z m 6.5445385,0.3634774 c -0.110792,-0.022353 -0.403324,0.5073135 0.03693,0.1214831 0.0049,-0.081637 -0.01069,-0.1166236 -0.03693,-0.1214831 z m -2.052579,0.1195393 c -0.165217,0.00583 -0.503426,0.5102293 0.06803,0.2089511 0.02332,-0.1574422 -0.01263,-0.2108948 -0.06803,-0.2089511 z M 8.0790615,8.4381292 c -0.06803,-0.035959 -1.087517,0.6803054 -0.346955,0.3557025 0.287672,-0.2468538 0.37028,-0.3430683 0.346955,-0.3547307 z m -10.316346,1.7649068 c 0,0 -0.04665,1.475291 -0.04665,2.34997 0.02624,0.597697 2.41897196,0.03596 1.98843596,0.291559 -0.05734,0.408184 0.492735,0.04568 0.8912,0.123427 -0.37514,-0.384858 3.08761504,-0.01555 1.13222304,-0.274066 -0.75513904,-0.07192 1.428641,-0.06997 1.836825,-0.07678 0.543272,0.103017 1.827106,-0.13023 0.467467,-0.186598 -0.607416,-0.02916 -2.961273,-0.01847 -1.249819,-0.115652 0.728899,-0.241023 2.591964,0.284756 2.799943,-0.386802 0.08552,-0.835805 0.116624,-1.71437 0.116624,-1.71437 z m 12.226061,5.378301 c -0.0933,0.002 -0.03693,0.155498 0.1418915,0.06317 -0.06511,-0.04859 -0.111764,-0.06414 -0.1428635,-0.06317 z m -0.589922,0.02818 c -0.151611,0.0058 -0.204092,0.546188 0.172992,0.223529 -0.06123,-0.168133 -0.122455,-0.225473 -0.172992,-0.223529 z m 3.6843395,0.08261 c -0.159386,-0.002 -0.968949,0.32849 -0.14092,0.143836 0.174935,-0.105934 0.194373,-0.143836 0.14092,-0.143836 z m -20.7745852,3.834982 c -0.4198457,0.0058 -1.0398953,0.238107 -1.3994855,0.428592 -1.0787703,0.296419 -1.7610193,0.289616 -0.388746,0.42179 0.6424027,0.110792 1.3887951,0.186598 1.9991263,0.170076 -0.087468,-0.27601 1.1341664,-0.535497 0.1914573,-0.499539 0.13023,-0.393605 -0.075805,-0.524807 -0.4023521,-0.520919 z m -0.8960595,0.709461 c 0.222557,0.01555 0.6219937,0.13023 0.043734,0.128287 -0.2449099,-0.109821 -0.1768794,-0.136062 -0.043734,-0.127315 z m -0.070946,0.418874 c -0.085524,-0.01263 -0.3790272,0.152583 -0.015549,0.0865 0.048593,-0.05831 0.043734,-0.08261 0.015549,-0.0865 z m -1.7882313,0.147724 c -0.09621,0.01166 -0.08552,0.131201 0.129258,0.03693 a 0.20506351,0.20506351 0 0 0 -0.128287,-0.03693 z m 2.7115031,0.04082 c -0.1846543,-0.0097 -0.8066479,0.217698 -0.027212,0.109821 0.1030177,-0.07775 0.090384,-0.106906 0.028184,-0.109821 z m -1.5481809,0.0097 c -0.2060354,0.0243 0.3012782,0.212839 0.1360612,9.78e-4 a 0.69779905,0.69779905 0 0 0 -0.1360612,0 z m 1.3518642,0.355703 c -0.1214831,0.002 -0.2983624,0.04859 -0.5277226,0.171048 -0.3625057,0.06997 -0.2701784,0.356675 0.040818,0.184655 0.714321,0.03887 0.8513539,-0.360562 0.4869046,-0.355703 z m -1.0233739,0.249784 c -0.1827106,-0.01361 -0.5870064,0.13509 -0.1428642,0.242967 0.2818408,-0.168133 0.2526848,-0.23422 0.1428642,-0.242967 z m 1.0690513,0.408184 c -0.194373,-0.02138 0.3518153,0.21381 0.1341175,0.02721 a 1.1127854,1.1127854 0 0 0 -0.1331455,-0.02721 z m -0.050537,1.139997 c -0.2818411,0.0049 -0.4256769,0.122455 0.1846543,0.423733 0.3799992,0.292532 0.3041936,1.305215 0.8999469,0.705574 0.2186695,-0.351815 -0.2575442,-0.727926 -0.1185676,-0.78721 -0.18757,0.05637 -0.4004083,0.381943 -0.5141164,0.05054 0.4985666,-0.217698 -0.089412,-0.398465 -0.4519172,-0.392634 z m 0.8785658,2.971963 c -0.1370327,0.02624 -0.087468,0.423734 0.289616,0.279897 -0.1263426,-0.227416 -0.2274165,-0.291559 -0.289616,-0.279897 z"
+         id="path232" />
+      <path
+         style="stroke-width:0.971865"
+         inkscape:connector-curvature="0"
+         d="M -6.2287344,2.298858 A 6.2529792,6.2529792 0 0 0 -12.497264,8.5654435 V 24.298966 a 6.2539512,6.2539512 0 0 0 6.2685296,6.268528 H 9.5047875 A 6.2539512,6.2539512 0 0 0 15.772344,24.298966 V 8.5654435 A 6.2539512,6.2539512 0 0 0 9.5038155,2.2978862 Z m -0.1020457,1.7746255 h 3.0293026 c 0.257545,0.053453 0.449974,0.280869 0.449974,0.5549349 v 4.4705789 c 0,0.3139123 -0.252685,0.567569 -0.567569,0.567569 h -6.6086825 a 0.56659728,0.56659728 0 0 1 -0.568541,-0.5685407 v -0.80762 a 4.2567686,4.2567686 0 0 1 4.2655159,-4.217894 z m 4.5483276,0 h 6.843874 c 0.257544,0.053453 0.449973,0.280869 0.449973,0.5549349 v 4.4705789 c 0,0.3139123 -0.252685,0.567569 -0.567569,0.567569 h -6.608682 A 0.56659728,0.56659728 0 0 1 -2.2324255,9.0980256 V 4.6284184 c 0,-0.2740659 0.192429,-0.5014823 0.449973,-0.5549349 z m 8.362899,0 h 3.026387 A 4.2567686,4.2567686 0 0 1 13.873321,8.3399707 V 9.1028848 A 0.56659728,0.56659728 0 0 1 13.305752,9.6665663 H 6.6980415 A 0.56659728,0.56659728 0 0 1 6.1295005,9.0980256 V 4.6284184 c 0,-0.2740659 0.193401,-0.5014823 0.450946,-0.5549349 z M -10.027755,10.3459 h 6.6086825 c 0.314884,0 0.567569,0.252685 0.567569,0.567569 v 4.470579 c 0,0.314885 -0.252685,0.56757 -0.567569,0.56757 h -6.6086825 a 0.56659728,0.56659728 0 0 1 -0.568541,-0.56757 v -4.470579 c 0,-0.313912 0.253657,-0.567569 0.568541,-0.567569 z m 8.3638705,0 h 6.60771 c 0.314884,0 0.567569,0.252685 0.567569,0.567569 v 4.470579 c 0,0.314885 -0.252685,0.56757 -0.567569,0.56757 h -6.608682 a 0.56659728,0.56659728 0 0 1 -0.567569,-0.56757 v -4.470579 c 0,-0.313912 0.252685,-0.567569 0.568541,-0.567569 z m 8.361926,0 h 6.6086825 c 0.312939,0 0.563681,0.250741 0.566597,0.563682 v 4.479326 a 0.56562541,0.56562541 0 0 1 -0.567569,0.56271 H 6.6980415 a 0.56659728,0.56659728 0 0 1 -0.568541,-0.56757 v -4.470579 c 0,-0.313912 0.253657,-0.567569 0.568541,-0.567569 z m -16.7257965,6.300601 h 6.6086825 c 0.314884,0 0.567569,0.252685 0.567569,0.567569 v 4.470579 l -0.567569,0.567569 h -6.6086825 a 0.56659728,0.56659728 0 0 1 -0.568541,-0.567569 V 17.21407 c 0,-0.314884 0.253657,-0.567569 0.568541,-0.567569 z m 0,6.286023 h 6.6086825 v 5.605718 H -6.440601 a 4.2538529,4.2538529 0 0 1 -4.155695,-4.212064 v -0.826085 c 0,-0.314884 0.253657,-0.567569 0.568541,-0.567569 z"
+         id="path234" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#f3f3f3;stroke-width:0.971865"
+         d="m 7.9235635,4.1454015 c -0.134117,0.0068 0.101074,0.179795 0.272122,0.066087 a 0.82511335,0.82511335 0 0 0 -0.272122,-0.066087 z m 1.496672,0.050537 c -0.575344,0 -0.986443,0.1477235 -0.04179,0.215754 0.300306,-0.2070072 0.8630155,0.1963167 1.0019925,-0.00389 C 10.172458,4.2503604 9.7671915,4.1969079 9.4212075,4.195936 Z m 1.2760585,0.1817387 c -0.13023,-0.0068 -0.257544,0.230332 0.113708,0.1107926 -0.02624,-0.078721 -0.06997,-0.1088489 -0.113708,-0.1107926 z M 10.039313,4.566219 c -0.2565715,0.0068 -0.3741675,0.2002042 0.279897,0.07289 a 0.50634165,0.50634165 0 0 0 -0.279897,-0.07289 z m 1.98552,0.5957532 c -0.202148,0.00972 0.40624,0.1943729 0.140921,0.00778 a 0.95923073,0.95923073 0 0 0 -0.140921,-0.00778 z m -0.08747,0.4791295 c -0.351815,-0.011661 -0.88634,0.068031 0.0311,0.1768793 l 0.04859,-0.04179 C 12.292096,5.688723 12.14826,5.6479049 11.937365,5.6401299 Z m 0.863016,0.2050636 c -0.08941,0.014577 -0.09719,0.2847563 0.111765,0.097187 -0.04276,-0.077749 -0.08164,-0.102046 -0.111765,-0.097187 z m -1.82419,1.3343705 c -0.05442,0.015549 -0.0049,0.1875701 0.09136,0.054424 -0.04373,-0.047621 -0.07289,-0.060256 -0.09136,-0.054424 z M -9.1239202,7.7451894 c -0.4985666,0.00195 -0.8882848,0.4013801 0.026241,0.3615337 0.2040917,-0.00972 0.4081833,-0.00875 0.6093592,-0.038875 A 0.73084247,0.73084247 0 0 0 -9.1239202,7.7451894 Z M 5.3218815,8.9512737 c -0.894116,0.2283885 -2.796056,-0.1720199 -3.117743,0.2876722 0.335293,0.085524 0.686136,0.044706 1.026289,0.034987 0.556879,-0.1554983 2.046748,0.019437 2.091454,-0.3226592 z m -13.31941,0.4373393 c -0.3547308,0.011661 -0.649206,0.1554986 0.058312,0.2245008 0.1438362,0.024297 0.3187718,0.04665 0.4431706,-0.052481 C -7.5494988,9.424572 -7.7846902,9.3827818 -7.9975285,9.389585 Z m 0.4247049,10.22402 a 4.0828047,4.0828047 0 0 0 -0.3858305,0.03499 c -0.5850627,-0.04762 -1.9689984,0.611303 -0.6083875,0.510229 0.2254727,-0.0058 0.4567767,0.02235 0.6803057,-0.03207 -1.0360081,-0.05831 0.8358037,-0.52092 0.3139123,-0.513145 z m -0.6900241,0.202148 c 0.1127363,-0.0078 -0.025269,0.257544 -0.2021479,0.124399 0.1001019,-0.08844 0.1652169,-0.121483 0.2031196,-0.124399 z m 0.2837845,3.223676 c -0.069974,-0.01166 -0.2293602,0.136061 0.022353,0.07775 0.015549,-0.05248 9.772e-4,-0.07386 -0.022353,-0.07775 z"
+         id="path236" />
       <g
-         id="g1969">
+         transform="matrix(0.97186498,0,0,0.97186498,-19.968324,-0.15024167)"
+         id="g290">
         <path
+           d="m 38.285,17.946 v 13.708 a 0.652,0.652 0 0 1 -0.654,0.654 H 14.556 A 0.652,0.652 0 0 1 13.902,31.654 V 17.946 Z"
+           id="path238"
            inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 12.846087,-40.227186 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1927"
-           sodipodi:nodetypes="ccccc" />
+           style="fill:url(#b)" />
         <path
+           d="m 38.285,17.946 v 13.708 a 0.652,0.652 0 0 1 -0.654,0.654 H 14.556 A 0.652,0.652 0 0 1 13.902,31.654 V 17.946 Z"
+           id="path240"
            inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1929"
-           d="m 14.244018,-40.435874 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
+           style="fill:url(#c)" />
         <path
+           d="m 14.34,17.574 h 23.495 c 0.243,0 0.468,0.046 0.438,0.234 -0.03,0.187 -0.331,0.261 -0.573,0.261 l -23.359,0.01 c -0.242,0 -0.438,-0.063 -0.438,-0.238 0,-0.174 0.196,-0.267 0.437,-0.267 z"
+           id="path242"
            inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 15.852941,-39.971117 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1931"
-           sodipodi:nodetypes="ccccc" />
+           style="fill:url(#d)" />
+        <circle
+           cx="27.805"
+           cy="26.004999"
+           r="7.1560001"
+           id="circle244"
+           style="fill:url(#e)" />
+        <circle
+           cx="27.875"
+           cy="25.075001"
+           r="6.724"
+           id="circle246"
+           style="fill:url(#f)" />
+        <circle
+           cx="27.875"
+           cy="25.285"
+           r="6.724"
+           id="circle248"
+           style="fill:url(#g);stroke:#484846;stroke-width:0.053;stroke-linecap:round;stroke-linejoin:round" />
+        <circle
+           cx="27.875"
+           cy="25.580999"
+           r="6.724"
+           id="circle250"
+           style="fill:url(#h)" />
+        <circle
+           cx="27.875"
+           cy="25.580999"
+           r="6.2529998"
+           id="circle252"
+           style="fill:none;stroke:#2d2d2c;stroke-width:0.26499999;stroke-linecap:round;stroke-linejoin:round" />
+        <circle
+           cx="27.875"
+           cy="25.580999"
+           r="5.5749998"
+           id="circle254"
+           style="fill:url(#i)" />
+        <circle
+           cx="27.875"
+           cy="25.580999"
+           r="4.184"
+           id="circle256"
+           style="fill:url(#j);stroke:#0d0e12;stroke-width:0.52899998;stroke-linecap:round;stroke-linejoin:round" />
+        <circle
+           cx="27.875"
+           cy="25.580999"
+           r="3.763"
+           id="circle258"
+           style="fill:url(#k)" />
+        <circle
+           cx="-31.353001"
+           cy="-21.176001"
+           r="3.517"
+           transform="rotate(-171.493)"
+           id="circle260"
+           style="fill:url(#l)" />
+        <circle
+           cx="31.737"
+           cy="20.594999"
+           r="3.178"
+           transform="rotate(9.562)"
+           id="circle262"
+           style="fill:url(#m)" />
+        <circle
+           cx="-24.416"
+           cy="-28.900999"
+           r="2.582"
+           transform="rotate(172.735)"
+           id="circle264"
+           style="fill:url(#n)" />
         <path
+           d="m 19.075,17.784 a 2.137,0.19 0 0 1 -2.137,0.192 2.137,0.19 0 0 1 -2.14,-0.192 2.137,0.19 0 0 1 2.132,-0.19 2.137,0.19 0 0 1 2.144,0.189"
+           id="path266"
            inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1933"
-           d="m 16.719505,-40.428528 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
+           style="fill:#0e0e0e;fill-opacity:0.747" />
         <path
+           d="m 19.012,17.195 a 2.086,0.145 0 0 1 -2.085,0.146 2.086,0.145 0 0 1 -2.088,-0.145 2.086,0.145 0 0 1 2.082,-0.145 2.086,0.145 0 0 1 2.09,0.145"
+           id="path268"
            inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 19.854061,-40.512011 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1935"
-           sodipodi:nodetypes="ccccc" />
+           style="fill:url(#o)" />
         <path
+           d="m 19.012,17.195 v 0.478 c 0,0.088 -0.057,0.153 -0.127,0.158 a 22.739,22.739 0 0 1 -3.912,0 c -0.07,-0.005 -0.127,-0.07 -0.127,-0.158 v -0.477 c 1.402,0.135 2.789,0.12 4.166,0 z"
+           id="path270"
            inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1949"
-           d="m 12.034768,-39.853122 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
+           style="fill:url(#p)" />
         <path
+           d="m 14.846,17.195 v 0.047 c 1.401,0.136 2.789,0.121 4.167,0 v -0.046 a 28.408,35.546 0 0 1 -4.167,0 z"
+           id="path272"
            inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 18.548553,-39.94667 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1951"
-           sodipodi:nodetypes="ccccc" />
+           style="fill:#ffffff;fill-opacity:0.29100001" />
+        <g
+           id="g284"
+           style="stroke-linecap:round;stroke-linejoin:round">
+          <path
+             d="m 37.267,17.758 a 2.231,0.134 0 0 1 -2.23,0.135 2.231,0.134 0 0 1 -2.233,-0.135 2.231,0.134 0 0 1 2.227,-0.134 2.231,0.134 0 0 1 2.236,0.134"
+             id="path274"
+             inkscape:connector-curvature="0"
+             style="fill:#272728" />
+          <path
+             d="m 31.962,-24.875 v 0.66 c 0,0.05 -0.006,0.086 -0.058,0.09 -1.251,0.09 -2.565,0.138 -3.918,0 -0.052,-0.005 -0.092,-0.04 -0.094,-0.09 l 0.006,-0.66 a 24.86,24.86 0 0 0 4.064,0 z"
+             transform="matrix(1.08387,0,0,1.04133,2.585,42.875)"
+             id="path276"
+             inkscape:connector-curvature="0"
+             style="fill:url(#q)" />
+          <path
+             d="m 31.933,-24.883 a 2.005,0.147 0 0 1 -2.003,0.147 2.005,0.147 0 0 1 -2.006,-0.147 2.005,0.147 0 0 1 2,-0.148 2.005,0.147 0 0 1 2.01,0.147"
+             transform="matrix(1.08387,0,0,1.04133,2.585,42.875)"
+             id="path278"
+             inkscape:connector-curvature="0"
+             style="fill:url(#r);stroke:#040403;stroke-width:0.066;stroke-opacity:0.20499998" />
+          <g
+             id="g282"
+             style="fill:#add3ff;fill-opacity:0.36700056">
+            <path
+               d="M 27.753,24.02 27.6,22.82 c -0.872,0.107 -1.627,0.47 -2.158,1.323 l 1.017,0.62 c 0.342,-0.49 0.786,-0.705 1.294,-0.744 z m -1.576,1.508 c 0.028,-0.187 0.074,-0.38 0.145,-0.578 l -1.009,-0.57 c -0.166,0.274 -0.3,0.575 -0.314,0.97 z"
+               id="path280"
+               inkscape:connector-curvature="0" />
+          </g>
+        </g>
         <path
+           d="m 29.566,27.283 a 0.553,0.553 0 0 1 -0.552,0.552 0.553,0.553 0 0 1 -0.553,-0.551 0.553,0.553 0 0 1 0.552,-0.554 0.553,0.553 0 0 1 0.553,0.55"
+           id="path286"
            inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1953"
-           d="m 20.350432,-39.361987 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
+           style="fill:url(#s)" />
         <path
+           d="m 29.13,27.064 a 0.334,0.334 0 0 1 -0.333,0.334 0.334,0.334 0 0 1 -0.336,-0.333 0.334,0.334 0 0 1 0.335,-0.335 0.334,0.334 0 0 1 0.334,0.333"
+           id="path288"
            inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 22.228168,-40.583295 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1955"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1957"
-           d="m 22.902081,-40.098605 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-      </g>
-      <g
-         style="fill:#ffffff;fill-opacity:0.07814349"
-         transform="translate(0.055571,1.087924)"
-         id="g1991">
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1971"
-           d="m 12.846087,-40.227186 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 14.244018,-40.435874 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1973"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1975"
-           d="m 15.852941,-39.971117 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 16.719505,-40.428528 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1977"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1979"
-           d="m 19.854061,-40.512011 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 12.034768,-39.853122 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1981"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1983"
-           d="m 18.548553,-39.94667 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 20.350432,-39.361987 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1985"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1987"
-           d="m 22.228168,-40.583295 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 22.902081,-40.098605 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1989"
-           sodipodi:nodetypes="ccccc" />
-      </g>
-      <g
-         id="g2013"
-         transform="translate(0.06222562,2.8464061)"
-         style="fill:#ffffff;fill-opacity:0.23629402">
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 12.846087,-40.227186 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1993"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1995"
-           d="m 14.244018,-40.435874 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 15.852941,-39.971117 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1997"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1999"
-           d="m 16.719505,-40.428528 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 19.854061,-40.512011 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path2001"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path2003"
-           d="m 12.034768,-39.853122 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 18.548553,-39.94667 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path2005"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path2007"
-           d="m 20.350432,-39.361987 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 22.228168,-40.583295 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path2009"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path2011"
-           d="m 22.902081,-40.098605 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
+           style="fill:#ffffff;fill-opacity:0.347" />
       </g>
       <path
          inkscape:connector-curvature="0"
-         d="m 24.422015,-41.144888 -0.425814,0.0832 0.4408,0.06201 0.460437,-0.08371 z m -2.374015,0.07131 -0.426331,0.0832 0.4408,0.06201 0.460954,-0.08372 z m -5.609993,0.07596 -0.426331,0.0832 0.4408,0.06201 0.460954,-0.0832 z m 2.4753,0.0078 -0.425813,0.08268 0.4408,0.06201 0.460437,-0.0832 z m -3.873148,0.201023 -0.426331,0.0832 0.4408,0.06201 0.460437,-0.0832 z m 10.055717,0.128672 -0.425814,0.0832 0.4408,0.06201 0.460437,-0.08371 z m -7.049182,0.127643 -0.425814,0.08268 0.4408,0.06201 0.460437,-0.0832 z m 2.695442,0.02429 -0.425813,0.0832 0.440799,0.06201 0.460438,-0.08371 z m -6.513297,0.09354 -0.426331,0.0832 0.4408,0.06201 0.460437,-0.08372 z m 8.315255,0.491443 -0.425814,0.08268 0.4408,0.06201 0.460437,-0.0832 z"
-         style="fill:#ffffff;fill-opacity:0.03830872;stroke:none;stroke-width:0.264999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         id="path2015" />
+         style="fill:#e24361;fill-opacity:0.725;stroke-width:0.971865"
+         d="m 1.9261845,9.4090221 c -1.69104504,-0.2060351 -3.566744,0.5024543 -4.563878,2.9146239 -0.148695,0.828029 -0.152583,1.273143 0.431508,0.177851 0.932991,-2.256671 2.54434296,-2.8164651 4.076002,-2.629867 1.531659,0.18757 2.960301,1.210944 3.343216,2.079791 0.171048,0.386803 0.191457,1.039896 0.01458,1.702708 -0.175908,0.660868 -0.541329,1.329511 -1.079742,1.783372 -0.539385,0.453861 -1.243987,0.707518 -2.172118,0.553963 -1.64050804,-0.150639 -3.445262,-1.739638 -4.03324,-2.08951 1.42183896,1.282862 2.90587596,2.379126 3.957434,2.551146 1.049615,0.17202 1.91749,-0.127314 2.54823,-0.658925 0.631713,-0.530638 1.033093,-1.278974 1.231353,-2.018563 0.197289,-0.740561 0.199233,-1.473348 -0.03887,-2.012733 C 5.1488885,10.64815 3.6182015,9.6150575 1.9261845,9.4090221 Z"
+         id="path292" />
       <path
          inkscape:connector-curvature="0"
-         transform="scale(0.26458333)"
-         d="m 79.232422,-147.68555 -1.609375,0.31446 1.666015,0.23437 1.740235,-0.3164 z m -8.972656,0.26953 -1.611328,0.31446 1.666015,0.23437 1.742188,-0.3164 z m -21.203125,0.28711 -1.611329,0.31446 1.666016,0.23437 1.742188,-0.31445 z m 9.355468,0.0293 -1.609375,0.3125 1.666016,0.23438 1.740234,-0.31446 z m -13.441406,0.91602 v 0.18554 l 0.597656,-0.10742 z m 36.808594,0.33007 -1.609375,0.31446 1.666016,0.23437 1.740234,-0.3164 z m -26.642578,0.48243 -1.609375,0.3125 1.666015,0.23437 1.740235,-0.31445 z m 10.1875,0.0918 -1.609375,0.31446 1.666015,0.23437 1.740235,-0.31641 z m 6.810547,2.21094 -1.609375,0.3125 1.666015,0.23438 1.740235,-0.31446 z"
-         style="fill:#ffffff;fill-opacity:0.38948604;stroke:none;stroke-width:1.00156999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         id="path2048" />
+         style="fill:url(#t);stroke-width:0.971865"
+         d="m -0.42572854,12.371267 c 0.310025,-0.02916 0.511201,0.14578 0.771661,0.136061 0.279897,-0.01069 0.542301,-0.192429 0.81345104,-0.208951 -0.52966704,-0.429564 -0.123427,-0.611303 0.294475,-0.789154 0.580203,-1.008796 -0.14578,-0.308082 -0.59283804,0.02624 -0.349871,0.06512 -0.654065,0.272122 -1.100151,0.02333 -0.699743,-0.787211 -1.21483096,-0.908694 -0.147723,0.06123 0.177851,0.309053 0.405267,0.632684 -0.03888,0.751251 z"
+         id="path294" />
       <path
          inkscape:connector-curvature="0"
-         transform="scale(0.26458333)"
-         d="m 80.019531,-136.01953 -1.609375,0.31445 1.666016,0.23438 1.740234,-0.31641 z m -8.972656,0.26953 -1.611328,0.31445 1.666015,0.23438 1.742188,-0.31641 z m -21.203125,0.28711 -1.611328,0.31445 1.666016,0.23438 1.742187,-0.31446 z m 9.355469,0.0293 -1.609375,0.3125 1.666015,0.23437 1.740235,-0.31445 z m -14.228516,0.8125 v 0.43164 l 1.384766,-0.25 z m 37.595703,0.43359 -1.609375,0.31445 1.666016,0.23438 1.740234,-0.31641 z m -26.642578,0.48242 -1.609375,0.3125 1.666016,0.23438 1.740234,-0.31446 z m 10.1875,0.0918 -1.609375,0.31445 1.666016,0.23438 1.740234,-0.31641 z m 6.810547,2.21094 -1.609375,0.3125 1.666016,0.23437 1.740234,-0.31445 z"
-         style="fill:#ffffff;fill-opacity:0.38948604;stroke:none;stroke-width:1.00156999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         id="path2050" />
+         style="fill:url(#u);stroke-width:0.971865"
+         d="m -8.6535374,12.553977 c 0.7143206,-0.163273 1.5452651,-0.501482 2.0564661,-0.361533 -0.00583,0.287672 0.069974,0.521891 0.2575442,0.683221 0.5442445,-0.184654 1.0855733,-0.395549 1.6395364,-0.425677 0.1448079,0.01166 0.2206133,0.129258 0.2886438,0.256572 -0.4334516,0.44803 -0.899947,0.771661 -1.4140634,1.117645 -1.0282332,-0.408183 -1.3800485,-0.381943 -2.0574381,-0.345984 -0.0622,-0.15647 0.3236309,-0.06803 0.6355995,-0.257544 l -0.3780553,-0.770689 c -0.3119688,0.04956 -0.9718651,0.256572 -1.0282332,0.103989 z"
+         id="path296" />
       <path
          inkscape:connector-curvature="0"
-         transform="scale(0.26458333)"
-         d="m 89.529297,-138.36133 -1.609375,0.31445 1.666016,0.23438 1.740234,-0.31641 z m -8.972656,0.26953 -1.611329,0.31446 1.666016,0.23437 1.742188,-0.31641 z m -21.203125,0.28711 -1.611328,0.31446 1.666015,0.23437 1.742188,-0.31445 z m 9.355468,0.0293 -1.609375,0.3125 1.666016,0.23437 1.740234,-0.31445 z m -14.638672,0.75977 -1.611328,0.31445 1.666016,0.23437 1.740234,-0.31445 z m 38.00586,0.48632 -1.609375,0.31446 1.666015,0.23437 0.01172,-0.002 v -0.53711 z m -26.642578,0.48242 -1.609375,0.3125 1.666015,0.23438 1.740235,-0.31445 z m 10.1875,0.0918 -1.609375,0.31446 1.666015,0.23437 1.740235,-0.31641 z m -24.617188,0.35352 -1.611328,0.31445 1.666016,0.23438 1.740234,-0.31641 z m 31.427735,1.85742 -1.609375,0.3125 1.666015,0.23437 1.740235,-0.31445 z"
-         style="fill:#ffffff;fill-opacity:0.38948604;stroke:none;stroke-width:1.00156999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         id="path2052" />
+         style="fill:#c6c6c6;stroke-width:0.971865"
+         d="m -6.76326,12.192444 c -0.4538609,0.167161 0.3401526,0.771661 -0.4208177,1.028233 0.3236312,-0.05637 0.8746787,-0.0029 0.9660339,-0.173964 -0.2915594,-0.164245 -0.5053697,-0.412071 -0.5452162,-0.854269 z"
+         id="path298" />
       <path
          inkscape:connector-curvature="0"
-         transform="scale(0.26458333)"
-         d="m 80.957031,-133.87305 -1.609375,0.31446 1.666016,0.23437 1.740234,-0.3164 z m -8.972656,0.26953 -1.611328,0.31446 1.666015,0.23437 1.742188,-0.3164 z m -21.203125,0.28711 -1.611328,0.31446 1.666016,0.23437 1.742187,-0.31445 z m 9.355469,0.0293 -1.609375,0.3125 1.666015,0.23438 1.740235,-0.31446 z m -14.638672,0.75977 -0.171875,0.0332 c 0.08194,0.17475 0.167925,0.34771 0.27539,0.50586 l 1.691407,-0.30469 z m 38.005859,0.48632 -1.609375,0.31446 1.666016,0.23437 1.740234,-0.3164 z m -26.642578,0.48243 -1.609375,0.3125 1.666016,0.23437 1.740234,-0.31445 z m 10.1875,0.0918 -1.609375,0.31446 1.666016,0.23437 1.740234,-0.31641 z"
-         style="fill:#ffffff;fill-opacity:0.38948604;stroke:none;stroke-width:1.00156999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         id="path2054" />
-      <g
-         transform="translate(-0.06595615,-3.2566105)"
-         id="g2154">
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:url(#linearGradient3878);fill-opacity:1;stroke:none;stroke-width:0.05;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 19.351426,-35.747819 c 0.114809,-0.03536 0.263727,0.02423 0.284833,0.165198 0.147138,-0.04147 0.241384,0.150992 0.325592,0.219169 l -0.8524,0.03612 c -0.756955,0.123752 -1.26554,0.647059 -2.49549,0.0099 -0.379032,-0.02204 -0.829317,-0.100418 -1.291637,-0.188298 l 0.894475,-0.383789 c -0.07266,-0.381309 -0.213755,-0.747738 -0.545756,-1.072653 -0.104507,-0.09177 -0.229885,-0.161374 -0.338248,-0.126124 l -1.265543,0.438534 c 0.796399,-0.380798 1.336705,-0.938733 2.777425,-0.873858 0.212994,0.01338 0.278249,0.153653 0.34303,0.252653 l 0.565731,0.900578 z"
-           id="path2068"
-           sodipodi:nodetypes="cccccccccccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccccccccccc"
-           id="path2086"
-           d="m 19.402935,-35.560371 c 0.240401,-0.07405 0.397731,0.06641 0.558916,0.196919 l -0.8524,0.03612 c -0.756955,0.123752 -1.26554,0.647059 -2.49549,0.0099 -0.379032,-0.02204 -0.829317,-0.100418 -1.291637,-0.188298 l 0.894475,-0.383789 c -0.07266,-0.381309 -0.213755,-0.747738 -0.545756,-1.072653 -0.104507,-0.09177 -0.229885,-0.161374 -0.338248,-0.126124 l -1.265543,0.438534 c 0.796399,-0.380798 1.336705,-0.938733 2.777425,-0.873858 0.212994,0.01338 0.278249,0.153653 0.34303,0.252653 l 0.565731,0.900578 z"
-           style="fill:url(#linearGradient3880);fill-opacity:1;stroke:none;stroke-width:0.05;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:url(#radialGradient2106);fill-opacity:1;stroke:none;stroke-width:0.05;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 19.402935,-35.560371 c 0.240401,-0.07405 0.397731,0.06641 0.558916,0.196919 l -0.8524,0.03612 c -0.756955,0.123752 -1.26554,0.647059 -2.49549,0.0099 -0.379032,-0.02204 -0.829317,-0.100418 -1.291637,-0.188298 l 0.894475,-0.383789 c -0.07266,-0.381309 -0.213755,-0.747738 -0.545756,-1.072653 -0.104507,-0.09177 -0.229885,-0.161374 -0.338248,-0.126124 l -1.265543,0.438534 c 0.796399,-0.380798 1.336705,-0.938733 2.777425,-0.873858 0.212994,0.01338 0.278249,0.153653 0.34303,0.252653 l 0.565731,0.900578 z"
-           id="path2096"
-           sodipodi:nodetypes="ccccccccccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#9f9f9f;fill-opacity:1;stroke:none;stroke-width:0.26458299px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           d="m 16.940372,-35.597325 c 0.577523,-0.11639 1.172383,-0.431079 1.715147,-0.149886 l 0.10847,-0.795483 -0.54513,0.09202 z"
-           id="path2122"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cccccccccccccc"
-           id="path2138"
-           d="m 19.351426,-35.747819 c 0.114809,-0.03536 0.263727,0.02423 0.284833,0.165198 0.147138,-0.04147 0.241384,0.150992 0.325592,0.219169 l -0.8524,0.03612 c -0.756955,0.123752 -1.26554,0.647059 -2.49549,0.0099 -0.379032,-0.02204 -0.829317,-0.100418 -1.291637,-0.188298 l 0.894475,-0.383789 c -0.07266,-0.381309 -0.213755,-0.747738 -0.545756,-1.072653 -0.104507,-0.09177 -0.229885,-0.161374 -0.338248,-0.126124 l -1.265543,0.438534 c 0.796399,-0.380798 1.336705,-0.938733 2.777425,-0.873858 0.212994,0.01338 0.278249,0.153653 0.34303,0.252653 l 0.565731,0.900578 z"
-           style="fill:url(#linearGradient3882);fill-opacity:1;stroke:none;stroke-width:0.05;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:url(#linearGradient3884);fill-opacity:1;stroke:none;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 16.940372,-35.597325 c 0.441069,-0.285912 0.786602,-0.639697 1.466786,-0.755734 0.219864,-0.05227 0.209846,0.07698 0.156431,0.240493 l -0.447033,1.243465 c 0.777373,-0.484948 1.629873,-0.91218 2.156218,-1.589979 0.194172,-0.200111 -0.02268,-0.407236 -0.41634,-0.363355 -1.737259,0.0442 -2.155933,0.520356 -2.916062,1.22511 z"
-           id="path2108"
-           sodipodi:nodetypes="ccccccc" />
-      </g>
+         style="fill:url(#v);stroke-width:0.971865"
+         d="m -6.7214698,13.478221 c 0.2283882,-0.515088 0.6783617,-0.62005 1.1536037,-0.679333 0.1049614,0.05054 -0.1846543,0.67253 -0.2575442,0.981583 z"
+         id="path300" />
     </g>
-    <g
-       id="g2317"
-       transform="matrix(0.60420488,0,0,0.60420488,8.4258642,307.63861)">
-      <rect
-         ry="0.96645641"
-         rx="0.96645641"
-         y="-54.932831"
-         x="20.901146"
-         height="9.0284538"
-         width="12.481599"
-         id="rect1900-3"
-         style="fill:url(#linearGradient2245);fill-opacity:1;stroke:none;stroke-width:0.40000001;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:1" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.264999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         d="m 21.915184,-48.993478 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-         id="path1993-5"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc"
-         id="path1995-6"
-         d="m 23.313115,-49.202166 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-         style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.264999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.264999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         d="m 24.922038,-48.737409 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-         id="path1997-2"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc"
-         id="path1999-9"
-         d="m 25.788602,-49.19482 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-         style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.264999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-      <path
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc"
-         id="path2003-1"
-         d="m 21.103865,-48.619414 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-         style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.264999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.264999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         d="m 27.61765,-48.712962 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-         id="path2005-2"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.264999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         d="m 31.297265,-49.349587 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-         id="path2009-7"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc"
-         id="path2011-0"
-         d="m 31.971178,-48.864897 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-         style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.264999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-      <path
-         inkscape:connector-curvature="0"
-         d="m 29.970449,-50.687833 -0.425813,0.0832 0.440799,0.06201 0.460438,-0.08371 z m -2.374015,0.07131 -0.42633,0.0832 0.4408,0.06201 0.460953,-0.08371 z m -5.609993,0.07597 -0.426331,0.0832 0.4408,0.06201 0.460954,-0.0832 z m 2.475301,0.0078 -0.425814,0.08268 0.4408,0.06201 0.460437,-0.0832 z m -3.556372,0.242364 v 0.04909 l 0.158129,-0.02842 z m 9.73894,0.08733 -0.425814,0.0832 0.4408,0.06201 0.460438,-0.08371 z m -7.049182,0.127643 -0.425814,0.08268 0.4408,0.06201 0.460437,-0.0832 z m 2.695443,0.02429 -0.425814,0.0832 0.4408,0.06201 0.460437,-0.08372 z m 1.801957,0.584978 -0.425814,0.08268 0.4408,0.06201 0.460437,-0.0832 z"
-         style="fill:#ffffff;fill-opacity:0.38948604;stroke:none;stroke-width:0.264999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         id="path2048-9" />
-      <path
-         inkscape:connector-curvature="0"
-         d="m 32.694831,-48.2208 -0.425813,0.0832 0.4408,0.06201 0.460437,-0.08372 z m -2.374015,0.07131 -0.426331,0.0832 0.4408,0.06201 0.460954,-0.08372 z m -5.609994,0.07596 -0.42633,0.0832 0.4408,0.06201 0.460953,-0.0832 z m 2.475301,0.0078 -0.425814,0.08268 0.4408,0.06201 0.460437,-0.0832 z m -3.873148,0.201023 -0.426331,0.0832 0.4408,0.06201 0.460437,-0.0832 z m 10.055717,0.128672 -0.425814,0.0832 0.4408,0.06201 0.0031,-5.29e-4 v -0.142107 z m -7.049182,0.12764 -0.425814,0.08268 0.4408,0.06201 0.460437,-0.0832 z m 2.695442,0.02429 -0.425814,0.0832 0.4408,0.06201 0.460437,-0.08372 z m -6.513297,0.09354 -0.426331,0.0832 0.4408,0.06201 0.460437,-0.08372 z m 8.315254,0.491443 -0.425813,0.08268 0.440799,0.06201 0.460438,-0.0832 z"
-         style="fill:#ffffff;fill-opacity:0.38948604;stroke:none;stroke-width:0.264999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         id="path2052-3" />
-      <path
-         inkscape:connector-curvature="0"
-         d="m 30.426752,-47.033276 -0.425814,0.0832 0.440801,0.06201 0.460436,-0.08371 z m -2.374015,0.07131 -0.426331,0.0832 0.4408,0.06201 0.460954,-0.08371 z m -5.609993,0.07596 -0.426331,0.0832 0.4408,0.06201 0.460954,-0.0832 z m 2.475301,0.0078 -0.425814,0.08268 0.4408,0.06201 0.460437,-0.0832 z m -3.873149,0.201023 -0.04547,0.0088 c 0.02168,0.04624 0.04443,0.092 0.07286,0.133842 l 0.447519,-0.08062 z m 10.055717,0.128674 -0.425814,0.0832 0.440801,0.06201 0.460436,-0.08371 z m -7.049182,0.127643 -0.425814,0.08268 0.4408,0.06201 0.460437,-0.0832 z m 2.695443,0.02429 -0.425814,0.0832 0.4408,0.06201 0.460437,-0.08372 z"
-         style="fill:#ffffff;fill-opacity:0.38948604;stroke:none;stroke-width:0.264999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         id="path2054-6" />
-      <path
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sssccss"
-         d="m 21.867602,-54.932831 h 10.548686 c 0.535417,0 0.966457,0.43104 0.966457,0.966457 v 3.283729 H 20.901146 v -3.283729 c 0,-0.535417 0.431039,-0.966457 0.966456,-0.966457 z"
-         style="fill:url(#radialGradient2301);fill-opacity:1;stroke:none;stroke-width:0.40000001;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:1"
-         id="rect2293" />
-    </g>
-    <g
-       id="g2670"
-       transform="matrix(0.60420488,0,0,0.60420488,3.3283435,318.09002)">
-      <path
-         inkscape:connector-curvature="0"
-         transform="scale(0.26458333)"
-         d="m 63.730469,-273.86523 c -2.02362,0 -3.652344,1.63067 -3.652344,3.65429 v 26.81641 c 0,2.02362 1.628724,3.65234 3.652344,3.65234 h 24.626953 l -2.953125,-34.12304 z"
-         style="fill:url(#linearGradient1113);fill-opacity:1;stroke:none;stroke-width:0.30836901px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path1105" />
-      <path
-         inkscape:connector-curvature="0"
-         transform="scale(0.26458333)"
-         d="m 69.490234,-273.86523 c 0.222948,0.79435 0.708854,1.60378 0.96875,2.30664 -0.135118,0.55763 -0.543236,0.88647 -1.050781,1.07031 1.090205,0.0644 2.536359,-0.10562 2.816406,-1.26172 -0.238972,-0.64627 -0.672915,-1.38337 -0.914062,-2.11523 z m 14.382813,0.0684 c -0.09059,0.13981 -0.285827,0.28611 -0.521485,0.41797 0.114785,0.40596 1.067831,0.18444 1.722657,-0.16797 -0.392701,-0.0875 -0.785432,-0.18907 -1.201172,-0.25 z m -17.091797,3.48243 c -1.430343,0.0422 -2.900255,0.31458 -4.035156,1.10351 -1.03708,0.5426 -0.911495,2.38537 0.474609,2.42578 1.035916,0.54499 2.151199,0.9566 3.121094,1.42969 0.425745,1.64058 2.363641,1.54427 3.521484,2.37305 0.85115,1.02424 2.13342,1.14371 3.361328,1.33398 1.026683,0.13523 3.338836,0.82779 1.34961,1.71094 -0.851993,0.94055 0.415495,2.53203 -1.144531,3.01953 -0.415465,1.13174 -1.861764,1.24912 -2.878907,1.50586 -1.610313,0.67376 -3.179286,1.4539 -4.863281,1.93359 -1.031943,0.29314 -2.638146,2.06641 -0.625,2.18555 0.923732,0.23943 1.893183,0.2755 2.787109,-0.0195 -0.342803,-0.028 -0.685034,-0.0849 -1.021484,-0.17188 -2.01315,-0.11913 -0.408896,-1.89242 0.623047,-2.18554 1.683995,-0.4797 3.254921,-1.26179 4.865234,-1.93555 1.017143,-0.25674 2.463438,-0.3741 2.878906,-1.50586 1.560019,-0.48747 0.292539,-2.07898 1.144532,-3.01953 1.989226,-0.88315 -0.322916,-1.57575 -1.34961,-1.71094 -1.227911,-0.19026 -2.51212,-0.30983 -3.363281,-1.33398 -1.157847,-0.82876 -3.093798,-0.73247 -3.519531,-2.37305 -0.969906,-0.47309 -2.085178,-0.8847 -3.121094,-1.42969 -1.386092,-0.0405 -1.513646,-1.88122 -0.476562,-2.42382 0.666107,-0.46305 1.449955,-0.74652 2.271484,-0.91211 z m 18.609375,2.21484 c -0.338608,0.011 -0.674357,0.0457 -0.990234,0.17773 0.34662,-0.008 0.682735,-0.0432 0.990234,-0.17773 z m -10.130859,14.97852 c -0.410079,0.0426 -0.819701,0.1096 -1.226563,0.19336 0.896459,0.0629 1.983823,0.45763 1.314453,1.37109 -0.07952,0.8277 0.215232,1.76091 0.267578,2.54492 0.595382,7.1e-4 1.187507,0.0511 1.769532,0.18945 0.05435,-0.8485 -0.364386,-1.95929 -0.271485,-2.92578 0.611029,-0.83387 -0.244303,-1.24116 -1.080078,-1.35351 -0.278513,-0.0379 -0.55441,-0.0426 -0.773437,-0.0195 z m 13.001953,1.88476 c -0.110816,0.19597 -0.262388,0.38841 -0.435547,0.5586 0.203338,0.27972 0.46315,0.38294 0.740234,0.35937 0.03477,-0.24805 -0.04847,-0.5472 -0.304687,-0.91797 z m -15.046875,2.4336 c -0.578567,0.0321 -1.159196,0.10205 -1.732422,0.18554 -0.676513,0.0969 -2.303114,0.67532 -2.216797,1.05469 1.591544,-0.22915 3.246643,-0.0437 4.859375,-0.0918 0.218494,-0.0941 0.424275,-0.15275 0.621094,-0.18945 -1.243877,-0.0197 -2.498305,-0.0873 -3.714844,0.0879 -0.08508,-0.37383 1.49019,-0.93774 2.183594,-1.04687 z m 3.621094,0.72265 c -0.295084,0.0175 -0.604107,0.0856 -0.945313,0.23242 -0.04804,0.002 -0.0963,3e-5 -0.144531,0.002 0.631714,0.0941 1.267897,0.31758 2.109375,0.35742 0.888007,1.10592 -0.348827,3.06775 0.835937,3.93164 0.425609,0.75473 0.433499,1.38584 -0.65039,1.26367 -0.716871,0.41751 -0.948874,1.27721 -1.730469,1.66602 -0.356334,0.28002 -0.713979,0.5598 -1.070313,0.83984 l -0.101562,0.0449 h 1.326172 l 0.541015,-0.23828 c 0.356334,-0.28002 0.712037,-0.55785 1.06836,-0.83789 0.781606,-0.38878 1.015544,-1.25046 1.732422,-1.66797 1.083877,0.12216 1.075999,-0.50894 0.65039,-1.26367 -1.184757,-0.86391 0.05014,-2.8257 -0.83789,-3.93164 -0.758631,-0.0363 -1.348027,-0.2241 -1.919922,-0.33008 -0.285942,-0.053 -0.568198,-0.0859 -0.863281,-0.0684 z"
-         style="fill:#8d7c6a;fill-opacity:0.08791211;stroke:none;stroke-width:0.30836901px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path1139" />
-      <path
-         inkscape:connector-curvature="0"
-         transform="scale(0.26458333)"
-         d="m 82.900391,-273.86523 c -0.829286,11.47077 2.299911,24.70689 -3.134766,34.12304 h 23.833985 c 2.02362,0 3.65234,-1.62872 3.65234,-3.65234 v -26.81641 c 0,-2.02362 -1.62872,-3.65429 -3.65234,-3.65429 z"
-         style="fill:url(#linearGradient1218);fill-opacity:1;stroke:none;stroke-width:0.30836901px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path1145" />
-      <path
-         inkscape:connector-curvature="0"
-         transform="scale(0.26458333)"
-         d="m 71.308594,-273.86523 c 0.242483,0.73164 0.677128,1.46721 0.916015,2.11328 -0.310261,1.28082 -2.055817,1.35469 -3.158203,1.23633 -1.58708,-0.0113 -3.283559,0.22633 -4.55664,1.11132 -1.03708,0.5426 -0.909549,2.38537 0.476562,2.42578 1.035904,0.54499 2.153152,0.95658 3.123047,1.42969 0.425741,1.64056 2.361677,1.54427 3.519531,2.37305 0.851135,1.02426 2.133424,1.1437 3.361328,1.33398 1.026683,0.13523 3.338824,0.82779 1.34961,1.71094 -0.852,0.94054 0.415491,2.53206 -1.144532,3.01953 -0.415468,1.13176 -1.861759,1.24912 -2.878906,1.50586 -1.610309,0.67374 -3.181243,1.45585 -4.865234,1.93555 -1.031943,0.2931 -2.63619,2.06641 -0.623047,2.18554 1.179454,0.30581 2.434301,0.28711 3.509766,-0.33984 1.599307,-0.55666 3.249381,-1.12318 4.921875,-1.29687 0.875981,-0.092 2.670176,0.26122 1.855468,1.37304 -0.09294,0.96651 0.323957,2.0773 0.269532,2.92578 -1.353253,-0.32197 -2.760167,-0.18848 -4.134766,0.0117 -0.676517,0.0969 -2.305056,0.67532 -2.21875,1.05469 1.591551,-0.22911 3.246643,-0.0438 4.859375,-0.0918 1.364833,-0.58759 2.211289,0.0934 3.728516,0.16602 0.888007,1.10592 -0.346833,3.06775 0.83789,3.93164 0.42562,0.75474 0.433487,1.38584 -0.65039,1.26367 -0.716882,0.41751 -0.950824,1.27721 -1.732422,1.66602 -0.356334,0.28002 -0.71203,0.56177 -1.06836,0.84179 l -0.537109,0.23633 h 17.498047 c -0.09438,-0.65544 -0.196222,-1.31083 -0.0098,-1.87304 0.755475,-1.92384 -1.180897,-3.07924 -1.576172,-4.83985 -1.58197,-0.5017 -5.441125,0.0159 -4.599609,-2.60937 1.04109,-0.44924 3.406775,-0.68549 2.246094,-2.36524 -0.542548,0.96007 -2.038557,1.87987 -2.476563,0.1211 0.313134,-1.54462 -1.619887,-1.20511 -2.011719,-2.21289 1.228113,-0.46235 0.91758,-2.06949 1.75586,-2.78321 0.111987,-1.82867 -1.905625,-2.91354 -1.652344,-4.81054 -0.423621,-1.41812 -0.6004,-2.972 -0.630859,-4.38086 1.105954,-1.60161 -3.089576,-1.32649 -0.802735,-2.33594 1.174882,-0.66119 2.686245,0.24846 3.609375,-0.99609 1.279276,-0.95353 2.706918,-1.60555 4.181641,-2.18555 -0.0087,-0.009 -0.01865,-0.0183 -0.02734,-0.0274 -0.0013,1.2e-4 -0.0025,10e-4 -0.0039,0.002 -0.02532,0.002 -0.05089,-0.008 -0.07617,-0.0117 l -0.113281,-0.0195 -0.265625,-0.043 c -0.01398,-0.002 -0.151399,-0.0243 -0.152344,-0.0254 -0.0076,-0.011 -0.0062,-0.035 0.0059,-0.0391 0.02457,-0.008 0.0516,0.0216 0.07617,0.0137 0.01247,-0.004 -0.0047,-0.0312 0.0059,-0.0391 0.01058,-0.008 0.02456,0.01 0.03711,0.008 0.02835,-0.005 0.05357,-0.0224 0.08203,-0.0274 0.01247,-0.002 0.02595,0.008 0.03906,0.006 0.04044,-0.003 0.07896,-0.0112 0.11914,-0.0176 0.0098,-0.002 0.01985,-0.004 0.0293,-0.006 -0.584919,-0.52065 -1.354492,-1.00076 -2.070312,-1.55274 -0.0027,0.004 -0.0044,0.004 -0.0078,0.01 -0.01512,0.0208 0.0015,0.0554 -0.01367,0.0762 -0.01058,0.014 -0.03231,0.0165 -0.04297,0.0312 -0.01512,0.0208 0.0015,0.0554 -0.01367,0.0762 -0.01058,0.014 -0.03235,0.0165 -0.04297,0.0312 -0.0076,0.0106 0.0047,0.0312 -0.0059,0.0391 -0.01058,0.008 -0.02822,-0.0161 -0.03906,-0.008 -0.01058,0.008 0.0016,0.0286 -0.0059,0.0391 -0.01058,0.014 -0.03011,0.0207 -0.04492,0.0312 -0.01512,0.0113 -0.02551,0.026 -0.04297,0.0312 -0.01209,0.004 -0.02632,-0.008 -0.03906,-0.006 -0.290608,0.0465 0.06153,-3.6e-4 -0.126953,0.0586 -0.0121,0.004 -0.02479,-0.01 -0.03711,-0.006 -0.01739,0.005 -0.02708,0.0282 -0.04492,0.0312 -0.02532,0.004 -0.05062,-0.0156 -0.07617,-0.0137 -0.08568,0.007 -0.122168,0.0667 -0.208984,0.084 -0.505652,0.10027 0.03517,-0.0615 -0.316406,0.0254 -0.05575,0.0136 -0.108277,0.0372 -0.164063,0.0508 -0.07888,0.0197 -0.161986,0.0259 -0.242187,0.0391 -0.04025,0.007 -0.07843,0.0192 -0.119141,0.0195 -0.03844,-4.1e-4 -0.07717,-0.0135 -0.115234,-0.0195 l -0.113281,-0.0176 c -0.02608,-0.004 -0.141686,-0.0178 -0.152344,-0.0254 -0.02268,-0.0155 -0.04614,-0.0531 -0.02539,-0.082 0.01058,-0.014 0.03426,-0.0165 0.04492,-0.0312 0.02721,-0.037 -0.01549,-0.039 0.01172,-0.0762 0.01058,-0.014 0.03426,-0.0165 0.04492,-0.0312 0.01512,-0.0208 -0.0035,-0.0554 0.01172,-0.0762 0.01058,-0.014 0.03426,-0.0185 0.04492,-0.0332 0.0076,-0.0106 -0.0047,-0.0293 0.0059,-0.0371 0.01058,-0.008 0.02626,0.0142 0.03711,0.006 0.01058,-0.008 -0.0047,-0.0312 0.0059,-0.0391 0.01058,-0.008 0.02595,0.01 0.03906,0.008 0.04044,-0.003 0.08129,-0.0116 0.121094,-0.0195 0.653752,-0.12957 -0.368647,0.0618 0.486328,-0.11524 0.0796,-0.0166 0.161733,-0.0179 0.240234,-0.0391 0.07234,-0.0197 0.135322,-0.0681 0.208985,-0.082 0.07684,-0.0147 0.158734,0.009 0.236328,-0.002 0.05681,-0.006 0.10839,-0.0364 0.164062,-0.0508 0.07586,-0.0197 0.101607,-0.0225 0.136719,-0.0293 -0.286072,-0.2312 -0.55848,-0.47617 -0.798828,-0.74414 -0.874654,0.24033 -1.650996,0.007 -2.464844,-0.17578 h -0.705078 c -0.61038,0.60458 -2.719714,1.23054 -2.041016,0 z m 14.685547,0.67187 c 0.02948,0.057 0.0708,0.10858 0.08984,0.16992 0.0037,0.0125 -0.02626,-0.0142 -0.03711,-0.006 -0.01058,0.008 0.0028,0.0293 -0.0078,0.0371 -0.05907,0.0424 -0.02626,-0.0682 -0.04297,0.0332 -0.02079,0.0144 -0.0516,-0.0216 -0.07617,-0.0137 -0.01739,0.005 -0.02746,0.0279 -0.04492,0.0332 -0.01209,0.004 -0.02437,-0.006 -0.03711,-0.008 l -0.03906,-0.006 c -0.09695,-0.0159 -0.05836,0.0372 -0.126953,0.0586 -0.01209,0.004 -0.02475,-0.01 -0.03711,-0.006 -0.03477,0.0102 -0.05149,0.059 -0.08789,0.0625 -0.03851,0.004 -0.0768,-0.0172 -0.115234,-0.0176 -0.04082,10e-4 -0.08043,0.0203 -0.121094,0.0195 -0.05151,-5.8e-4 -0.09971,-0.0171 -0.150391,-0.0254 l -0.267578,-0.0449 -0.228516,-0.0371 c -0.03806,-0.006 -0.0821,0.005 -0.113281,-0.0176 -0.01474,-0.0102 0.02746,-0.0279 0.04492,-0.0332 0.0121,-0.004 0.02399,0.01 0.03711,0.008 0.04044,-0.003 0.08096,-0.0131 0.121094,-0.0195 0.114747,-0.0185 0.155971,-0.0291 0.279297,-0.0332 0.18308,-0.006 0.239044,0.0283 0.398438,-0.0508 0.04887,-0.0242 0.08077,-0.0796 0.132812,-0.0957 0.02859,-0.009 0.41915,-0.008 0.429688,-0.008 z m 0.986328,1.375 c -0.006,-0.001 -0.009,0.01 0.113281,0.0176 0.09078,0.005 0.182653,0.003 0.273438,0.006 0.116144,0.005 0.231322,0.018 0.347656,0.0195 0.285014,0.004 0.659224,-0.0254 0.939453,-0.002 0.153562,0.0136 0.30186,0.0569 0.455078,0.0742 0.05136,0.006 0.59002,0.0305 0.660156,0.0312 0.06546,9.2e-4 0.130078,-0.002 0.195313,-0.008 0.04044,-0.003 0.08046,-0.0203 0.121094,-0.0195 v -0.002 c 0.05151,5.8e-4 0.101622,0.0171 0.152343,0.0254 -0.187653,0.13489 -0.107115,0.13916 -0.216797,0.12109 -0.01285,-0.002 -0.02475,-0.01 -0.03711,-0.006 -0.03477,0.0102 -0.0532,0.0519 -0.08789,0.0625 -0.02457,0.008 -0.0516,-0.0197 -0.07617,-0.0117 -0.01739,0.005 -0.0275,0.026 -0.04492,0.0312 -0.0121,0.004 -0.02475,-0.01 -0.03711,-0.006 -0.01739,0.005 -0.02746,0.026 -0.04492,0.0313 -0.01209,0.004 -0.02822,-0.0142 -0.03906,-0.006 -0.01058,0.008 0.0047,0.0312 -0.0059,0.0391 -0.02079,0.0144 -0.05539,-0.028 -0.07617,-0.0137 -0.01058,0.008 0.0062,0.035 -0.0059,0.0391 -0.02457,0.008 -0.05062,-0.0156 -0.07617,-0.0137 -0.02872,0.003 -0.05361,0.0224 -0.08203,0.0273 -0.01247,0.002 -0.02437,-0.0101 -0.03711,-0.008 -0.02835,0.005 -0.05518,0.0258 -0.08398,0.0273 -0.03851,0.002 -0.07522,-0.0135 -0.113281,-0.0195 -0.02759,0.009 -0.05338,0.0227 -0.08203,0.0254 -0.0257,0.002 -0.05089,-0.008 -0.07617,-0.0117 l -0.341797,-0.0566 c -0.05068,-0.008 -0.100829,-0.025 -0.152344,-0.0254 -0.05299,-8.3e-4 -0.105214,0.0152 -0.158203,0.0137 -0.05129,-0.003 -0.101622,-0.0171 -0.152343,-0.0254 l -0.152344,-0.0234 -0.457032,-0.0762 -0.265624,-0.043 c -0.03806,-0.006 -0.07869,-0.008 -0.115235,-0.0195 -0.03829,-0.0144 -0.06898,-0.0432 -0.107422,-0.0566 -0.03666,-0.0117 -0.0773,-0.004 -0.113281,-0.0176 -0.238753,-0.0902 0.09042,-0.0256 -0.146484,-0.0645 -0.01247,-0.002 0.02746,0.0119 0.03906,0.006 0.104277,-0.0474 0.09386,-0.0612 0.08789,-0.0625 z m -1.634766,0.43164 c 0.0511,0.005 0.101018,0.0231 0.152344,0.0254 0.0655,0.003 0.131766,-0.0101 0.197265,-0.008 0.102879,0.003 0.1991,0.0552 0.302735,0.0508 -0.04641,0.0444 -0.09706,0.0838 -0.138672,0.13281 -0.03825,0.045 0.04514,0.0796 0.06445,0.0898 0.01134,0.006 0.02664,-0.002 0.03711,0.006 0.01474,0.0102 0.01538,0.0346 0.03125,0.043 0.02268,0.0117 0.05085,0.01 0.07617,0.0137 0.01285,0.002 0.04125,-0.007 0.03906,0.006 -0.01096,0.0667 -0.09271,0.0108 -0.121094,0.0195 -0.140523,0.0436 0.111542,0.0559 -0.158203,0.0117 -0.08874,-0.0147 -0.175861,-0.0381 -0.265625,-0.043 -0.0655,-0.003 -0.13188,0.009 -0.197266,0.006 -0.05129,-0.003 -0.101017,-0.0212 -0.152343,-0.0234 -0.0655,-0.003 -0.129889,0.009 -0.195313,0.006 -0.05129,-0.003 -0.100829,-0.025 -0.152344,-0.0254 -0.04063,-7.7e-4 -0.08043,0.0203 -0.121093,0.0195 -0.05151,-5.9e-4 -0.101623,-0.0151 -0.152344,-0.0234 l -0.189453,-0.0332 c -0.03795,-0.006 -0.07673,-0.006 -0.113282,-0.0176 -0.24548,-0.083 -0.02856,-0.0431 -0.146484,-0.0625 0.01928,-0.007 0.151731,-0.10813 0.177734,-0.12695 0.01512,-0.0113 0.02551,-0.0279 0.04297,-0.0332 0.02457,-0.008 0.05089,0.0175 0.07617,0.0137 0.04188,-0.007 0.03708,-0.008 0.05469,-0.0117 0.02041,0.003 0.05006,0.005 0.142578,0.004 0.04082,-0.001 0.0787,-0.0123 0.11914,-0.0176 0.05246,-0.005 0.107168,-0.0103 0.160157,-0.0137 0.08712,-0.005 0.353269,-0.012 0.429687,-0.008 z m 5.066406,0.52344 c -0.05567,0.0292 -0.110352,0.0589 -0.166015,0.0879 -0.0021,0.0136 0.0047,0.0293 -0.0059,0.0371 -0.01172,0.008 -0.165856,-0.035 -0.191406,-0.0312 -0.138331,0.0223 -0.03316,0.0335 -0.11914,0.0195 -0.0091,-0.002 -0.113874,-0.0187 -0.115235,-0.0176 -0.01058,0.008 0.0047,0.0293 -0.0059,0.0371 -0.01058,0.008 -0.02437,-0.008 -0.03711,-0.006 -0.02835,0.005 -0.05361,0.0205 -0.08203,0.0254 -0.01247,0.002 -0.02632,-0.008 -0.03906,-0.006 -0.05665,0.008 -0.107257,0.0416 -0.164063,0.0508 -0.03364,0.004 -0.12498,-0.0348 -0.152344,-0.0254 -0.01739,0.005 -0.02708,0.0302 -0.04492,0.0332 -0.02532,0.004 -0.0516,-0.0216 -0.07617,-0.0137 -0.01247,0.004 0.0047,0.0312 -0.0059,0.0391 -0.08372,0.06 -0.07441,0.004 -0.158203,0.0117 -0.02872,0.003 -0.05323,0.0258 -0.08203,0.0273 -0.03851,0.002 -0.0768,-0.0192 -0.115235,-0.0195 -0.04082,0.001 -0.07859,0.0214 -0.11914,0.0195 -0.06418,-0.003 -0.128024,-0.0207 -0.191406,-0.0312 l -0.150391,-0.0254 c -0.05068,-0.008 -0.103588,-0.01 -0.152344,-0.0254 -0.02721,-0.008 -0.04344,-0.0385 -0.07031,-0.0488 -0.06025,-0.0219 -0.126071,-0.0226 -0.189453,-0.0332 -0.01285,-0.002 -0.03124,0.005 -0.03906,-0.006 -0.0076,-0.011 -0.0047,-0.0293 0.0059,-0.0371 0.0042,-0.003 0.130574,0.0258 0.152344,0.0254 0.255723,-0.009 -0.03441,-0.0529 0.316406,-0.0273 0.07703,0.005 0.151603,0.0424 0.228516,0.0371 0.09766,-0.006 0.187304,-0.0691 0.285156,-0.0703 0.128504,-0.002 0.254083,0.0436 0.38086,0.0645 0.0929,-0.0106 0.183876,-0.0287 0.277344,-0.0332 0.09082,-0.005 0.182577,0.006 0.273437,0.006 0.186955,-3.9e-4 0.372222,-0.0122 0.552734,-0.0644 z m -6.089843,1.18555 c 0.02532,-0.004 0.05058,0.0113 0.07617,0.0117 0.05276,7.9e-4 0.105365,-0.0121 0.158203,-0.0117 0.774561,-0.002 -0.179248,0.0155 0.654297,0.0684 0.22919,0.0147 0.781558,-0.0336 0.982421,-0.0351 0.194419,-10e-4 0.387662,0.0229 0.582032,0.0176 0.146456,-0.004 0.29102,-0.0412 0.4375,-0.0449 0.129108,-0.004 0.258256,0.0125 0.386718,0.0254 0.09695,0.008 0.144574,0.0158 0.167969,0.0215 v -0.002 c 0.02305,0.005 0.02224,0.008 0.02148,0.01 -0.0012,0.004 0.0049,-0.001 0.19336,-0.008 -0.05208,0.005 -0.104093,0.0118 -0.15625,0.0137 -0.01247,-10e-5 -0.02464,-0.01 -0.03711,-0.006 -0.01739,0.005 -0.02746,0.026 -0.04492,0.0312 -0.0121,0.004 -0.02626,-0.0142 -0.03711,-0.006 -0.01058,0.008 0.0047,0.0293 -0.0059,0.0371 -0.0091,0.006 -0.09891,-0.0229 -0.115234,-0.0176 -0.01739,0.005 -0.02746,0.026 -0.04492,0.0312 -0.0257,0.008 -0.163526,-0.0387 -0.189454,-0.0312 -0.01739,0.005 -0.02746,0.026 -0.04492,0.0312 -0.02457,0.008 -0.05539,-0.0261 -0.07617,-0.0117 -0.01058,0.008 0.0047,0.0293 -0.0059,0.0371 -0.02079,0.0144 -0.05089,-0.0155 -0.07617,-0.0117 -0.02835,0.005 -0.05338,0.0227 -0.08203,0.0254 -0.02532,0.002 -0.04893,-0.008 -0.07422,-0.0117 -0.06338,-0.0106 -0.127382,-0.0324 -0.191407,-0.0312 -0.02872,10e-4 -0.05323,0.0239 -0.08203,0.0254 -0.03851,0.002 -0.07484,-0.0192 -0.113281,-0.0195 -0.04082,10e-4 -0.08039,0.0192 -0.121094,0.0195 -0.03844,-4.1e-4 -0.07477,-0.0195 -0.113281,-0.0176 -0.05745,0.002 -0.10921,0.0418 -0.166016,0.0508 -0.01247,0.002 -0.02475,-0.01 -0.03711,-0.006 -0.01739,0.005 -0.02822,0.0233 -0.04492,0.0312 -0.213241,0.0965 -0.0017,4e-4 -0.121094,0.0195 -0.02835,0.005 -0.05463,0.0167 -0.08203,0.0254 -0.02759,0.009 -0.05463,0.0167 -0.08203,0.0254 -0.02759,0.009 -0.05323,0.0265 -0.08203,0.0254 -0.07706,-0.003 -0.152396,-0.0246 -0.228515,-0.0371 l -0.646485,-0.10547 -0.265625,-0.0449 c -0.03806,-0.006 -0.07869,-0.006 -0.115234,-0.0176 -0.03829,-0.0144 -0.06902,-0.0432 -0.107422,-0.0566 -0.03666,-0.0117 -0.0821,0.003 -0.113281,-0.0195 -0.01474,-0.0102 0.02513,-0.0282 0.04297,-0.0312 z"
-         style="fill:url(#linearGradient1319);fill-opacity:1;stroke:none;stroke-width:0.30836901px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path1119" />
-      <path
-         inkscape:connector-curvature="0"
-         transform="scale(0.26458333)"
-         d="m 81.115234,-273.86523 c -0.0071,0.0428 -0.01218,0.0843 -0.01953,0.1289 l -0.02539,0.15039 c -0.0083,0.0507 -0.02955,0.10113 -0.02539,0.15235 0.0049,0.0572 0.04363,0.10928 0.05273,0.16601 0.0042,0.0253 -0.02879,0.0554 -0.01367,0.0762 0.08474,0.11811 0.09783,-0.11499 0.06445,0.0879 l -0.03711,0.22852 c 0.163805,-0.37874 0.06158,0.0926 0.125,-0.29297 l 0.115234,-0.69726 z m -1.357422,4.66601 c -0.01246,-0.004 -0.02513,-0.006 -0.03516,0.002 -0.0418,0.0299 0.0064,0.11074 -0.02344,0.15235 -0.02154,0.0295 -0.06845,0.0349 -0.08984,0.0644 -0.04048,0.0559 0.0032,0.1707 -0.03711,0.22656 -0.02117,0.0291 -0.06661,0.0349 -0.08789,0.0645 -0.0033,0.005 -0.07965,0.43485 -0.07617,0.45703 0.0057,0.0359 0.05867,0.052 0.06445,0.0879 0.0079,0.0506 -0.0337,0.10166 -0.02539,0.15234 0.0057,0.0359 0.05364,0.0532 0.06445,0.0879 0.01512,0.0491 -0.04066,0.10329 -0.02539,0.15235 0.01058,0.0344 0.0518,0.0532 0.0625,0.0879 0.01512,0.0492 -0.03871,0.10328 -0.02344,0.15234 0.01096,0.0344 0.05683,0.052 0.0625,0.0879 0.0079,0.0507 -0.02955,0.10113 -0.02539,0.15235 0.0094,0.11459 0.09414,0.21548 0.103516,0.33007 0.0042,0.0512 -0.01708,0.10163 -0.02539,0.15235 l -0.05078,0.30468 c -0.01096,0.0659 -0.02867,0.26116 -0.05078,0.30274 -0.02683,0.0508 -0.07292,0.0898 -0.09961,0.14062 -0.03288,0.0621 -0.03052,0.33641 -0.0625,0.38086 -0.02154,0.0291 -0.06845,0.033 -0.08984,0.0625 -0.01512,0.0208 -0.0076,0.051 -0.01172,0.0762 -0.0091,0.054 -0.06374,0.43887 -0.07617,0.45703 -0.02117,0.0291 -0.07085,0.0303 -0.08789,0.0625 -0.02381,0.0448 -0.09288,0.56843 -0.09961,0.60937 -0.01852,0.11316 -0.02697,0.0947 0.03906,0.24024 0.01512,0.0329 0.05169,0.0551 0.0625,0.0898 0.0079,0.0246 -0.0076,0.0508 -0.01172,0.0762 -0.0042,0.0253 0.0071,0.0611 -0.01367,0.0762 -0.02079,0.0144 -0.05542,-0.028 -0.07617,-0.0137 -0.0418,0.0299 0.0064,0.11073 -0.02344,0.15235 -0.02116,0.0291 -0.0686,0.0349 -0.08984,0.0645 -0.04048,0.0559 0.0032,0.1707 -0.03711,0.22656 -0.02116,0.0291 -0.06661,0.0349 -0.08789,0.0645 -0.04052,0.0559 0.0032,0.17266 -0.03711,0.22852 -0.154091,0.21256 -0.03913,-0.14905 -0.191406,0.20312 -0.02041,0.0472 -0.003,0.10518 -0.02344,0.15235 -0.02268,0.0527 -0.0787,0.086 -0.101562,0.13867 -0.02041,0.0472 -0.01708,0.10162 -0.02539,0.15234 l -0.03711,0.22852 c -0.02079,0.1268 -0.06273,0.25237 -0.0625,0.38086 2.3e-4,0.0813 0.03884,0.15894 0.03906,0.24023 1.78e-4,0.0876 -0.09968,0.45934 -0.08789,0.53321 0.0057,0.0359 0.0518,0.0532 0.0625,0.0879 0.01625,0.0526 -0.05911,0.24013 -0.04883,0.30469 0.0091,0.0567 0.04167,0.10733 0.05078,0.16406 0.0042,0.0253 -0.02161,0.0516 -0.01367,0.0762 0.01058,0.0344 0.04949,0.0546 0.06445,0.0879 0.02381,0.0522 0.01718,0.11731 0.05078,0.16406 0.01512,0.0204 0.05542,-0.002 0.07617,0.0137 0.02948,0.0208 0.03486,0.0667 0.06445,0.0879 0.02079,0.0151 0.05347,-0.002 0.07422,0.0137 0.02948,0.0208 0.04321,0.0584 0.06445,0.0879 0.08179,0.11391 0.136013,0.20818 0.267578,0.27734 0.04532,0.0234 0.310335,0.0512 0.378907,0.0625 l 0.533203,0.0879 c 0.07612,0.0125 0.151413,0.0404 0.228515,0.0371 0.05745,-0.002 0.106803,-0.046 0.164063,-0.0508 0.04879,-0.004 0.208852,0.0304 0.308594,0.0488 -5.75e-4,9.1e-4 -0.0037,6.7e-4 -0.0039,0.002 -0.0042,0.0253 0.05554,0.0261 0.07617,0.0117 0.01399,-0.009 0.02199,-0.20066 0.03711,-0.22852 0.02683,-0.0509 0.0717,-0.0895 0.101562,-0.13867 0.04203,-0.0695 0.07137,-0.14541 0.113281,-0.21484 0.02986,-0.0492 0.0787,-0.088 0.101563,-0.14063 0.02041,-0.0472 0.01512,-0.10162 0.02344,-0.15234 0.0083,-0.0507 0.03371,-0.10166 0.02539,-0.15234 -0.0019,-0.0102 -0.179501,-0.25656 -0.191406,-0.26563 -0.04157,-0.0302 -0.120457,0.0162 -0.150391,-0.0254 -0.01512,-0.0204 0.02684,-0.0554 0.01172,-0.0762 -0.02986,-0.0418 -0.12241,0.0181 -0.152344,-0.0234 -0.01512,-0.0204 0.02646,-0.0552 0.01172,-0.0762 -0.01512,-0.0204 -0.05339,0.003 -0.07422,-0.0117 -0.02948,-0.0208 -0.03497,-0.0685 -0.06445,-0.0898 -0.205455,-0.14865 0.07211,0.19218 -0.138672,-0.10157 -0.04199,-0.0391 -0.0941,-0.0659 -0.140625,-0.0996 -0.04656,-0.0336 -0.08784,-0.0747 -0.138672,-0.10157 -0.02268,-0.0117 -0.06121,0.009 -0.07617,-0.0117 -0.01512,-0.0204 0.02684,-0.0551 0.01172,-0.0762 -0.01512,-0.0204 -0.06109,0.007 -0.07617,-0.0137 -0.01512,-0.0204 0.02684,-0.0552 0.01172,-0.0762 -0.01512,-0.0204 -0.05925,0.009 -0.07422,-0.0117 -0.01512,-0.0204 0.02684,-0.0552 0.01172,-0.0762 -0.01512,-0.0204 -0.06109,0.009 -0.07617,-0.0117 -0.01512,-0.0204 0.02684,-0.0552 0.01172,-0.0762 -0.01512,-0.0204 -0.05542,0.002 -0.07617,-0.0137 -0.154356,-0.11183 -0.01556,-0.0505 -0.05078,-0.16406 -0.05639,-0.18194 -0.04233,-0.0318 -0.138672,-0.10156 -0.154356,-0.11184 -0.01567,-0.0505 -0.05078,-0.16406 -0.04082,-0.13161 -0.08613,-0.0461 -0.126954,-0.17774 -0.07502,-0.2423 0.157975,0.12969 -0.05273,-0.16406 -0.0017,-0.004 0.03642,-0.22545 0.03906,-0.22852 0.02116,-0.0291 0.06661,-0.0349 0.08789,-0.0645 0.05397,-0.0746 -0.02866,-0.0777 0.02539,-0.15234 0.02154,-0.0291 0.0665,-0.033 0.08789,-0.0625 0.04048,-0.0559 -0.0032,-0.17266 0.03711,-0.22852 0.02116,-0.0291 0.06857,-0.0329 0.08984,-0.0625 0.02003,-0.0276 0.01935,-0.21555 0.03711,-0.22851 0.02079,-0.0144 0.05538,0.0261 0.07617,0.0117 0.01739,-0.0129 0.04409,-0.35529 0.0625,-0.38086 0.01512,-0.0208 0.06117,0.0345 0.07617,0.0137 0.03099,-0.0429 0.03128,-0.33758 0.0625,-0.38086 0.02154,-0.0291 0.06661,-0.0331 0.08789,-0.0625 0.01512,-0.0208 0.0076,-0.0508 0.01172,-0.0762 0.0083,-0.0507 0.0016,-0.10695 0.02539,-0.15235 0.01701,-0.0321 0.06845,-0.0349 0.08984,-0.0645 0.01512,-0.0208 -2.51e-4,-0.0535 0.01172,-0.0762 0.02684,-0.0509 0.07881,-0.086 0.101563,-0.13867 0.02457,-0.0569 0.05963,-0.36827 0.07422,-0.45704 0.0042,-0.0253 0.02879,-0.0552 0.01367,-0.0762 -0.01512,-0.0204 -0.06121,0.009 -0.07617,-0.0117 -0.01512,-0.0204 -0.01285,-0.0684 0.01172,-0.0762 0.04902,-0.0151 0.10321,0.0407 0.152344,0.0254 0.04906,-0.0151 -0.0045,-0.11073 0.02539,-0.15234 0.02116,-0.0291 0.06665,-0.0349 0.08789,-0.0644 0.01512,-0.0208 -0.0035,-0.0554 0.01172,-0.0762 0.148687,-0.20519 0.05824,0.13152 0.115234,-0.21484 0.0042,-0.0253 0.03062,-0.0587 0.01172,-0.0762 -0.43991,-0.41069 -0.07097,-0.0114 -0.291016,-0.12695 -0.05098,-0.0261 -0.08979,-0.0727 -0.140624,-0.0996 -0.02268,-0.0117 -0.06117,0.007 -0.07617,-0.0137 -0.01512,-0.0204 0.0017,-0.0535 0.01367,-0.0762 0.274355,-0.52076 -0.04193,0.11632 0.189453,-0.20312 0.01512,-0.0208 0.0076,-0.0508 0.01172,-0.0762 0.03364,-0.0466 0.06789,-0.0921 0.101563,-0.13868 0.02495,-0.0264 0.0583,-0.0433 0.08789,-0.0644 0.02532,0.004 0.05554,0.028 0.07617,0.0137 0.0418,-0.0299 -0.01618,-0.12229 0.02539,-0.15234 0.345713,-0.24798 0.03742,0.025 0.240234,-0.0391 0.342577,-0.10583 -0.08186,-0.007 0.101563,-0.13868 0.05907,-0.0424 0.09327,0.0678 0.152344,0.0254 0.01814,-0.0129 0.01708,-0.20084 0.03711,-0.22851 0.02116,-0.0291 0.082,-0.0285 0.08789,-0.0644 0.0042,-0.0253 -0.05263,-0.002 -0.07617,-0.0117 -0.07457,-0.0321 -0.1388,-0.0846 -0.214844,-0.11328 -0.04811,-0.0178 -0.103588,-0.01 -0.152344,-0.0254 -0.615243,-0.20958 -0.05941,-0.0322 -0.43164,-0.22852 -0.0401,-0.0204 -0.202399,-0.0129 -0.228516,-0.0371 -0.05314,-0.0496 -0.07381,-0.12619 -0.126953,-0.17578 -0.0189,-0.017 -0.08037,0.0117 -0.07617,-0.0137 0.0049,-0.031 0.243099,-0.14682 0.265625,-0.18946 0.02381,-0.0454 -0.0098,-0.1147 0.02539,-0.15234 0.03916,-0.0419 0.124831,-0.009 0.164062,-0.0508 0.03515,-0.0378 0.0016,-0.10695 0.02539,-0.15234 0.01701,-0.0321 0.06857,-0.0349 0.08984,-0.0645 0.08988,-0.12412 -0.03611,-0.0485 -0.06445,-0.0879 -0.01512,-0.0204 0.0076,-0.0506 0.01172,-0.0762 l -0.367187,-0.13867 v -0.002 c -0.315402,-0.13594 -0.186564,-0.10896 -0.367188,-0.13867 -0.01194,-0.002 -0.02654,-0.008 -0.03906,-0.0137 z m 2.423829,11.60156 v 0.0547 l -0.0625,0.38086 c -0.06342,0.38549 0.03666,-0.0857 -0.126953,0.29297 -0.02041,0.0472 -0.005,0.10322 -0.02539,0.15039 -0.04562,0.10556 -0.147616,0.17763 -0.201172,0.2793 -0.01209,0.0227 -0.0017,0.0535 -0.01367,0.0762 -0.02684,0.0509 -0.07686,0.0879 -0.09961,0.14062 -0.02041,0.0472 -0.01708,0.10163 -0.02539,0.15235 l -0.02539,0.15234 c -0.0083,0.0507 -0.0337,0.10166 -0.02539,0.15235 0.0057,0.0359 0.05376,0.0532 0.06445,0.0879 0.02419,0.0778 0.01969,0.16082 0.03711,0.24023 0.01247,0.0561 0.04805,0.10883 0.05273,0.16602 -0.057,0.34628 -0.0381,-0.003 0.03711,0.24023 0.0079,0.0246 -0.01966,0.0516 -0.01172,0.0762 0.05163,0.16657 0.171644,0.0531 0.214844,0.11328 0.01512,0.0204 0.0091,0.0611 -0.01172,0.0762 -0.02079,0.0144 -0.05554,-0.028 -0.07617,-0.0137 -0.131527,0.0944 -0.127222,0.30458 -0.15039,0.44532 l -0.08789,0.53125 -0.0625,0.38085 -0.01367,0.0762 c -0.0042,0.0253 -0.01966,0.0516 -0.01172,0.0762 0.01058,0.0348 0.04321,0.0584 0.06445,0.0879 0.08447,0.11769 0.12737,0.2195 0.265625,0.2793 0.04732,0.0197 0.10166,0.0151 0.152343,0.0234 0.02532,0.004 0.05535,-0.002 0.07617,0.0137 0.02948,0.0208 0.03497,0.0667 0.06445,0.0879 0.02079,0.0151 0.06658,-0.0128 0.07422,0.0117 0.01512,0.0491 -0.01512,0.10162 -0.02344,0.15234 -0.0042,0.0253 0.0015,0.0554 -0.01367,0.0762 -0.03591,0.0494 -0.247034,0.11557 -0.02344,0.15234 0.05072,0.008 0.1036,0.0466 0.150391,0.0254 0.05235,-0.0238 0.05492,-0.10507 0.101562,-0.13867 0.04675,-0.0336 0.11731,-0.0191 0.164063,-0.0527 0.02079,-0.0144 -0.0015,-0.0554 0.01367,-0.0762 0.02116,-0.0295 0.07103,-0.0305 0.08789,-0.0625 0.0359,-0.0681 0.02464,-0.15247 0.03711,-0.22852 0.0072,-0.0424 0.06832,-0.34221 0.0625,-0.37891 -0.0057,-0.0359 -0.04749,-0.0568 -0.0625,-0.0898 -0.02381,-0.0522 -0.03381,-0.10918 -0.05078,-0.16406 -0.01701,-0.0549 -0.0337,-0.10919 -0.05078,-0.16406 0.0083,-0.0507 0.03175,-0.1017 0.02344,-0.15235 -0.0057,-0.0359 -0.05177,-0.0553 -0.0625,-0.0898 -0.0079,-0.0246 0.0076,-0.0508 0.01172,-0.0762 0.01247,-0.0767 0.08328,-0.4107 0.07617,-0.45508 -0.0057,-0.0359 -0.05364,-0.0551 -0.06445,-0.0898 -0.0079,-0.0246 0.02161,-0.0516 0.01367,-0.0762 -0.01058,-0.0348 -0.05878,-0.052 -0.06445,-0.0879 -0.0079,-0.0506 0.04675,-0.10544 0.02539,-0.15234 -0.13954,-0.30845 -0.1247,0.0634 -0.203125,-0.18945 -0.0079,-0.0246 0.01966,-0.0516 0.01172,-0.0762 -0.03061,-0.0988 -0.158838,-0.1669 -0.189453,-0.26562 -0.0079,-0.0246 0.01588,-0.0508 0.01172,-0.0762 -0.01134,-0.0709 -0.122107,-0.42735 -0.152344,-0.49414 -0.01512,-0.0333 -0.05867,-0.052 -0.06445,-0.0879 -0.01209,-0.076 0.02464,-0.15248 0.03711,-0.22852 l 0.09961,-0.60938 c 0.01361,-0.0818 0.05377,-0.21425 0.05078,-0.30273 -0.0042,-0.12503 -0.0167,-0.24938 -0.02539,-0.37305 z m 3.566406,2.59571 -0.152344,0.44336 -0.113281,0.68554 c -0.0083,0.0507 -0.03137,0.10147 -0.02344,0.15235 0.0091,0.0567 0.04179,0.10733 0.05078,0.16406 0.0072,0.0452 -0.02917,0.17859 -0.03711,0.22852 -0.0068,0.0398 -0.05789,0.28295 -0.05078,0.30468 0.01058,0.0348 0.05364,0.0531 0.06445,0.0879 0.07502,0.24227 -0.159965,-0.12968 0.05078,0.16407 0.210785,0.29382 -0.06678,-0.0473 0.138672,0.10156 0.01814,0.0128 0.07138,0.15134 0.140625,0.10156 0.02079,-0.0144 0.0076,-0.051 0.01172,-0.0762 l 0.05078,-0.30469 c 0.0083,-0.0507 0.0049,-0.10427 0.02344,-0.15234 0.02872,-0.076 0.08908,-0.13786 0.115234,-0.21485 0.02495,-0.0729 0.02464,-0.15247 0.03711,-0.22851 l 0.03711,-0.22852 0.02539,-0.15234 c 0.0083,-0.0507 0.02759,-0.10113 0.02344,-0.15234 0.06856,-0.13021 -0.09865,-0.16038 -0.113281,-0.25196 -0.0079,-0.0506 0.02955,-0.10113 0.02539,-0.15234 -0.03137,-0.38244 -0.0373,-0.003 -0.115234,-0.25391 -0.0079,-0.0246 0.01966,-0.0516 0.01172,-0.0762 -0.01058,-0.0348 -0.05165,-0.0534 -0.0625,-0.0879 -0.02117,-0.0686 0.01827,-0.0823 0.02734,-0.084 0.0078,-0.002 -0.01568,0.007 -0.166015,-0.0176 z"
-         style="fill:#5e5e5e;fill-opacity:0.252747;stroke:none;stroke-width:0.30836901px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path1130" />
-      <path
-         inkscape:connector-curvature="0"
-         transform="scale(0.26458333)"
-         d="m 80.507812,-273.86523 c 0.05537,0.19983 0.189375,0.37837 0.431641,0.51367 0.119433,0.64304 -0.566901,1.25264 -0.310547,1.88281 0.129638,0.40554 -0.18744,1.04362 -0.203125,1.56836 -0.01172,0.45851 -0.450711,0.52644 -0.160156,0.9668 -0.642505,0.35353 0.376497,0.71515 0.02734,0.89257 -0.476421,0.40426 0.558091,1.07724 0.308593,1.09766 -0.186859,0.62947 0.03345,1.22024 -0.138671,1.85547 0.405471,0.33747 -0.02232,1.06915 -0.189453,1.45703 -0.03591,0.71448 -1.05826,0.87995 -1.044922,1.67578 -0.182703,0.6179 0.06579,1.21518 -0.136719,1.83399 0.344844,0.30497 0.767982,0.92991 1.498047,0.63476 1.009674,-0.23323 -0.03526,1.29109 1.21289,1.02344 0.676441,0.21059 0.130242,1.27303 0.65625,1.71484 0.431278,0.24718 0.190405,0.81453 -0.04102,1.26367 -0.294955,0.53261 -0.673856,1.03861 -0.521485,1.81836 -0.138708,0.87894 1.276605,1.04584 1.613282,1.6211 0.156623,0.30999 -0.633228,1.15749 -0.476563,1.43554 -0.03628,0.96468 1.073962,1.3996 0.726563,2.41602 -0.197178,0.81838 1.200073,1.3078 0.568359,1.91797 -0.05193,0.36593 -0.168386,0.97872 -0.240234,1.45117 0.517734,0.47078 0.975155,1.10504 0.408203,1.89063 0.146116,0.49651 0.182232,1.00493 -0.08789,1.5332 0.359623,0.64193 -0.139798,1.11781 -0.441406,1.6582 h 1.763672 c 0.191747,-0.45458 0.05736,-1.16845 -0.121094,-1.57226 -0.402576,-0.83059 0.356592,-1.61097 0.230469,-2.40625 -0.500134,-1.01632 0.05644,-2.19618 -0.357422,-3.19336 -0.03175,-0.75556 -0.132953,-1.63512 -0.695313,-2.16016 -0.05412,-0.99169 -0.263278,-2.01119 -0.927734,-2.74805 -0.159194,-0.89353 -0.360592,-1.78993 -0.333984,-2.67578 0.05382,-0.77857 0.375877,-1.35871 0.746093,-1.84179 0.246841,-0.84753 -1.089959,-1.29439 -1.242187,-2.19336 -0.706647,-0.35641 -0.9336,-1.26844 -1.615235,-1.5918 -0.717928,-0.43068 0.277259,-1.08227 0.291016,-1.77539 -0.272277,-0.42816 -0.101421,-1.02542 -0.02148,-1.55078 -0.391287,-0.78717 -0.265355,-1.73532 -0.460938,-2.56055 0.296391,-0.57454 -0.46064,-1.34254 0.220703,-1.67773 0.69069,-0.66867 0.100186,-1.49001 0.146485,-2.24024 0.152504,-0.65738 0.0513,-1.28168 0.04102,-1.92578 7.49e-4,-0.56649 0.329099,-1.14952 0.347657,-1.77148 0.03724,-0.0719 0.06062,-0.15797 0.08984,-0.23828 z"
-         style="fill:#e3e3e3;fill-opacity:1;stroke:none;stroke-width:0.30836901px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path1127-2" />
-      <path
-         id="path1147"
-         d="m 22.099004,-69.465704 c -0.0095,-0.0021 -0.01898,-0.0037 -0.02848,-0.0026 -0.03199,0.0041 -0.06072,0.02274 -0.09242,0.0287 -0.02409,0.0045 -0.0492,-4.23e-4 -0.07355,0.0024 -0.04531,0.0052 -0.0898,0.01587 -0.135029,0.02168 -0.05436,0.007 -0.109254,0.0098 -0.16362,0.01682 -0.04523,0.0058 -0.08972,0.01645 -0.135028,0.02168 -0.02433,0.0028 -0.04934,-0.0015 -0.07355,0.0024 -0.0067,9.79e-4 -0.02047,0.0064 -0.0165,0.01196 0.0015,0.0023 0.06646,0.0094 0.07107,0.0117 0.006,0.0031 0.007,0.01185 0.01198,0.01648 0.0079,0.0073 0.01867,0.01122 0.02611,0.01897 0.02794,0.02919 0.04339,0.07028 0.07133,0.09943 0.0074,0.0078 0.01866,0.01121 0.02611,0.01897 0.0094,0.0099 0.01327,0.02442 0.0238,0.03299 0.02009,0.01636 0.04457,0.02623 0.06639,0.04016 0.0091,0.0057 0.01743,0.01268 0.02611,0.01897 0.01349,0.0069 0.02739,0.01349 0.04042,0.02132 0.0092,0.0057 0.01665,0.01381 0.02613,0.01881 0.0043,0.0023 0.0114,-0.0018 0.01415,0.0023 0.0028,0.0041 -0.0052,0.01037 -0.0024,0.01429 0.0056,0.0078 0.01999,1.57e-4 0.02846,0.0047 0.0095,0.0052 0.01695,0.01329 0.02613,0.01881 0.02601,0.01571 0.05467,0.0268 0.08069,0.04251 0.0092,0.0057 0.01624,0.01473 0.02611,0.01897 6.18e-4,2.3e-4 0.04271,0.007 0.04277,0.007 0.02461,0.03428 -0.04492,-0.0084 0.0095,0.0308 0.0039,0.0027 0.01039,-3.79e-4 0.01431,0.0024 0.0055,0.004 0.0068,0.01183 0.01183,0.01646 0.0079,0.0073 0.01739,0.01268 0.02611,0.01897 0.0079,0.01107 0.01469,0.02304 0.02378,0.03315 0.0116,0.01287 0.02648,0.02258 0.03809,0.0355 0.0091,0.01011 0.01439,0.02336 0.02377,0.03315 0.0074,0.0078 0.01869,0.01107 0.02613,0.01881 0.0094,0.0099 0.01587,0.02214 0.02377,0.03315 0.004,0.0054 0.0058,0.01343 0.0118,0.01661 0.08065,0.01327 0.0064,-0.0088 0.02613,0.01881 0.0032,0.0047 0.04987,0.004 0.05692,0.0094 0.03942,0.05499 -0.01231,-0.0089 0.02611,0.01897 0.0055,0.004 0.0065,0.0125 0.01198,0.01649 0.0039,0.0027 0.01039,-3.79e-4 0.01431,0.0024 0.0055,0.004 0.0063,0.01263 0.0118,0.01661 0.0039,0.0027 0.01039,-3.79e-4 0.01431,0.0024 0.0023,0.0014 0.0353,0.04779 0.0356,0.04961 0.0015,0.0095 -0.0067,0.0191 -0.0047,0.02847 0.0038,0.01691 0.01772,0.03048 0.02143,0.04744 0.0021,0.0094 -0.0056,0.01886 -0.0047,0.02847 7.72e-4,0.01067 0.0092,0.02011 0.0096,0.03082 5.66e-4,0.01555 -0.01299,0.07896 -0.01638,0.09954 -7.73e-4,0.0046 -0.0052,0.01037 -0.0024,0.01429 0.0041,0.0059 0.06208,0.005 0.07107,0.0117 0.011,0.008 0.01277,0.02517 0.02377,0.03315 0.0039,0.0027 0.0096,0.0016 0.01431,0.0024 0.02118,0.0035 0.01842,9.28e-4 0.04029,0.02114 0.0099,0.0093 0.01175,0.02684 0.02378,0.03315 0.0085,0.0045 0.02141,-0.0019 0.02846,0.0047 0.0079,0.0073 0.0022,0.02307 0.0096,0.03082 0.0105,0.01097 0.02723,0.01346 0.04026,0.0213 0.03039,0.01837 0.0341,0.02879 0.06422,0.05432 0.01711,0.01451 0.04669,0.03274 0.06639,0.04016 0.009,0.0036 0.02064,-7.73e-4 0.02846,0.0047 0.0039,0.0027 0.0024,0.0135 -0.0024,0.01429 -0.01426,0.0024 -0.02837,-0.0047 -0.04261,-0.007 l -0.05692,-0.0094 -0.170762,-0.0281 c -0.06641,-0.01093 -0.132068,-0.02821 -0.199223,-0.03279 -0.03489,-0.0026 -0.0694,0.01087 -0.104374,0.01206 -0.024,7.73e-4 -0.04735,-0.0078 -0.07107,-0.0117 -0.0095,-0.0015 -0.01999,-1.57e-4 -0.02846,-0.0047 -0.006,-0.0031 -0.007,-0.01201 -0.01196,-0.01664 -0.01571,-0.0147 -0.03482,-0.02526 -0.05224,-0.03783 -0.01742,-0.01263 -0.03384,-0.02671 -0.05223,-0.03783 -0.01303,-0.0078 -0.02884,-0.01132 -0.04045,-0.02117 -0.01037,-0.0088 -0.01341,-0.02435 -0.02377,-0.03315 -0.0116,-0.0098 -0.02866,-0.01145 -0.04026,-0.0213 -0.01037,-0.0088 -0.01338,-0.02434 -0.02378,-0.03315 -0.0116,-0.0098 -0.02884,-0.01132 -0.04044,-0.02117 -0.06413,-0.05441 0.0024,-0.01427 -0.03558,-0.04976 -0.0079,-0.0073 -0.01793,-0.01188 -0.02613,-0.01881 -0.01322,-0.01121 -0.02486,-0.02429 -0.03809,-0.0355 -0.0164,-0.01392 -0.03584,-0.02391 -0.05224,-0.03783 -0.01322,-0.0112 -0.02388,-0.02528 -0.03792,-0.03548 -0.01232,-0.0089 -0.02695,-0.01425 -0.04042,-0.02132 -0.01349,-0.0069 -0.02682,-0.01407 -0.04029,-0.02114 -0.01349,-0.0069 -0.02882,-0.01148 -0.04042,-0.02132 l -0.02377,-0.03315 c -0.0047,-7.72e-4 -0.01023,4.05e-4 -0.01415,-0.0023 -0.01156,-0.0084 -0.02421,-0.03886 -0.03576,-0.04964 -0.0079,-0.0073 -0.01826,-0.01162 -0.02611,-0.01897 -0.01937,-0.01807 -0.008,-0.02141 -0.02145,-0.04728 -0.0063,-0.01205 -0.0175,-0.0211 -0.02377,-0.03315 -0.0049,-0.0095 -0.0032,-0.02203 -0.0095,-0.0308 -0.02219,-0.03096 -0.04059,-0.01352 -0.05457,-0.02365 -0.0055,-0.004 -0.0065,-0.0125 -0.01198,-0.01649 -0.0039,-0.0027 -0.01151,0.0018 -0.01431,-0.0024 -0.0028,-0.0041 0.0062,-0.01145 0.0024,-0.01429 -0.0078,-0.0055 -0.01999,-1.56e-4 -0.02846,-0.0047 -0.006,-0.0031 -0.0063,-0.01247 -0.01183,-0.01646 -0.0039,-0.0027 -0.01038,3.79e-4 -0.01431,-0.0024 -0.0055,-0.004 -0.0068,-0.01198 -0.0118,-0.01661 -0.0079,-0.0074 -0.01826,-0.01162 -0.02611,-0.01897 -0.005,-0.0045 -0.008,-0.01098 -0.01198,-0.01649 -0.004,-0.0054 -0.0098,-0.01012 -0.0118,-0.01661 -0.0014,-0.0044 0.0038,-0.0096 0.0023,-0.01413 -0.01985,-0.0641 -0.0016,0.0153 -0.02611,-0.01897 -0.02461,-0.03428 0.04476,0.0084 -0.0096,-0.03082 -0.09367,-0.04935 0.0055,0.01067 -0.06406,-0.05429 -0.01571,-0.0147 -0.0384,-0.02136 -0.05224,-0.03783 -0.01548,-0.01837 -0.01939,-0.04444 -0.0334,-0.06395 -0.0063,-0.0088 -0.01826,-0.01162 -0.02611,-0.01897 -0.005,-0.0045 -0.0079,-0.01095 -0.01183,-0.01646 l -0.01196,-0.01664 c -0.004,-0.0054 -0.008,-0.02214 -0.01196,-0.01664 -0.0084,0.01166 -0.0072,0.02832 -0.007,0.04275 5e-6,0.01519 0.0073,0.02975 0.0073,0.04495 1.31e-4,0.01443 -0.01048,0.02877 -0.007,0.04275 0.0058,0.02335 0.02279,0.04239 0.0334,0.06396 0.0214,0.04351 0.0271,0.06777 0.05466,0.111388 0.0427,0.06758 0.06811,0.09401 0.121237,0.151413 0.01631,0.01767 0.03122,0.03699 0.04988,0.05212 0.02359,0.01918 0.05751,0.02283 0.0807,0.04251 0.03651,0.03097 0.0077,0.03373 0.04991,0.05197 0.08065,0.01327 0.0063,-0.0087 0.02611,0.01897 0.0056,0.0078 0.02284,-0.0031 0.02846,0.0047 0.0028,0.0041 -0.0038,0.0096 -0.0023,0.01413 0.0021,0.0065 0.008,0.01113 0.01196,0.01664 -0.0023,0.01423 -0.0071,0.02816 -0.007,0.0426 1.15e-4,0.05513 0.01204,0.03931 0.02853,0.09255 0.009,0.02905 0.0054,0.06102 0.01441,0.09007 0.0051,0.01656 0.01507,0.03115 0.02145,0.04728 0.004,0.01 0.0052,0.021 0.0096,0.03082 0.0028,0.0062 0.009,0.01041 0.0118,0.01661 0.0044,0.0098 0.0052,0.021 0.0096,0.03082 0.0028,0.0062 0.0092,0.01028 0.01198,0.01649 0.0044,0.0098 0.0042,0.02142 0.0095,0.0308 0.115588,0.161124 -0.0092,-0.02381 0.0452,0.08059 0.0063,0.01205 0.01879,0.02032 0.0238,0.03299 0.0056,0.01413 0.0028,0.03058 0.0073,0.0451 0.0021,0.0065 0.009,0.01041 0.0118,0.01661 0.0044,0.0098 0.0046,0.02129 0.0096,0.03082 0.0063,0.01205 0.01588,0.02209 0.02377,0.03315 0.004,0.0054 0.0109,0.0098 0.01198,0.01649 0.0015,0.0095 -0.0063,0.01897 -0.0047,0.02847 0.0011,0.0067 0.009,0.01041 0.0118,0.01661 0.0044,0.0098 0.0064,0.02059 0.0096,0.03082 0.0096,0.03081 0.019,0.06158 0.02856,0.09239 0.0031,0.01028 0.0052,0.02096 0.0096,0.03082 0.0028,0.0062 0.009,0.01025 0.01183,0.01646 0.0044,0.0098 0.0046,0.02128 0.0096,0.03082 0.0063,0.01205 0.0175,0.0211 0.02377,0.03315 0.0049,0.0095 0.0045,0.02126 0.0095,0.0308 0.0063,0.01205 0.01821,0.02069 0.02378,0.03315 0.0021,0.0045 -0.0038,0.0097 -0.0024,0.01429 0.0057,0.01848 0.03003,0.03115 0.03576,0.04964 0.0014,0.0044 -0.0038,0.0097 -0.0024,0.01429 0.0021,0.0065 0.009,0.01041 0.0118,0.01661 0.01316,0.02905 0.01694,0.06272 0.02872,0.09242 0.0064,0.01609 0.01633,0.03072 0.02145,0.04728 0.0045,0.01452 0.0015,0.03094 0.0071,0.04508 0.005,0.01263 0.0188,0.02048 0.02377,0.03315 0.0056,0.01413 0.0028,0.03043 0.0073,0.04495 0.004,0.01298 0.01975,0.02017 0.02377,0.03315 0.0014,0.0044 -0.0038,0.0097 -0.0024,0.01429 0.0021,0.0065 0.009,0.01025 0.01183,0.01646 0.0044,0.0098 0.0033,0.02206 0.0096,0.03082 0.0028,0.0041 0.01077,-8.24e-4 0.01431,0.0024 0.01489,0.01393 0.02367,0.03319 0.03558,0.04976 0.004,0.0054 0.0092,0.01028 0.01198,0.01648 0.0065,0.01444 0.0065,0.03662 0.02143,0.04744 0.03795,0.0062 -0.004,-0.0059 0.01183,0.01646 0.0028,0.0041 0.01155,-0.0018 0.01431,0.0024 0.0028,0.0041 -0.0052,0.01038 -0.0024,0.01429 0.0028,0.0041 0.01022,-4.06e-4 0.01415,0.0023 0.0055,0.004 0.0065,0.0125 0.01198,0.01648 0.0039,0.0027 0.0149,-0.0023 0.01415,0.0023 -7.73e-4,0.0046 -0.0096,-0.0037 -0.01415,-0.0023 -0.02082,0.0064 -0.04808,0.05488 -0.04016,0.06639 0.04331,-0.01114 0.08914,0.0013 0.132495,-0.0073 0.01699,-0.0033 0.03048,-0.01691 0.04727,-0.0213 0.02942,-0.0077 0.06071,-0.0065 0.09007,-0.01441 0.05391,-0.01452 0.08543,-0.04143 0.139873,-0.05014 0.0242,-0.0039 0.04962,0.0029 0.07355,-0.0024 0.02737,-0.006 0.05134,-0.02277 0.07811,-0.03105 0.01452,-0.0045 0.03013,-0.0048 0.04512,-0.0072 0.05565,-0.0089 0.03042,-0.0027 0.07576,-0.01677 0.02055,-0.0064 0.04037,-0.0157 0.06161,-0.0191 0.0048,-7.73e-4 0.01038,0.0054 0.01431,0.0024 0.0039,-0.003 -5.03e-4,-0.01026 0.0023,-0.01413 0.03935,-0.05436 -0.0034,0.015 0.03081,-0.0096 0.0039,-0.003 -0.0016,-0.01138 0.0023,-0.01413 0.0039,-0.003 0.0094,0.0031 0.01415,0.0023 0.01065,-0.0019 0.02034,-0.0073 0.03081,-0.0096 0.01486,-0.0033 0.03033,-0.0035 0.0451,-0.0071 0.02088,-0.0052 0.04028,-0.01634 0.06161,-0.0191 0.14053,-0.01812 0.04163,0.03363 0.196635,-0.04079 0.01839,-0.0088 0.03235,-0.02501 0.04978,-0.03556 0.0307,-0.01865 0.07005,-0.03123 0.0971,-0.05717 0.0078,-0.0074 0.01269,-0.01744 0.01899,-0.02611 0.0063,-0.0087 0.01253,-0.01746 0.01883,-0.02614 0.0063,-0.0087 0.01471,-0.01622 0.01899,-0.02611 0.004,-0.0088 1.54e-4,-0.01997 0.0047,-0.02847 0.0032,-0.006 0.0125,-0.0064 0.0165,-0.01195 0.0028,-0.0037 -5.03e-4,-0.01026 0.0023,-0.01413 0.004,-0.0055 0.01266,-0.0064 0.01666,-0.01193 0.0028,-0.0037 -0.0016,-0.01138 0.0023,-0.01413 0.0078,-0.0056 0.01895,0.0063 0.02846,0.0047 0.01065,-0.0019 0.02008,-0.0092 0.03081,-0.0096 0.01439,-2.42e-4 0.02836,0.0047 0.04261,0.007 l 0.04277,0.007 c 0.01424,0.0023 0.02832,0.0073 0.04277,0.007 0.01521,-1.09e-4 0.02974,-0.0066 0.04494,-0.0071 0.01917,-4.99e-4 0.03794,0.01241 0.05692,0.0094 0.0067,-9.79e-4 0.01017,-0.0099 0.01666,-0.01193 0.0045,-0.0013 0.0096,0.0037 0.01415,0.0023 0.01298,-0.004 0.02075,-0.0182 0.03314,-0.02378 0.0098,-0.0044 0.02128,-0.0045 0.03079,-0.0094 0.115003,-0.05993 -0.03256,0.01088 0.05214,-0.04988 0.0343,-0.02463 -0.0086,0.04474 0.03081,-0.0096 0.0028,-0.0037 0.0016,-0.0096 0.0024,-0.01429 0.0015,-0.0095 1.29e-4,-0.01982 0.0046,-0.02831 0.0032,-0.006 0.01098,-0.008 0.0165,-0.01196 0.01106,-0.0079 0.02334,-0.01433 0.03314,-0.02378 0.0078,-0.0074 0.01164,-0.01824 0.01899,-0.02611 0.0046,-0.005 0.01333,-0.0059 0.0165,-0.01196 0.0045,-0.0085 1.54e-4,-0.01997 0.0047,-0.02847 0.0032,-0.006 0.01263,-0.0063 0.01664,-0.01178 0.0056,-0.0078 -9.28e-4,-0.02067 0.0047,-0.02847 0.05496,-0.0394 -0.009,0.0123 0.01883,-0.02614 0.02091,-0.02887 0.0096,-0.0031 0.03081,-0.0096 0.01298,-0.004 0.01973,-0.02161 0.03315,-0.02378 0.0068,-9.79e-4 0.09005,0.01482 0.09969,0.01641 0.0047,7.73e-4 0.01022,0.0053 0.01415,0.0023 1.86e-4,-1.26e-4 0.01179,-0.0706 0.0117,-0.07107 -0.0017,-0.01062 -0.0078,-0.02018 -0.0095,-0.0308 -0.0061,-0.03791 0.02641,0.01949 -0.0073,-0.04511 -0.02076,-0.03986 -0.0201,-0.0267 -0.04991,-0.05196 -0.02644,-0.02241 -0.04793,-0.05065 -0.07601,-0.07097 -0.01232,-0.0089 -0.02724,-0.01346 -0.04026,-0.0213 -0.0092,-0.0057 -0.01664,-0.01381 -0.02613,-0.01881 -0.02019,-0.01063 -0.01666,0.01187 -0.04277,-0.007 -0.0039,-0.0027 0.0016,-0.0096 0.0024,-0.01429 7.73e-4,-0.0046 -0.0016,-0.01138 0.0023,-0.01413 0.0039,-0.003 0.0096,0.0031 0.01431,0.0024 0.05846,-0.0093 0.0036,-0.01408 0.05927,-0.0049 0.0093,0.0015 0.08156,0.01081 0.08538,0.01405 0.0079,0.0073 0.0032,0.02203 0.0095,0.0308 6.4e-5,8.9e-5 0.04231,0.0068 0.04277,0.007 0.0099,0.0042 0.01662,0.01396 0.02611,0.01897 0.0043,0.0023 0.01023,-4.05e-4 0.01415,0.0023 0.03228,0.02338 -0.0072,0.01333 0.02613,0.01881 l 0.01431,0.0024 c 0.0047,7.73e-4 0.01136,-0.0018 0.01415,0.0023 0.0028,0.0041 -0.0052,0.01038 -0.0024,0.01429 0.0028,0.0041 0.01038,-3.8e-4 0.01431,0.0024 0.0055,0.004 0.0065,0.0125 0.01198,0.01649 0.0039,0.0027 0.0094,0.0015 0.01415,0.0023 0.0095,0.0015 0.02067,-7.72e-4 0.02846,0.0047 0.0039,0.0027 -0.0062,0.01145 -0.0024,0.01429 0.0082,0.006 0.04873,0.0033 0.05692,0.0094 0.0055,0.004 0.0065,0.0125 0.01198,0.01649 0.0011,7.21e-4 0.05563,0.0097 0.05692,0.0094 0.0065,-0.0021 0.0097,-0.01072 0.01648,-0.0118 0.0095,-0.0015 0.01898,0.0063 0.02846,0.0047 0.0067,-9.79e-4 0.01017,-0.0099 0.01666,-0.01193 0.0045,-0.0013 0.0096,0.0037 0.01415,0.0023 0.0065,-0.0021 0.01111,-0.0078 0.01663,-0.01178 0.0055,-0.0038 0.0125,-0.0065 0.0165,-0.01196 0.0028,-0.0037 -0.0016,-0.01133 0.0023,-0.01413 0.0039,-0.003 0.0096,0.0016 0.01431,0.0024 l 0.01431,0.0024 0.127993,0.02106 c 0.01898,0.0031 0.03772,0.0088 0.05692,0.0094 0.01518,4.11e-4 0.02993,-0.0067 0.04512,-0.0072 0.0082,-2.22e-4 0.05528,0.01066 0.05692,0.0094 0.0039,-0.003 -0.0015,-0.01153 0.0024,-0.01429 0.0039,-0.003 0.0094,0.0015 0.01415,0.0023 l 0.01431,0.0024 0.185071,0.03046 c 0.02373,0.0039 0.04856,0.0033 0.07107,0.0117 0.01007,0.0038 0.01625,0.01468 0.02611,0.01897 0.01766,0.0076 0.0389,0.0027 0.05692,0.0094 0.01419,0.0055 0.02647,0.01527 0.04042,0.02132 0.0044,0.0018 0.0094,0.0015 0.01415,0.0023 l 0.07123,0.01172 c 0.03051,0.005 0.08765,0.01808 0.113841,0.01874 0.01518,4.11e-4 0.02977,-0.0073 0.04496,-0.0073 0.01445,-2.34e-4 0.02842,0.0073 0.04277,0.007 0.01074,-3.21e-4 0.02009,-0.0092 0.03081,-0.0096 0.0093,-5.67e-4 0.07411,0.01585 0.08538,0.01405 0.01856,-0.003 0.01673,-0.01333 0.01881,-0.02598 7.73e-4,-0.0046 0.0031,-0.0096 0.0024,-0.01429 -0.0017,-0.01062 -0.0063,-0.02056 -0.0095,-0.0308 -0.0031,-0.01028 -0.0046,-0.02129 -0.0096,-0.03082 -0.0063,-0.01206 -0.01587,-0.02214 -0.02378,-0.03315 -0.0079,-0.01107 -0.01469,-0.02304 -0.02377,-0.03315 -0.0116,-0.01287 -0.02782,-0.02139 -0.03793,-0.03548 -0.07901,-0.174635 0.02556,0.03564 -0.04755,-0.06629 -0.0063,-0.0087 -0.0033,-0.02211 -0.0096,-0.03082 -5.67e-4,-6.19e-4 -0.03916,-0.0064 -0.04261,-0.007 l -0.128149,-0.02109 c -0.01424,-0.0023 -0.02906,-0.0022 -0.04261,-0.007 -0.01007,-0.0038 -0.01664,-0.01386 -0.02613,-0.01881 -0.0043,-0.0023 -0.01039,3.8e-4 -0.01431,-0.0024 -0.0055,-0.004 -0.0063,-0.01263 -0.0118,-0.01661 -0.0039,-0.0027 -0.01039,3.79e-4 -0.01431,-0.0024 -0.0055,-0.004 -0.0059,-0.01335 -0.01198,-0.01648 -0.0085,-0.0045 -0.01969,-6.19e-4 -0.02846,-0.0047 -0.0099,-0.0042 -0.01677,-0.01341 -0.02595,-0.01894 -0.01302,-0.0079 -0.02741,-0.01334 -0.04044,-0.02117 -0.0092,-0.0057 -0.01689,-0.01343 -0.02611,-0.01897 -0.03984,-0.0241 -0.05,-0.02358 -0.09501,-0.04487 -0.01375,-0.0064 -0.02586,-0.01642 -0.04026,-0.0213 -0.01361,-0.0048 -0.02953,-0.0012 -0.04277,-0.007 -0.0063,-0.0026 -0.0063,-0.01247 -0.01183,-0.01646 -0.0039,-0.0027 -0.01038,3.79e-4 -0.01431,-0.0024 -0.0055,-0.004 -0.0063,-0.01263 -0.0118,-0.01661 -0.0039,-0.0027 -0.01005,-8.8e-5 -0.01431,-0.0024 -0.0095,-0.0052 -0.01628,-0.01453 -0.02613,-0.01881 -0.01078,-0.0044 -0.07058,-0.01162 -0.08538,-0.01405 -0.0095,-0.0015 -0.02067,7.72e-4 -0.02846,-0.0047 -0.0039,-0.0027 0.0062,-0.01145 0.0024,-0.01429 -0.0078,-0.0055 -0.01999,-1.57e-4 -0.02846,-0.0047 -0.006,-0.0031 -0.0079,-0.01095 -0.01183,-0.01646 -0.0087,-0.0061 -0.01625,-0.01468 -0.02611,-0.01897 -0.0088,-0.0041 -0.01897,-0.0031 -0.02846,-0.0047 -0.0087,-0.0061 -0.01625,-0.01468 -0.02611,-0.01897 -0.0088,-0.0041 -0.01899,-0.0031 -0.02846,-0.0047 l -0.08538,-0.01405 c -0.01898,-0.0031 -0.03871,-0.0032 -0.05692,-0.0094 -0.01879,-0.0062 -0.03551,-0.01816 -0.0546,-0.0235 -0.02316,-0.0064 -0.04751,-0.0078 -0.07123,-0.01172 l -0.05692,-0.0094 c -0.111009,-0.01827 0.02625,0.009 -0.08303,-0.02833 -0.02273,-0.0079 -0.04751,-0.0078 -0.07123,-0.01172 l -0.02846,-0.0047 c -0.0047,-7.72e-4 -0.01269,0.0021 -0.01415,-0.0023 -0.0028,-0.0092 0.0031,-0.01901 0.0047,-0.02847 l 0.0046,-0.02831 c 0.0036,-0.0217 0.006,-0.08977 0.03056,-0.09736 0.0065,-0.0021 0.0053,0.01538 0.01198,0.01649 0.0067,0.0011 0.01863,-0.0053 0.01663,-0.01178 -0.0031,-0.01028 -0.01608,-0.01518 -0.02611,-0.01897 -0.01355,-0.0048 -0.02852,-0.0047 -0.04277,-0.007 -0.05218,-0.0086 -0.104013,-0.02025 -0.15661,-0.02577 -0.134981,-0.01418 -0.19149,-0.0074 -0.334251,-0.0111 -0.0775,-0.002 -0.154921,-0.0056 -0.232366,-0.009 -0.0435,-0.0019 -0.08696,-0.0079 -0.130476,-0.007 -0.142278,0.0031 -0.06112,0.01918 -0.146986,0.005 -0.0047,-7.73e-4 -0.01006,-8.9e-5 -0.01431,-0.0024 -0.01901,-0.01002 -0.03482,-0.02526 -0.05224,-0.03783 -0.0947,-0.06858 0.0201,0.01871 -0.03793,-0.03548 -0.0079,-0.0073 -0.01828,-0.01147 -0.02613,-0.01881 -0.005,-0.0045 -0.008,-0.01113 -0.01196,-0.01664 -0.0079,-0.01107 -0.01819,-0.0208 -0.02377,-0.03315 -0.004,-0.0087 0.0075,-0.01928 0.0047,-0.02847 -0.0021,-0.0065 -0.0098,-0.01 -0.01183,-0.01646 -0.0014,-0.0044 0.0031,-0.0096 0.0024,-0.01429 -0.0017,-0.01062 -0.0079,-0.0202 -0.0096,-0.03082 -7.73e-4,-0.0048 0.0038,-0.0096 0.0023,-0.01413 -0.004,-0.01298 -0.01976,-0.02017 -0.02377,-0.03315 -0.0028,-0.0092 0.0075,-0.01928 0.0047,-0.02847 -0.0021,-0.0065 -0.0098,-0.01012 -0.0118,-0.01661 -0.0014,-0.0044 0.0038,-0.0096 0.0023,-0.01413 -0.0021,-0.0065 -0.0091,-0.01043 -0.01196,-0.01664 -0.0044,-0.0098 -0.0032,-0.02203 -0.0095,-0.0308 -0.0063,-0.0088 -0.01828,-0.01147 -0.02613,-0.01881 -0.01147,-0.01071 -0.01349,-0.0148 -0.01206,-0.01603 -0.0095,-0.0037 -0.0241,-0.0098 -0.05449,-0.02416 -0.04802,-0.02268 -0.04872,-0.03203 -0.109156,-0.0472 -0.03267,-0.008 -0.06648,-0.01094 -0.09969,-0.01641 l -0.170761,-0.0281 -0.08538,-0.01405 c -0.02373,-0.0039 -0.04901,-0.0022 -0.07107,-0.0117 -0.01591,-0.0068 -0.02324,-0.02654 -0.03809,-0.03551 -0.01234,-0.0075 -0.02836,-0.0047 -0.04261,-0.007 l -0.04277,-0.007 c -0.0095,-0.0015 -0.01902,-0.0042 -0.02844,-0.0068 z m 0.742454,0.197936 c 0.02264,0.0089 0.0033,-0.0031 0,0 z m 0.795626,0.593148 c 0.0032,-10e-4 0.0067,0.0011 0.01007,0.0016 l 0.01007,0.0016 0.05032,0.0083 c 0.0067,0.0011 0.01387,7.21e-4 0.02013,0.0033 0.007,0.0032 0.0115,0.01035 0.01847,0.01338 0.01252,0.0052 0.02773,0.0014 0.04025,0.0066 0.05008,0.02171 -0.01239,0.0083 0.0386,0.01669 0.0028,-0.0022 0.01064,-0.0019 0.01006,0.0016 -5.67e-4,0.0036 -0.0067,-0.0011 -0.01006,-0.0016 -0.0028,0.0022 0.0012,0.008 -0.0016,0.01007 -0.0028,0.0022 -0.0072,-0.0038 -0.01007,-0.0016 -0.0028,0.0022 0.0012,0.008 -0.0016,0.01007 -0.0055,0.0038 -0.01397,-0.006 -0.02013,-0.0033 -0.0088,0.0039 -0.01404,0.01476 -0.02344,0.01682 -0.0099,0.002 -0.02002,-0.0048 -0.03019,-0.0049 -0.0108,3.11e-4 -0.02122,0.0034 -0.03185,0.0051 -0.01065,0.0019 -0.02115,0.0037 -0.03185,0.0051 -0.01388,0.0014 -0.02808,0.0012 -0.04191,0.0035 -0.06731,0.0108 -0.03369,0.01095 -0.08547,0.01694 -0.01388,0.0014 -0.02814,6.7e-4 -0.04191,0.0035 -0.05225,0.01035 -0.03275,0.01899 -0.08547,0.01694 -0.01358,-6.7e-4 -0.02684,-0.0044 -0.04025,-0.0066 l -0.09057,-0.0149 -0.05032,-0.0083 c -0.0034,-5.66e-4 -0.008,0.0013 -0.01007,-0.0016 -0.002,-0.0029 -0.0012,-0.008 0.0016,-0.01007 0.0025,-0.0017 0.03438,0.0077 0.04025,0.0066 0.0055,-0.0012 0.01063,-0.0029 0.01584,-0.0049 -0.02674,-0.0039 0.04658,-0.02016 0.0059,-0.0016 -0.0018,7.72e-4 -0.0039,0.0014 -0.0056,0.0017 0.009,0.0013 0.0288,0.0011 0.06767,-0.002 0.01222,-0.0011 0.02148,-0.01275 0.0335,-0.01516 0.04057,-0.008 0.05523,0.0044 0.09388,-0.0052 0.0041,-8.75e-4 0.0077,-0.0035 0.01152,-0.0052 2.89e-4,-0.0015 -1.68e-4,-0.0011 1.67e-4,-0.0031 l 0.02179,-0.0068 0.06535,-0.02026 c 0.01534,-0.0073 0.03041,-0.01525 0.04522,-0.02357 0.0042,-0.0024 0.0071,-0.007 0.01172,-0.0084 z m -0.05694,0.03197 c -0.02062,0.01003 -0.04415,0.01184 -0.06535,0.02026 -0.0075,0.0029 -0.01472,0.0065 -0.02199,0.01 -0.0019,0.0098 -0.0017,0.0093 0.02032,2.11e-4 0.02262,-0.0094 0.04491,-0.01971 0.06701,-0.03032 z m 0.464997,0.250946 c 0.0067,0.0014 0.0134,0.0032 0.02012,0.0044 l 0.04025,0.0066 0.161013,0.0265 0.130823,0.02153 c -0.0046,0.0013 -0.0071,0.007 -0.01172,0.0084 -0.0032,0.001 -0.0067,-0.0011 -0.01007,-0.0016 -0.01341,-0.0022 -0.02668,-0.0065 -0.04025,-0.0066 -0.0108,3.1e-4 -0.02108,0.005 -0.03185,0.0051 -0.01017,-1.07e-4 -0.02001,-0.0059 -0.03019,-0.0049 -0.01827,0.0017 -0.03538,0.01031 -0.05363,0.01185 -0.02036,0.0019 -0.03993,-0.01023 -0.06038,-0.0099 -0.0108,3.11e-4 -0.02108,0.005 -0.03185,0.0051 -0.01017,-1.08e-4 -0.02012,-0.0033 -0.03019,-0.0049 l -0.04025,-0.0066 c -0.01007,-0.0016 -0.02002,-0.0048 -0.03019,-0.0049 -0.0108,3.1e-4 -0.02108,0.005 -0.03185,0.0051 -0.01017,-1.07e-4 -0.02012,-0.0033 -0.03019,-0.0049 l -0.07044,-0.0116 c 0.0028,-0.0022 0.0011,-0.0067 0.0016,-0.01007 l 0.02178,-0.0068 c 0.02345,-0.0037 -0.0049,0.0124 0.02179,-0.0068 0.0067,-9.79e-4 0.01343,0.0022 0.02013,0.0033 0.0073,-0.0025 0.01454,-0.0045 0.02178,-0.0068 0.01452,-0.0045 0.02842,-0.01224 0.04357,-0.0135 0.0068,-4.52e-4 0.01346,6.7e-4 0.02014,0.0023 z m -0.562387,3.06e-4 c 0.0017,-3.7e-5 0.0031,4.65e-4 0.004,0.0022 0.01829,0.03256 0.023,0.07108 0.03446,0.106606 -0.0027,6.18e-4 -0.03171,0.01149 -0.04261,0.0057 -0.0067,-0.0037 -0.0115,-0.01035 -0.01847,-0.01338 -0.0063,-0.0026 -0.01343,-0.0022 -0.02013,-0.0033 l -0.02012,-0.0033 -0.02013,-0.0033 c -0.0034,-5.67e-4 -0.0072,-0.0038 -0.01007,-0.0016 -0.0028,0.0022 0.0012,0.008 -0.0016,0.01007 -0.0028,0.0022 -0.0067,-0.0022 -0.01006,-0.0016 -0.0075,0.0014 -0.01426,0.0055 -0.02179,0.0068 -0.0033,4.9e-4 -0.0068,-0.0027 -0.01006,-0.0016 -0.0046,0.0013 -0.007,0.0076 -0.01172,0.0084 -0.0067,9.78e-4 -0.01344,-0.0022 -0.02013,-0.0033 -0.01007,-0.0016 -0.02002,-0.0048 -0.03019,-0.0049 -0.0108,3.11e-4 -0.02108,0.005 -0.03185,0.0051 -0.01018,-1.08e-4 -0.02002,-0.0048 -0.03019,-0.0049 -0.04304,6.9e-5 -0.01897,0.0063 -0.05363,0.01185 -0.0033,4.9e-4 -0.0067,-0.0011 -0.01007,-0.0016 l -0.07044,-0.01159 c -0.0034,-5.67e-4 -0.008,0.0013 -0.01007,-0.0016 -7.73e-4,-0.0012 0.0039,-0.02943 0.0049,-0.03019 0.0028,-0.0022 0.0068,0.0027 0.01007,0.0016 0.0046,-0.0013 0.0071,-0.007 0.01172,-0.0084 0.02159,-0.0067 0.06523,-0.0065 0.08382,-0.0069 0.02066,-2.54e-4 0.04161,0.0032 0.06203,-1.27e-4 0.01206,-0.0016 0.02165,-0.01205 0.0335,-0.01516 0.0208,-0.0054 0.04248,-0.0068 0.06369,-0.01019 0.01062,-0.0019 0.02116,-0.0043 0.03185,-0.0051 0.01726,-0.0013 0.03498,0.0016 0.05198,-0.0018 0.01199,-0.0022 0.0221,-0.01062 0.0335,-0.01516 0.0053,-0.0023 0.01278,-0.0085 0.01777,-0.0089 z m 1.671206,0.297181 c -0.02123,0.0034 -0.04228,0.0084 -0.06369,0.01019 -0.0068,4.53e-4 -0.01344,-0.0022 -0.02013,-0.0033 l -0.08051,-0.01325 c 0.01074,-3.2e-4 0.02108,-0.005 0.03185,-0.0051 0.01017,1.08e-4 0.02012,0.0033 0.03019,0.0049 0.03457,0.0057 0.06695,0.01467 0.10229,0.0065 z m -1.480206,0.138821 c -0.0022,0.01342 -0.0017,0.02755 -0.0066,0.04026 -0.0017,0.0044 -0.0078,0.0056 -0.01172,0.0084 -0.02733,0.01962 -0.03502,0.01089 -0.06535,0.02026 -0.0117,0.0037 -0.02178,0.0115 -0.0335,0.01516 -0.01749,0.0054 -0.03567,0.0083 -0.05363,0.01185 -0.01051,0.0019 -0.02194,0.0011 -0.03185,0.0051 -0.09263,0.03868 -0.01911,0.02917 -0.110571,0.04382 -0.01386,0.0024 -0.02825,5.67e-4 -0.04191,0.0035 -0.0047,0.0013 -0.007,0.0078 -0.01175,0.0086 -0.0067,9.78e-4 -0.01344,-0.0022 -0.02013,-0.0033 -0.0034,-5.67e-4 -0.008,0.0013 -0.01007,-0.0016 -0.002,-0.0029 -3.45e-4,-0.0074 0.0017,-0.01022 0.0028,-0.0037 0.0089,-0.0045 0.01172,-0.0084 0.002,-0.0028 -3.71e-4,-0.0073 0.0016,-0.01007 0.0028,-0.0037 0.009,-0.0045 0.01188,-0.0084 0.002,-0.0028 -3.71e-4,-0.0073 0.0016,-0.01007 0.0018,-0.0023 0.03206,-0.02448 0.035,-0.02525 0.0032,-0.001 0.0074,0.0038 0.01022,0.0017 0.0028,-0.0022 -0.0012,-0.008 0.0016,-0.01007 0.0062,-0.0045 0.01438,-0.0045 0.02163,-0.0068 0.0073,-0.0025 0.01454,-0.0045 0.02179,-0.0068 0.0073,-0.0025 0.01454,-0.0045 0.02178,-0.0068 0.0073,-0.0025 0.01422,-0.0058 0.02179,-0.0068 0.0172,-0.0019 0.03477,1.89e-4 0.05197,-0.0018 0.0075,-8.24e-4 0.01421,-0.0061 0.02179,-0.0068 0.0068,-4.53e-4 0.01337,0.0038 0.02013,0.0033 0.01513,-0.0012 0.02871,-0.0102 0.04357,-0.0135 0.01052,-0.0024 0.02185,-0.0011 0.03185,-0.0051 0.07043,-0.02793 -0.03802,-0.01174 0.06535,-0.02026 z m -1.64282,1.038571 c 0.0171,0.02365 0.05526,0.01875 0.0829,0.02816 z"
-         style="fill:#ffffff;fill-opacity:0.78022;stroke:none;stroke-width:0.0815893px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path1149"
-         d="m 25.232271,-69.423496 c 0.0111,0.01764 0.03541,-5.67e-4 0.04981,0.0082 0.0074,0.0044 0.01198,0.01267 0.01901,0.01775 0.0105,0.0076 0.02201,0.01365 0.03323,0.02008 0.0066,0.0037 0.01405,0.006 0.02019,0.01063 0.01612,0.01163 0.02557,0.02692 0.03684,0.04261 0.0059,0.0083 0.01363,0.01556 0.01785,0.02487 8.76e-4,0.0022 -0.0024,0.0052 -0.0012,0.0071 0.0015,0.0023 0.0058,-0.0011 0.0071,0.0012 0.0012,0.0023 -0.0027,0.0052 -0.0012,0.0071 0.0012,0.0023 0.0058,-0.0011 0.0071,0.0012 0.0013,0.0018 -0.0046,0.0183 -0.0035,0.02135 10e-4,0.0033 0.0054,0.005 0.0059,0.0083 7.73e-4,0.0048 -0.0015,0.0095 -0.0023,0.01423 -4.18e-4,0.0025 -0.0018,0.0049 -0.0012,0.0071 0.001,0.0033 0.004,0.0054 0.0059,0.0083 0.002,0.0029 0.0035,0.006 0.006,0.0083 0.0039,0.0038 0.0092,0.0057 0.01307,0.0095 0.005,0.0045 0.0064,0.01259 0.0119,0.01658 0.002,0.0014 0.0058,-0.0011 0.0071,0.0012 0.0015,0.0023 -0.0031,0.0057 -0.0012,0.0071 0.0039,0.0027 0.0095,0.0015 0.01424,0.0023 0.01661,0.0027 0.0332,0.0055 0.04981,0.0082 0.0047,7.73e-4 0.0095,0.0015 0.01424,0.0023 0.0024,4.02e-4 0.0052,-1.97e-4 0.0071,0.0012 0.0028,0.002 0.0032,0.0063 0.006,0.0083 0.002,0.0014 0.01814,0.003 0.02136,0.0035 0.01661,0.0027 0.03321,0.0055 0.04981,0.0082 0.004,6.7e-4 0.03113,0.0067 0.03558,0.0059 0.0054,-0.0012 0.01005,-0.0043 0.01541,-0.0048 0.0096,-0.001 0.01884,0.0057 0.02845,0.0047 0.0053,-1.7e-4 0.01009,-0.0039 0.01541,-0.0048 0.0036,-4.48e-4 0.04092,0.0062 0.0427,0.007 0.003,0.0015 0.0029,0.0067 0.0059,0.0083 0.0043,0.0023 0.0095,0.0015 0.01424,0.0023 0.0024,4.02e-4 0.0052,-1.96e-4 0.0071,0.0012 0.0028,0.002 0.0032,0.0063 0.0059,0.0083 0.0053,0.0035 0.01606,3.3e-5 0.02136,0.0035 0.0028,0.002 0.004,0.0054 0.006,0.0083 0.0047,7.73e-4 0.01,7.7e-5 0.01424,0.0023 0.003,0.0015 0.0032,0.0063 0.0059,0.0083 0.0053,0.0035 0.01606,3.2e-5 0.02136,0.0035 0.004,0.0027 0.0211,0.03036 0.02376,0.03315 0.0037,0.0038 0.0092,0.0057 0.01307,0.0095 0.0057,0.0056 0.01203,0.02067 0.01784,0.02487 0.002,0.0014 0.0058,-0.0011 0.0071,0.0012 0.0015,0.0023 -0.0024,0.0052 -0.0012,0.0071 0.0032,0.0042 0.0092,0.0057 0.01307,0.0095 0.0024,0.0025 0.0032,0.0063 0.006,0.0083 0.002,0.0014 0.0047,7.72e-4 0.0071,0.0012 0.0043,0.0033 0.0092,0.0057 0.01306,0.0095 0.0024,0.0025 0.0032,0.0063 0.0059,0.0083 0.0025,0.002 0.02015,0.0018 0.02136,0.0035 0.0013,0.0018 -0.0046,0.0183 -0.0035,0.02135 0.0033,0.01072 0.01149,0.0092 0.02019,0.01063 0.0024,4.02e-4 0.0052,-1.97e-4 0.0071,0.0012 0.0028,0.002 0.0032,0.0063 0.0059,0.0083 0.002,0.0014 0.0047,7.73e-4 0.0071,0.0012 0.01424,0.0023 0.02845,0.0047 0.0427,0.007 0.0024,4.02e-4 0.0051,0.0029 0.0071,0.0012 0.0019,-0.0018 -9.27e-4,-0.0057 0.0012,-0.0071 0.0019,-0.0018 0.0051,0.0029 0.0071,0.0012 0.0019,-0.0018 -9.28e-4,-0.0057 0.0012,-0.0071 0.0019,-0.0018 0.0091,-5.67e-4 0.0071,0.0012 -0.0088,0.0063 -0.02128,0.0045 -0.03079,0.0096 -0.01791,0.0093 -0.03181,0.02635 -0.04973,0.03567 -0.0047,0.0024 -0.01049,0.0025 -0.01541,0.0048 -0.0031,0.0016 -0.0055,0.0038 -0.0083,0.0059 -0.0028,0.0022 -0.006,0.0037 -0.0083,0.0059 -0.0038,0.0041 -0.0051,0.0099 -0.0095,0.01306 -0.0019,0.0018 -0.0048,-0.0019 -0.0071,-0.0012 -0.0033,0.001 -0.005,0.0049 -0.0083,0.0059 -0.003,0.0011 -0.01965,-0.0048 -0.02136,-0.0035 -0.0019,0.0018 9.27e-4,0.0057 -0.0012,0.0071 -0.0019,0.0018 -0.0047,-7.73e-4 -0.0071,-0.0012 -0.0047,-7.73e-4 -0.0096,-0.0037 -0.01424,-0.0023 -0.0023,6.69e-4 6.18e-4,0.0057 -0.0012,0.0071 -0.0022,0.0018 -0.0051,-0.0029 -0.0071,-0.0012 -0.0022,0.0018 0.0011,0.0064 -0.0012,0.0071 -0.04033,-0.0066 -0.0017,-0.005 -0.01541,0.0048 -0.0019,0.0018 -0.0051,-0.0029 -0.0071,-0.0012 -0.0019,0.0018 9.27e-4,0.0057 -0.0012,0.0071 -0.0043,0.0029 -0.01105,0.0019 -0.01541,0.0048 -0.0022,0.0018 6.18e-4,0.0057 -0.0012,0.0071 -0.0022,0.0018 -0.0051,-0.0029 -0.0071,-0.0012 -0.0018,0.0013 -0.0015,0.0188 -0.0035,0.02135 -0.002,0.0028 -0.0063,0.0031 -0.0083,0.0059 -0.0015,0.0019 3.83e-4,0.0053 -0.0012,0.0071 -0.01044,0.01447 -0.0047,0.0013 -0.01541,0.0048 -0.0033,0.001 -0.005,0.0049 -0.0083,0.0059 -0.0023,6.7e-4 -0.0047,-7.73e-4 -0.0071,-0.0012 -0.0024,-4.01e-4 -0.0075,0.0014 -0.0071,-0.0012 5.66e-4,-0.0036 0.0055,-0.0038 0.0083,-0.0059 0.01701,-0.01218 -0.002,-0.0014 0.02253,-0.0036 0.0053,-1.7e-4 0.01009,-0.0039 0.01541,-0.0048 0.0022,-1.57e-4 0.0048,0.0019 0.0071,0.0012 0.0033,-0.001 0.005,-0.0049 0.0083,-0.0059 0.0023,-6.69e-4 0.0047,7.73e-4 0.0071,0.0012 0.0047,7.73e-4 0.0095,0.0031 0.01424,0.0023 0.0033,-4.98e-4 0.005,-0.0049 0.0083,-0.0059 0.0023,-6.7e-4 0.0047,7.72e-4 0.0071,0.0012 0.0047,7.73e-4 0.0095,0.0031 0.01424,0.0023 0.0033,-4.9e-4 0.0052,-0.0046 0.0083,-0.0059 0.0049,-0.0023 0.01009,-0.0039 0.01541,-0.0048 0.0067,-9.79e-4 0.0146,0.0045 0.02136,0.0035 0.0033,-4.9e-4 0.005,-0.0049 0.0083,-0.0059 0.0023,-6.7e-4 0.0048,0.0019 0.0071,0.0012 0.0033,-0.001 0.0052,-0.0046 0.0083,-0.0059 0.0014,-8.24e-4 0.03026,-0.0092 0.03079,-0.0096 0.0022,-0.0018 -9.28e-4,-0.0057 0.0012,-0.0071 0.0043,-0.0029 0.0105,-0.0025 0.01541,-0.0048 0.0031,-0.0016 0.005,-0.0049 0.0083,-0.0059 0.0045,-0.0013 0.0096,0.0037 0.01424,0.0023 0.0033,-0.001 0.005,-0.0049 0.0083,-0.0059 0.0023,-6.69e-4 0.0051,0.0029 0.0071,0.0012 0.0019,-0.0018 -9.27e-4,-0.0057 0.0012,-0.0071 0.01715,-0.01232 -0.0043,0.02237 0.01541,-0.0048 0.0028,-0.0037 -4.95e-4,-0.01031 0.0023,-0.01423 0.0024,-0.0032 0.01404,-0.0084 0.01658,-0.01189 0.0015,-0.0019 -3.83e-4,-0.0053 0.0012,-0.0071 0.002,-0.0028 0.0063,-0.0031 0.0083,-0.0059 0.002,-0.0023 0.0018,-0.02018 0.0035,-0.02135 0.0019,-0.0018 0.0051,0.0029 0.0071,0.0012 0.0041,-0.003 -6.18e-4,-0.01838 0.0035,-0.02135 0.0019,-0.0018 0.0047,7.72e-4 0.0071,0.0012 4.18e-4,-0.0025 -6.19e-4,-0.0057 0.0012,-0.0071 0.0022,-0.0018 0.0051,0.0029 0.0071,0.0012 0.0022,-0.0018 -6.18e-4,-0.0057 0.0012,-0.0071 0.0014,-8.24e-4 0.01842,0.0041 0.02136,0.0035 0.0054,-0.0012 0.01009,-0.0039 0.01541,-0.0048 0.0022,-1.58e-4 0.0048,0.0013 0.0071,0.0012 0.0054,-0.0012 0.01004,-0.0046 0.01541,-0.0048 0.01204,-6.19e-4 0.0237,0.0039 0.03558,0.0059 0.0075,0.0012 0.02876,0.0031 0.03558,0.0059 0.0071,0.0027 0.01287,0.0086 0.02019,0.01063 0.01389,0.0039 0.02868,0.0037 0.0427,0.007 0.111912,0.02813 -0.02886,0.0026 0.08422,0.02117 0.0012,2.01e-4 0.04683,0.0061 0.04981,0.0082 0.0079,0.0055 0.01,0.01919 0.01785,0.02487 0.002,0.0014 0.0053,-1.7e-4 0.0071,0.0012 0.005,0.0045 0.0072,0.01167 0.01189,0.01658 0.0037,0.0038 0.0093,0.0057 0.01306,0.0095 0.0047,0.0049 0.0074,0.0115 0.0119,0.01658 0.01242,0.01379 0.01851,0.0174 0.03206,0.0272 0.0043,0.0033 0.0087,0.0061 0.01307,0.0095 0.0043,0.0033 0.008,0.0076 0.01307,0.0095 0.0091,0.0036 0.02489,0.0041 0.03558,0.0059 0.0237,0.0039 0.04744,0.0078 0.07116,0.01171 0.01187,0.002 0.02419,0.0019 0.03558,0.0059 0.0052,0.0014 0.0085,0.0067 0.01307,0.0095 0.0066,0.0037 0.01364,0.0069 0.02019,0.01063 0.0092,0.0057 0.01625,0.01463 0.02611,0.01892 0.0044,0.0018 0.0098,5.66e-4 0.01424,0.0023 0.0071,0.0027 0.01307,0.0079 0.02019,0.01063 0.0045,0.0018 0.0098,5.66e-4 0.01424,0.0023 0.005,0.0019 0.0083,0.0069 0.01307,0.0095 0.0043,0.0023 0.0095,0.0015 0.01424,0.0023 0.0095,0.0015 0.01898,0.0031 0.02845,0.0047 0.02136,0.0035 0.0427,0.007 0.06404,0.01054 0.02136,0.0035 0.0427,0.007 0.06404,0.01054 0.0037,6.18e-4 0.02643,0.0054 0.02845,0.0047 0.0033,-10e-4 0.005,-0.0049 0.0083,-0.0059 0.0061,-0.0016 0.01522,0.0051 0.02136,0.0035 0.0033,-0.001 0.0049,-0.0054 0.0083,-0.0059 0.0048,-7.72e-4 0.0095,0.0031 0.01424,0.0023 0.0033,-4.99e-4 0.005,-0.0049 0.0083,-0.0059 0.0023,-6.7e-4 0.0048,0.0019 0.0071,0.0012 0.0065,-0.0021 0.0098,-0.01133 0.01658,-0.01189 0.0072,-8.76e-4 0.01411,0.0039 0.02136,0.0035 0.0054,-1.6e-4 0.01005,-0.0043 0.01541,-0.0048 0.0047,-2.64e-4 0.0095,0.0031 0.01424,0.0023 0.0033,-4.98e-4 0.005,-0.0049 0.0083,-0.0059 0.0023,-6.69e-4 0.0048,0.0019 0.0071,0.0012 0.0033,-0.001 0.005,-0.0049 0.0083,-0.0059 0.0048,-0.0013 0.02367,0.006 0.02848,0.0047 0.01703,-0.0053 0.0029,-0.0042 0.0095,-0.01306 0.002,-0.0028 0.0055,-0.0038 0.0083,-0.0059 0.0028,-0.0022 0.0055,-0.0038 0.0083,-0.0059 0.0032,-0.0042 0.0051,-0.0099 0.0095,-0.01306 0.0019,-0.0018 0.0048,0.0019 0.0071,0.0012 0.0061,-0.0016 0.01042,-0.01 0.01658,-0.01189 0.0045,-0.0013 0.0096,0.0037 0.01424,0.0023 0.0033,-0.001 0.005,-0.0049 0.0083,-0.0059 0.0023,-6.7e-4 0.0047,7.72e-4 0.0071,0.0012 0.0052,-0.0018 0.01049,-0.0025 0.01541,-0.0048 0.0031,-0.0016 0.0052,-0.0046 0.0083,-0.0059 0.0049,-0.0023 0.01105,-0.0019 0.01541,-0.0048 0.01106,-0.0079 -0.01397,-0.0093 0.0095,-0.01306 0.0048,-7.73e-4 0.0095,0.0031 0.01424,0.0023 0.0067,-9.79e-4 0.01009,-0.0099 0.01658,-0.01189 0.002,-7.21e-4 0.03765,0.0062 0.0427,0.007 0.0024,4.01e-4 0.0051,0.0029 0.0071,0.0012 0.0022,-0.0018 -6.18e-4,-0.0057 0.0012,-0.0071 0.0022,-0.0018 0.0048,0.0019 0.0071,0.0012 0.0065,-0.0021 0.01036,-0.0091 0.01658,-0.01189 0.0049,-0.0023 0.01049,-0.0025 0.01541,-0.0048 0.0031,-0.0016 0.005,-0.0049 0.0083,-0.0059 0.0045,-0.0013 0.01031,0.0054 0.01424,0.0023 0.0019,-0.0018 -9.27e-4,-0.0057 0.0012,-0.0071 0.0039,-0.003 0.01031,0.0054 0.01424,0.0023 0.0019,-0.0018 -9.27e-4,-0.0057 0.0012,-0.0071 0.0019,-0.0018 0.0051,0.0029 0.0071,0.0012 0.0018,-0.0013 0.0015,-0.0188 0.0035,-0.02135 0.002,-0.0028 0.0063,-0.0031 0.0083,-0.0059 0.0012,-0.0014 0.0044,-0.02679 0.0047,-0.02847 0.0011,-0.0067 0.0067,-0.03126 0.0059,-0.03558 -7.21e-4,-0.0032 -0.0049,-0.005 -0.0059,-0.0083 -8.24e-4,-0.0027 0.0055,-0.01988 0.0035,-0.02135 -0.01103,-0.008 -0.01913,0.0015 -0.02962,0.0024 -0.0047,2.64e-4 -0.0096,-0.0037 -0.01424,-0.0023 -0.01751,0.0054 -0.01791,0.02076 -0.04026,0.02261 -0.0047,2.64e-4 -0.0095,-0.0031 -0.01424,-0.0023 -0.0033,4.9e-4 -0.0052,0.0046 -0.0083,0.0059 -0.0049,0.0023 -0.01025,0.003 -0.01541,0.0048 -0.0052,0.0018 -0.01016,0.0036 -0.01541,0.0048 -0.0074,0.0014 -0.01541,6.18e-4 -0.02253,0.0036 -0.0063,0.0026 -0.01053,0.0087 -0.01658,0.01189 -0.0052,0.0018 -0.01025,0.003 -0.01541,0.0048 -0.0024,-4.01e-4 -0.0048,-0.0019 -0.0071,-0.0012 -0.0033,10e-4 -0.005,0.0049 -0.0083,0.0059 -0.0023,6.7e-4 -0.0051,-0.0029 -0.0071,-0.0012 -0.0019,0.0018 0.0011,0.0064 -0.0012,0.0071 -0.0045,0.0013 -0.0095,-0.0015 -0.01424,-0.0023 -0.0047,-7.73e-4 -0.0098,-5.67e-4 -0.01424,-0.0023 -0.005,-0.0019 -0.0083,-0.0069 -0.01307,-0.0095 -0.0021,-8.75e-4 -0.0052,1.97e-4 -0.0071,-0.0012 -0.0028,-0.002 -0.0032,-0.0063 -0.006,-0.0083 -0.002,-0.0014 -0.0047,-7.73e-4 -0.0071,-0.0012 -0.0071,-0.0012 -0.01424,-0.0023 -0.02136,-0.0035 -0.0047,-7.73e-4 -0.0098,-5.67e-4 -0.01424,-0.0023 -0.0071,-0.0027 -0.01349,-0.0069 -0.02019,-0.01063 -0.0095,-0.0015 -0.01925,-0.0021 -0.02845,-0.0047 -0.0073,-0.0022 -0.01298,-0.0081 -0.02019,-0.01063 -0.0069,-0.0022 -0.01424,-0.0023 -0.02136,-0.0035 -0.02136,-0.0035 -0.0427,-0.007 -0.06404,-0.01054 -0.004,-6.7e-4 -0.03113,-0.0067 -0.03558,-0.0059 -0.0054,0.0012 -0.01009,0.0039 -0.01541,0.0048 -0.0048,7.72e-4 -0.01031,-0.0054 -0.01424,-0.0023 -0.0019,0.0018 0.0011,0.0064 -0.0012,0.0071 -0.0045,0.0013 -0.0096,-0.0037 -0.01424,-0.0023 -0.0065,0.0021 -0.01054,0.0088 -0.01658,0.01189 -0.01398,0.0073 -0.0224,0.0036 -0.03792,0.0084 -0.0033,10e-4 -0.0055,0.0038 -0.0083,0.0059 -0.0052,0.0018 -0.01016,0.0036 -0.01541,0.0048 -0.0074,0.0014 -0.01506,0.0017 -0.02253,0.0036 -0.0053,0.0012 -0.01004,0.0046 -0.01541,0.0048 -0.0072,3.79e-4 -0.01412,-0.0044 -0.02136,-0.0035 -0.0068,4.54e-4 -0.01009,0.0099 -0.01658,0.01189 -0.0045,0.0013 -0.0095,-0.0031 -0.01424,-0.0023 -0.0054,0.0012 -0.01006,0.0043 -0.01541,0.0048 -0.0072,8.76e-4 -0.01412,-0.0044 -0.02136,-0.0035 -0.0076,8.24e-4 -0.0149,0.0036 -0.02253,0.0036 -0.0072,-1.4e-4 -0.01411,-0.0039 -0.02136,-0.0035 -0.0054,1.6e-4 -0.01004,0.0046 -0.01541,0.0048 -0.0078,2.87e-4 -0.03952,-0.0065 -0.04981,-0.0082 -0.0083,-0.0013 -0.02937,-0.0032 -0.03558,-0.0059 -0.005,-0.0019 -0.0083,-0.0069 -0.01307,-0.0095 -0.0048,-0.0024 -0.0269,-0.0023 -0.02845,-0.0047 -0.0015,-0.0023 0.0021,-0.0049 0.0012,-0.0071 -0.001,-0.0033 -0.0049,-0.005 -0.006,-0.0083 -8.76e-4,-0.0022 7.73e-4,-0.0046 0.0012,-0.0071 -0.0017,-0.005 -0.0026,-0.0105 -0.0048,-0.0154 -0.0014,-0.0028 -0.0046,-0.0049 -0.006,-0.0083 -0.0052,-0.01151 -0.002,-0.01557 -0.01072,-0.02369 -0.0039,-0.0038 -0.0099,-0.0053 -0.01307,-0.0095 -0.0012,-0.0023 0.0014,-0.005 0.0012,-0.0071 -6.7e-4,-0.0053 -0.0039,-0.0101 -0.0048,-0.0154 -2.75e-4,-0.0021 7.73e-4,-0.0046 0.0012,-0.0071 7.73e-4,-0.0046 0.0015,-0.0095 0.0023,-0.01423 7.73e-4,-0.0046 0.0028,-0.0094 0.0023,-0.01423 -3.75e-4,-0.0053 -0.0043,-0.01006 -0.0048,-0.0154 -4.67e-4,-0.0048 0.0015,-0.0095 0.0023,-0.01423 7.72e-4,-0.0046 0.0015,-0.0095 0.0023,-0.01423 4.18e-4,-0.0025 7.73e-4,-0.0046 0.0012,-0.0071 4.18e-4,-0.0025 -9.28e-4,-0.0057 0.0012,-0.0071 6.69e-4,-4.08e-4 0.01127,0.0024 0.01424,0.0023 0.0099,-4.55e-4 0.01971,-0.0026 0.02965,-0.0024 0.0072,1.41e-4 0.01424,0.0023 0.02136,0.0035 0.0071,0.0012 0.01461,8.24e-4 0.02136,0.0035 0.005,0.0019 0.0081,0.0073 0.01306,0.0095 0.0044,0.0018 0.01898,0.0031 0.01424,0.0023 -0.01661,-0.0027 -0.03321,-0.0055 -0.04981,-0.0082 -0.0095,-0.0015 -0.01918,-0.0021 -0.02845,-0.0047 -0.01185,-0.003 -0.02253,-0.0099 -0.03441,-0.01297 -0.02794,-0.0072 -0.05744,-0.0068 -0.08539,-0.01405 -0.01422,-0.0034 -0.02735,-0.01061 -0.04152,-0.01414 -0.01401,-0.0033 -0.02845,-0.0047 -0.0427,-0.007 -0.01661,-0.0027 -0.03321,-0.0055 -0.04981,-0.0082 -0.01424,-0.0023 -0.02845,-0.0047 -0.0427,-0.007 -0.007,-0.0011 -0.02124,-0.0035 -0.01424,-0.0023 0.08216,0.01352 -0.04193,-0.0048 0.04387,-8.9e-5 0.0144,8.24e-4 0.02828,0.0073 0.0427,0.007 0.01298,-4.74e-4 0.02502,-0.0073 0.03792,-0.0084 0.0072,-8.75e-4 0.01427,0.0044 0.02136,0.0035 0.0085,-0.0012 0.01513,-0.0094 0.0237,-0.01071 0.0071,-9.27e-4 0.01412,0.0044 0.02136,0.0035 0.0068,-4.53e-4 0.0098,-0.01081 0.01658,-0.01189 0.0048,-7.72e-4 0.0096,0.0037 0.01424,0.0023 0.0023,-6.7e-4 -8.75e-4,-0.0061 0.0012,-0.0071 0.0086,-0.02087 0.02014,7.22e-4 0.02962,-0.0024 0.0033,-10e-4 0.005,-0.0049 0.0083,-0.0059 0.0023,-6.69e-4 0.0048,0.0019 0.0071,0.0012 0.0033,-10e-4 0.005,-0.0049 0.0083,-0.0059 0.0023,-6.69e-4 0.0047,7.73e-4 0.0071,0.0012 0.0047,7.73e-4 0.0095,0.0031 0.01424,0.0023 0.0033,-4.97e-4 0.005,-0.0049 0.0083,-0.0059 0.0023,-6.69e-4 0.0047,7.73e-4 0.0071,0.0012 0.0071,0.0012 0.01411,0.0039 0.02136,0.0035 0.0054,-1.59e-4 0.0105,-0.0025 0.01541,-0.0048 0.03704,-0.01677 -0.03021,0.0048 0.02253,-0.0036 0.0149,-0.0023 0.0044,-0.0061 0.0095,-0.01306 0.002,-0.0028 0.0063,-0.0031 0.0083,-0.0059 0.0015,-0.0019 -9.27e-4,-0.0057 0.0012,-0.0071 0.0019,-0.0018 0.0051,0.0029 0.0071,0.0012 0.0041,-0.003 -6.18e-4,-0.01838 0.0035,-0.02135 0.0019,-0.0018 0.0048,0.0019 0.0071,0.0012 0.0033,-0.001 0.0055,-0.0038 0.0083,-0.0059 0.0028,-0.0022 0.01105,-0.0039 0.0083,-0.0059 -0.0059,-0.0041 -0.01478,-3.45e-4 -0.02136,-0.0035 -0.0031,-0.0015 -0.004,-0.0054 -0.006,-0.0083 -0.0067,-0.0037 -0.01298,-0.0081 -0.02019,-0.01063 -0.0069,-0.0022 -0.0145,-0.0013 -0.02136,-0.0035 -0.01437,-0.005 -0.02596,-0.01639 -0.04035,-0.02126 -0.0069,-0.0022 -0.01518,1.13e-4 -0.02136,-0.0035 -0.0058,-0.0036 -0.0064,-0.01259 -0.01189,-0.01658 -0.0039,-0.0027 -0.0098,-5.67e-4 -0.01424,-0.0023 -0.005,-0.0019 -0.008,-0.0076 -0.01307,-0.0095 -0.0067,-0.0027 -0.01494,-3.7e-4 -0.02136,-0.0035 -0.0021,-8.76e-4 0.0027,-0.0052 0.0012,-0.0071 -0.0032,-0.0042 -0.0092,-0.0057 -0.01307,-0.0095 -0.0024,-0.0025 -0.0035,-0.006 -0.0059,-0.0083 -0.0039,-0.0038 -0.0092,-0.0057 -0.01307,-0.0095 -0.0024,-0.0025 -0.0035,-0.006 -0.0059,-0.0083 -0.0039,-0.0038 -0.0092,-0.0057 -0.01307,-0.0095 -0.0024,-0.0025 -0.0032,-0.0063 -0.006,-0.0083 -0.0042,-0.0028 -0.02307,-0.0017 -0.02845,-0.0047 -0.0047,-0.0029 -0.0083,-0.0069 -0.01307,-0.0095 -0.0046,-0.0023 -0.01749,-7.73e-4 -0.02136,-0.0035 -0.0028,-0.002 -0.004,-0.0054 -0.006,-0.0083 -0.002,-0.0029 -0.0049,-0.005 -0.0059,-0.0083 -8.76e-4,-0.0022 7.73e-4,-0.0046 0.0012,-0.0071 0.0021,-0.01241 -3.83e-4,-0.0053 0.01064,-0.02018 0.0032,-0.0042 0.0046,-0.01058 0.0095,-0.01306 0.0067,-0.0036 0.01522,-0.0011 0.02253,-0.0036 0.01179,-0.0037 0.0077,-0.01179 0.01775,-0.019 0.0022,-0.0018 0.0048,0.0019 0.0071,0.0012 0.0065,-0.0021 0.01009,-0.0099 0.01658,-0.01189 0.0023,-6.69e-4 0.0051,0.0029 0.0071,0.0012 0.0039,-0.003 -0.0022,-0.01279 0.0023,-0.01423 0.0045,-0.0013 0.0096,0.0037 0.01424,0.0023 0.0023,-6.7e-4 0.0031,-0.0057 0.0012,-0.0071 -0.0039,-0.0027 -0.0098,-5.67e-4 -0.01424,-0.0023 -0.005,-0.0019 -0.0079,-0.0078 -0.01307,-0.0095 -0.08647,-0.02723 0.0026,0.0082 -0.05693,-0.0094 -0.105903,-0.03993 0.02671,0.0075 -0.06287,-0.01765 -0.01185,-0.003 -0.02272,-0.0093 -0.03441,-0.01297 -0.0085,-0.0024 -0.01947,-0.0032 -0.02845,-0.0047 -0.0024,-4.01e-4 -0.0047,-7.73e-4 -0.0071,-0.0012 -0.0024,-4.01e-4 -0.0048,-0.0019 -0.0071,-0.0012 -0.01885,0.0135 0.0012,0.0023 -0.01541,0.0048 -0.0054,0.0012 -0.01009,0.0039 -0.01541,0.0048 -0.0022,1.57e-4 -0.0048,-0.0019 -0.0071,-0.0012 -0.0033,0.001 -0.0049,0.0054 -0.0083,0.0059 -0.0045,8.24e-4 -0.03429,-0.0056 -0.0427,-0.007 -0.0071,-0.0012 -0.01424,-0.0023 -0.02136,-0.0035 -0.0024,-4.01e-4 -0.0091,5.67e-4 -0.0071,-0.0012 0.0043,-0.0029 0.01043,-0.003 0.01541,-0.0048 0.0081,-0.0033 0.01541,-0.0082 0.0237,-0.01072 0.0073,-0.0025 0.01508,-0.0022 0.02253,-0.0036 0.01271,-0.0026 0.02513,-0.0063 0.03792,-0.0084 0.0098,-0.0015 0.01998,1.55e-4 0.02962,-0.0024 0.0084,-0.0023 0.01564,-0.0075 0.0237,-0.01072 0.0049,-0.0018 0.01105,-0.0019 0.01541,-0.0048 0.0019,-0.0018 -3.84e-4,-0.0053 0.0012,-0.0071 0.002,-0.0028 0.0055,-0.0038 0.0083,-0.0059 0.0028,-0.0022 0.01025,-0.003 0.0083,-0.0059 -0.0028,-0.0041 -0.0095,-0.0015 -0.01424,-0.0023 -0.01898,-0.0031 -0.03795,-0.0062 -0.05693,-0.0094 -0.04269,-0.007 -0.08539,-0.01405 -0.128085,-0.02108 -0.01187,-0.002 -0.02359,-0.0049 -0.03558,-0.0059 -0.01453,-0.0013 -0.02928,0.0011 -0.04387,9e-5 -0.01198,-9.27e-4 -0.0237,-0.0039 -0.03558,-0.0059 -0.0047,-7.73e-4 -0.0095,-0.0031 -0.01424,-0.0023 -0.0033,4.98e-4 -0.005,0.0049 -0.0083,0.0059 -0.0023,6.69e-4 -0.0048,-0.0019 -0.0071,-0.0012 -0.03205,0.01 0.0077,7.21e-4 -0.0095,0.01306 -0.0019,0.0018 -0.0047,-7.73e-4 -0.0071,-0.0012 -0.0024,-4.02e-4 -0.0047,-7.73e-4 -0.0071,-0.0012 -0.0071,-0.0012 -0.01424,-0.0023 -0.02136,-0.0035 -0.01898,-0.0031 -0.03795,-0.0062 -0.05693,-0.0094 -0.01186,-0.002 -0.02437,-0.0014 -0.03558,-0.0059 -0.005,-0.0019 -0.0081,-0.0073 -0.01306,-0.0095 -0.0044,-0.0018 -0.0095,-0.0015 -0.01424,-0.0023 -0.01661,-0.0027 -0.03321,-0.0055 -0.04981,-0.0082 -0.0019,-3.02e-4 -0.02108,-0.0037 -0.02136,-0.0035 -0.004,0.003 0.0015,0.01143 -0.0023,0.01423 -0.0043,0.0029 -0.01049,0.0025 -0.01541,0.0048 -0.0031,0.0016 -0.0052,0.0046 -0.0083,0.0059 -0.0049,0.0023 -0.01009,0.0039 -0.01541,0.0048 -0.0022,1.57e-4 -0.0047,-0.0013 -0.0071,-0.0012 -0.0076,8.24e-4 -0.01491,0.0036 -0.02253,0.0036 -0.01444,2.34e-4 -0.02825,-0.0073 -0.04269,-0.007 -0.0076,-2.01e-4 -0.01493,0.0033 -0.02253,0.0036 -0.0048,2.47e-4 -0.0095,-0.0015 -0.01424,-0.0023 -0.01661,-0.0027 -0.0332,-0.0055 -0.04981,-0.0082 -0.0071,-0.0012 -0.01427,-0.0044 -0.02136,-0.0035 -0.0033,4.98e-4 -0.005,0.0049 -0.0083,0.0059 -0.0023,6.7e-4 -0.0048,-0.0019 -0.0071,-0.0012 -0.0033,10e-4 -0.0063,0.0031 -0.0083,0.0059 -3.88e-4,4.58e-4 -0.0049,0.0278 -0.0047,0.02847 0.001,0.0033 0.0046,0.0049 0.006,0.0083 0.0023,0.0051 8.76e-4,0.01174 0.0048,0.0154 0.0036,0.0032 0.01,7.8e-5 0.01424,0.0023 0.003,0.0015 0.0032,0.0063 0.006,0.0083 0.002,0.0014 0.0052,-1.96e-4 0.0071,0.0012 0.0016,0.0013 0.01719,0.02283 0.01785,0.02487 8.76e-4,0.0022 -0.0027,0.0052 -0.0012,0.0071 0.0015,0.0023 0.0058,-0.0011 0.0071,0.0012 0.0028,0.0041 -0.0038,0.0096 -0.0023,0.01423 0.001,0.0033 0.0087,0.0061 0.006,0.0083 -0.0062,0.0044 -0.01522,0.0011 -0.02253,0.0036 -0.0033,10e-4 -0.0049,0.0057 -0.0083,0.0059 -0.0072,8.76e-4 -0.01431,-0.0049 -0.02136,-0.0035 -0.0067,0.0015 -0.0099,0.01043 -0.01658,0.01189 -0.007,0.0014 -0.01411,-0.0039 -0.02136,-0.0035 -0.0054,1.6e-4 -0.01009,0.0039 -0.01541,0.0048 -0.0098,0.0015 -0.0198,0.0014 -0.02962,0.0024 -0.0075,8.24e-4 -0.01493,0.0033 -0.02253,0.0036 -0.0048,2.47e-4 -0.0095,-0.0015 -0.01424,-0.0023 -0.0075,0.0014 -0.01493,0.0033 -0.02253,0.0036 -2.49e-4,1.6e-5 -0.02129,-0.0036 -0.02136,-0.0035 -0.0022,0.0018 0.0011,0.0064 -0.0012,0.0071 -0.0045,0.0013 -0.0095,-0.0015 -0.01424,-0.0023 -0.0024,-4.01e-4 -0.0051,-0.0029 -0.0071,-0.0012 -0.0019,0.0018 0.0011,0.0064 -0.0012,0.0071 -0.0045,0.0013 -0.0096,-0.0037 -0.01424,-0.0023 -0.0023,6.7e-4 6.18e-4,0.0057 -0.0012,0.0071 -0.0022,0.0018 -0.0051,-0.0029 -0.0071,-0.0012 -0.0022,0.0018 3.83e-4,0.0053 -0.0012,0.0071 -0.002,0.0028 -0.0215,0.0163 -0.02487,0.01783 -0.0049,0.0023 -0.01009,0.0039 -0.01541,0.0048 -0.0093,0.0016 -0.0068,-0.0071 -0.01541,0.0048 -0.0015,0.0019 -7.73e-4,0.0046 -0.0012,0.0071 -0.0032,0.0042 -0.0058,0.0091 -0.0095,0.01306 -0.0023,0.0022 -0.0063,0.0031 -0.0083,0.0059 -0.01165,0.01609 0.02172,-0.003 -0.01063,0.02018 -0.0022,0.0018 -0.0051,-0.0029 -0.0071,-0.0012 -0.0039,0.003 0.0022,0.01279 -0.0023,0.01423 -0.0297,0.0092 -5.66e-4,-0.03388 -0.02605,0.02495 z"
-         style="fill:#ffffff;fill-opacity:0.214286;stroke:none;stroke-width:0.0815893px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path1151"
-         d="m 25.569312,-70.678991 c 0.0092,-0.04819 0.03052,0.0061 0.04387,-9e-5 0.0062,-0.0026 0.01106,-0.0079 0.01659,-0.01189 0.0028,-0.0022 0.0049,-0.0054 0.0083,-0.0059 0.0048,-7.73e-4 0.0099,0.0042 0.01424,0.0023 0.0049,-0.0023 0.0058,-0.0091 0.0095,-0.01306 0.0023,-0.0022 0.0063,-0.0031 0.0083,-0.0059 0.0015,-0.0019 -6.19e-4,-0.0057 0.0012,-0.0071 0.0043,-0.0029 0.01105,-0.0019 0.01541,-0.0048 0.0019,-0.0018 -3.84e-4,-0.0053 0.0012,-0.0071 0.002,-0.0028 0.0063,-0.0031 0.0083,-0.0059 0.0015,-0.0019 -9.27e-4,-0.0057 0.0012,-0.0071 0.0019,-0.0018 0.0047,7.72e-4 0.0071,0.0012 0.0095,0.0015 0.01898,0.0031 0.02845,0.0047 0.04506,0.0074 0.09013,0.01484 0.135198,0.02225 0.0024,4.01e-4 0.04603,0.0065 0.04981,0.0082 0.0047,0.0029 0.0083,0.0069 0.01307,0.0095 0.0021,8.76e-4 0.0058,-0.0011 0.0071,0.0012 0.0012,0.0023 -0.0027,0.0052 -0.0012,0.0071 0.0012,0.0023 0.0047,7.73e-4 0.0071,0.0012 0.01187,0.002 0.02373,0.0039 0.03558,0.0059 0.0071,0.0012 0.01416,0.0034 0.02136,0.0035 0.0076,2.01e-4 0.0149,-0.0038 0.02253,-0.0036 0.0096,5.15e-4 0.01885,0.0047 0.02848,0.0047 0.0054,-1.55e-4 0.01009,-0.0039 0.01541,-0.0048 0.0022,-1.56e-4 0.0342,0.0051 0.03558,0.0059 0.01991,0.01445 -0.01395,0.0035 0.01902,0.01775 0.0053,0.0024 0.03529,0.0058 0.04269,0.007 0.0019,3.02e-4 0.0267,0.0054 0.02845,0.0047 0.0033,-0.001 0.005,-0.0049 0.0083,-0.0059 0.0023,-6.69e-4 0.0051,0.0029 0.0071,0.0012 0.0019,-0.0018 7.73e-4,-0.0046 0.0012,-0.0071 4.18e-4,-0.0025 7.72e-4,-0.0046 0.0012,-0.0071 4.18e-4,-0.0025 7.72e-4,-0.0046 0.0012,-0.0071 4.19e-4,-0.0025 0.0021,-0.0049 0.0012,-0.0071 -10e-4,-0.0033 -0.0049,-0.005 -0.0059,-0.0083 -8.76e-4,-0.0022 0.0027,-0.0052 0.0012,-0.0071 -0.0232,-0.03238 -0.0041,8.76e-4 -0.02019,-0.01063 -0.0028,-0.002 -0.0035,-0.0059 -0.006,-0.0083 -0.0039,-0.0038 -0.0092,-0.0057 -0.01306,-0.0095 -0.0024,-0.0025 -0.0029,-0.0067 -0.0059,-0.0083 -0.0043,-0.0023 -0.01031,3.91e-4 -0.01424,-0.0023 -0.002,-0.0014 0.0024,-0.0052 0.0012,-0.0071 -0.0015,-0.0023 -0.0047,-7.73e-4 -0.0071,-0.0012 -0.01186,-0.002 -0.02373,-0.0039 -0.03558,-0.0059 -0.0024,-4.02e-4 -0.0047,-7.73e-4 -0.0071,-0.0012 -0.0024,-4.02e-4 -0.0051,-0.0029 -0.0071,-0.0012 -0.0019,0.0018 -7.72e-4,0.0046 -0.0012,0.0071 -0.0028,0.0022 -0.0052,0.0046 -0.0083,0.0059 -0.01816,0.0082 -0.01981,3.94e-4 -0.03792,0.0084 -0.01401,-0.0028 -0.0051,0.0099 -0.0095,0.01306 -0.0039,0.003 -0.01028,-0.0053 -0.01424,-0.0023 -0.0022,0.0018 0.0011,0.0064 -0.0012,0.0071 -0.0045,0.0013 -0.0095,-0.0015 -0.01424,-0.0023 -0.0047,-7.73e-4 -0.0095,-0.0015 -0.01424,-0.0023 -0.0047,-7.72e-4 -0.0095,-0.0015 -0.01424,-0.0023 -0.0047,-7.72e-4 -0.0098,-5.66e-4 -0.01424,-0.0023 -0.005,-0.0019 -0.0081,-0.0073 -0.01306,-0.0095 -0.01711,-0.0075 -0.01137,0.0028 -0.02845,-0.0047 -0.03294,-0.01424 8.76e-4,-0.0035 -0.01902,-0.01775 -0.0039,-0.0027 -0.01031,3.91e-4 -0.01424,-0.0023 -0.0028,-0.002 -0.0029,-0.0067 -0.0059,-0.0083 -0.0092,-0.0046 -0.03348,-0.0024 -0.04269,-0.007 -0.003,-0.0015 -0.0032,-0.0063 -0.0059,-0.0083 -0.002,-0.0014 -0.0047,-7.73e-4 -0.0071,-0.0012 -0.0044,-7.22e-4 -0.04064,-0.0056 -0.0427,-0.007 -0.002,-0.0014 7.73e-4,-0.0046 0.0012,-0.0071 -0.0047,-7.73e-4 -0.0098,-5.67e-4 -0.01424,-0.0023 -0.005,-0.0019 -0.0083,-0.007 -0.01307,-0.0095 -0.0042,-0.0023 -0.02273,-0.0038 -0.02845,-0.0047 -0.0024,-4.02e-4 -0.0051,-0.0029 -0.0071,-0.0012 -0.0019,0.0018 9.27e-4,0.0057 -0.0012,0.0071 -0.0043,0.0029 -0.01171,6.7e-4 -0.01541,0.0048 -0.0034,0.0036 0.0015,0.01143 -0.0023,0.01423 -0.004,0.003 -0.0099,-0.0042 -0.01424,-0.0023 -0.0049,0.0023 -0.0051,0.0099 -0.0095,0.01306 -6.69e-4,4.08e-4 -0.02934,0.0089 -0.03079,0.0096 -0.0031,0.0016 -0.0052,0.0046 -0.0083,0.0059 -0.0049,0.0023 -0.0105,0.0025 -0.01541,0.0048 -0.0031,0.0016 -0.005,0.0049 -0.0083,0.0059 -0.0023,6.7e-4 -0.0051,-0.0029 -0.0071,-0.0012 -0.0018,0.0013 -0.0015,0.0188 -0.0035,0.02135 -0.002,0.0028 -0.0063,0.0031 -0.0083,0.0059 -0.0015,0.0019 9.28e-4,0.0057 -0.0012,0.0071 -0.0022,0.0018 -0.0051,-0.0029 -0.0071,-0.0012 -0.0039,0.003 2.15e-4,0.01011 -0.0023,0.01423 -0.0055,0.0092 -0.01263,0.01745 -0.01892,0.02612 z"
-         style="fill:#ffffff;fill-opacity:0.214286;stroke:none;stroke-width:0.0815893px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-      <path
-         inkscape:connector-curvature="0"
-         transform="scale(0.26458333)"
-         d="m 91.894531,-273.86523 c 0.046,0.0351 0.09579,0.0756 0.123047,0.0898 0.04082,0.0227 0.08809,0.0263 0.128906,0.0488 0.251301,0.13251 -0.07178,0.0107 0.22461,0.14648 0.100497,0.046 0.212217,0.0654 0.314453,0.10742 0.06104,0.0257 0.115448,0.0617 0.177734,0.084 0.03402,0.0136 0.07351,0.0115 0.109375,0.0176 0.01776,0.003 0.03667,10e-4 0.05273,0.01 0.07937,0.0417 -0.01228,0.0161 0.01758,0.0586 0.0029,0.005 0.04399,0.006 0.05469,0.01 0.06524,0.0284 0.1189,0.07 0.175782,0.11133 0.01625,0.0125 0.03416,0.0212 0.04883,0.0352 0.0091,0.009 0.0109,0.0237 0.02148,0.0312 0.0076,0.005 0.02243,-0.005 0.02734,0.004 0.0045,0.009 -0.0073,0.019 -0.0039,0.0274 0.0038,0.0125 0.01393,0.0218 0.02148,0.0312 0.0076,0.011 0.01588,0.0203 0.02344,0.0312 0.0076,0.011 0.01393,0.0203 0.02148,0.0312 0.0076,0.011 0.01323,0.0253 0.02344,0.0332 0.0076,0.005 0.01632,0.002 0.02539,0.004 0.01776,0.003 0.03674,0.009 0.05469,0.008 0.131868,-0.011 0.263136,-0.03 0.394532,-0.0449 0.224012,-0.0181 0.447677,-0.0389 0.671875,-0.0547 0.167093,-0.0117 0.334731,-0.0191 0.501953,-0.0293 0.03742,-0.002 0.07391,-0.009 0.111328,-0.008 0.02721,5.5e-4 0.05275,0.011 0.08008,0.0117 0.03742,2.5e-4 0.07399,-0.01 0.111328,-0.008 0.04516,0.004 0.09186,0.0139 0.136719,0.0215 l 0.160156,0.0273 0.564453,0.0918 0.216797,0.0371 c 0.02684,0.005 0.05271,0.0151 0.08008,0.0117 0.02003,-6.4e-4 0.03834,-0.0157 0.05859,-0.0176 0.01776,-9.9e-4 0.03478,0.0108 0.05273,0.008 0.01247,-0.002 0.0184,-0.0192 0.03125,-0.0215 0.02684,-0.004 0.05317,0.009 0.08008,0.0137 l 0.269532,0.043 0.05469,0.01 c 0.01776,0.003 0.03497,0.0105 0.05273,0.008 0.01247,-0.002 0.0184,-0.0196 0.03125,-0.0215 0.01814,-0.003 0.03655,0.0105 0.05469,0.01 0.02003,-6.4e-4 0.03852,-0.0161 0.05859,-0.0176 0.01776,-9.9e-4 0.03535,0.0127 0.05273,0.008 0.02457,-0.008 0.03978,-0.033 0.0625,-0.0449 0.01776,-0.009 0.04007,-0.009 0.05859,-0.0176 0.08538,-0.0386 -0.04028,-0.0109 0.08984,-0.041 0.02835,-0.0466 0.103824,0.002 0.138672,-0.004 0.01247,-0.002 0.01915,-0.0197 0.03125,-0.0234 0.0087,-0.003 0.01827,0.004 0.02734,0.006 0.01776,0.003 0.03459,0.0105 0.05273,0.008 0.01247,-0.002 0.0184,-0.0196 0.03125,-0.0215 0.01814,-0.003 0.03692,0.005 0.05469,0.008 l 0.134766,0.0215 0.294922,0.0488 0.107422,0.0195 c 0.02683,0.005 0.0547,0.011 0.08203,0.0117 0.03742,2.5e-4 0.07391,-0.009 0.111328,-0.008 0.02721,5.3e-4 0.05317,0.008 0.08008,0.0117 l 0.162109,0.0274 c 0.02268,0.004 0.14296,0.0205 0.160157,0.0273 0.0189,0.007 0.03135,0.0287 0.05078,0.0352 0.3696,0.12593 -0.203458,-0.12378 0.236328,0.0664 0.05276,0.0223 0.100514,0.0598 0.154297,0.0801 0.02532,0.0102 0.05317,0.009 0.08008,0.0137 l 0.02734,0.004 c 0.0091,0.002 0.0167,0.008 0.02539,0.006 0.01247,-0.004 0.02224,-0.0155 0.0332,-0.0234 0.01058,-0.008 0.02174,-0.0109 0.0293,-0.0215 0.0057,-0.007 -9.4e-5,-0.0198 0.0059,-0.0274 0.07442,-0.10257 -0.0055,0.027 0.05859,-0.0195 0.0083,-0.007 -0.0021,-0.0186 0.0039,-0.0254 0.01587,-0.0219 0.07338,-0.0464 0.09375,-0.0684 0.08946,-0.0958 -0.02572,-0.0128 0.09375,-0.0664 0.05295,0.0106 0.02048,-0.039 0.03711,-0.0508 0.0072,-0.007 0.01745,0.0103 0.02539,0.004 0.0083,-0.007 -0.0022,-0.0201 0.0059,-0.0254 0.003,-0.002 0.12582,0.0226 0.13281,0.0215 0.0125,-0.002 0.0204,-0.0192 0.0332,-0.0215 0.0268,-0.004 0.0532,0.007 0.0801,0.0117 l 0.13477,0.0234 0.50976,0.084 c 0.0538,0.009 0.10746,0.0243 0.16211,0.0254 0.02,10e-4 0.0388,-0.0134 0.0586,-0.0176 0.028,-0.005 0.0553,-0.0125 0.084,-0.0137 0.0181,-9.3e-4 0.0362,0.0105 0.0547,0.01 0.22979,-4.7e-4 0.0231,-0.005 0.16992,-0.0274 0.008,-5.9e-4 0.0198,0.0103 0.0273,0.004 0.007,-0.007 -0.004,-0.0221 0.004,-0.0274 0.007,-0.007 0.0187,0.007 0.0273,0.004 0.0125,-0.004 0.0207,-0.0136 0.0312,-0.0215 0.037,-0.0265 0.0718,-0.0607 0.1211,-0.0625 0.0272,-10e-4 0.0528,0.0113 0.0801,0.0117 0.0374,2.5e-4 0.0743,-0.004 0.11133,-0.008 0.0283,-0.003 0.0573,-0.0152 0.0859,-0.0137 0.0544,0.003 0.10581,0.0224 0.16016,0.0254 0.0287,8e-4 0.0572,-0.0125 0.0859,-0.0137 0.0181,-9.3e-4 0.0344,0.0109 0.0527,0.01 0.0287,-10e-4 0.0573,-0.0126 0.0859,-0.0156 0.009,-4e-4 0.0183,0.006 0.0273,0.006 0.0287,-0.003 0.0553,-0.0148 0.084,-0.0137 0.0455,0.002 0.0919,0.0139 0.13672,0.0215 0.0178,0.003 0.0348,0.0151 0.0527,0.01 0.27673,-0.0612 -0.11866,-0.0323 0.20117,-0.0508 0.0462,-0.002 0.0946,0.008 0.13867,-0.004 0.037,-0.0117 0.0579,-0.0541 0.0937,-0.0684 0.017,-0.007 0.0367,0.0128 0.0547,0.01 0.0125,-0.002 0.0195,-0.0181 0.0312,-0.0234 0.0185,-0.009 0.04,-0.009 0.0586,-0.0176 0.0272,-0.0132 0.068,-0.0604 0.0937,-0.0684 0.009,-0.003 0.0186,0.009 0.0273,0.006 0.0125,-0.004 0.0188,-0.0193 0.0312,-0.0234 0.017,-0.005 0.0379,0.0211 0.0527,0.01 0.0162,-0.011 0.019,-0.0423 0.0371,-0.0508 0.0166,-0.007 0.0346,0.0124 0.0527,0.01 0.0125,-0.002 0.0207,-0.0166 0.0312,-0.0234 0.0208,-0.0144 0.0416,-0.0302 0.0625,-0.0449 0.0106,-0.008 0.0226,-0.0113 0.0312,-0.0215 0.0413,-0.0443 0.0661,-0.1041 0.10742,-0.14844 0.009,-0.008 0.0272,-0.0109 0.0332,-0.0215 0.009,-0.0163 -9.2e-4,-0.0387 0.008,-0.0547 0.006,-0.0106 0.0226,-0.0113 0.0312,-0.0215 0.0144,-0.0155 0.0185,-0.039 0.0352,-0.0508 0.008,-0.007 0.0186,0.009 0.0273,0.006 0.0348,-0.0102 0.0588,-0.0574 0.0937,-0.0684 0.009,-0.003 0.0186,0.009 0.0273,0.006 0.0125,-0.004 0.0195,-0.0181 0.0312,-0.0234 0.0185,-0.009 0.0391,-0.0112 0.0586,-0.0176 0.0196,-0.007 0.0384,-0.0161 0.0586,-0.0176 0.0178,-10e-4 0.0355,0.0131 0.0527,0.008 0.0246,-0.008 0.0398,-0.0331 0.0625,-0.0449 0.0353,-0.0182 0.0823,-0.0126 0.11523,-0.0352 -0.23821,-0.0485 -0.48533,-0.0742 -0.73828,-0.0742 h -2.66797 c -3.3e-4,0.002 -9.7e-4,0.004 -0.002,0.006 -0.006,0.007 -0.0162,0.008 -0.0215,0.0156 -0.005,0.007 -0.006,0.0537 -0.01,0.0566 -0.005,0.003 -0.0146,-0.007 -0.0195,-0.004 -0.0106,0.008 -6.2e-4,0.0275 -0.006,0.0391 -0.007,0.0125 -0.0141,0.0265 -0.0254,0.0352 -0.005,0.003 -0.0115,-0.005 -0.0176,-0.004 -0.0856,0.0261 0.0203,0.003 -0.0254,0.0352 -0.0117,0.008 -0.0312,0.005 -0.043,0.0137 -0.005,0.003 -7.4e-4,0.0116 -0.002,0.0195 -0.008,0.007 -0.0159,0.009 -0.0234,0.0156 -0.0132,0.006 -0.027,0.008 -0.041,0.0137 -0.014,0.006 -0.027,0.008 -0.041,0.0117 -0.02,0.005 -0.041,0.003 -0.0606,0.01 -0.0359,0.0117 -0.0667,0.0359 -0.10352,0.043 -0.0384,0.008 -0.0781,-10e-4 -0.11718,0 -0.0265,-3.8e-4 -0.0541,0.002 -0.0801,0.006 -0.0193,0.003 -0.12561,0.0317 -0.16016,0.0332 -0.0129,-1.3e-4 -0.0263,-0.008 -0.0391,-0.006 -0.0144,0.002 -0.0266,0.0144 -0.041,0.0117 -0.009,-0.002 0.0139,-0.009 0.0215,-0.0156 0.008,-0.005 0.0151,-0.0107 0.0234,-0.0156 0.0193,-0.009 0.0478,-0.009 0.0625,-0.0293 0.005,-0.005 0.008,-0.0485 0.01,-0.0566 9.5e-4,-0.006 0.008,-0.0127 0.004,-0.0195 -0.004,-0.005 -0.0142,-10e-4 -0.0195,-0.004 -0.008,-0.005 -0.013,-0.0132 -0.0156,-0.0215 -4.6e-4,-0.001 0.009,-0.0577 0.01,-0.0586 0.0231,-0.0317 0.016,-0.008 0.041,-0.0117 0.014,-0.002 0.0285,-0.008 0.041,-0.0137 0.0159,-0.007 0.0278,-0.0244 0.0449,-0.0312 0.0185,-0.007 0.041,-0.003 0.0605,-0.01 0.009,-0.003 0.0132,-0.0149 0.0215,-0.0176 0.006,-9.7e-4 0.0135,0.005 0.0195,0.004 0.017,-0.005 0.0251,-0.0271 0.043,-0.0312 0.0257,-0.006 0.0544,-0.002 0.0801,-0.008 0.009,-0.002 0.0169,-0.008 0.0254,-0.0117 h -1.599579 c -0.0027,0.002 -0.005,0.003 -0.0078,0.006 -9.53e-4,0.006 0.0015,0.0146 -0.0039,0.0195 -0.0053,0.003 -0.01153,-0.003 -0.01758,-0.002 -0.0087,0.003 -0.01512,0.0107 -0.02344,0.0156 -0.02608,0.0113 -0.05535,0.0148 -0.08203,0.0254 -0.02154,0.008 -0.04005,0.0236 -0.0625,0.0293 -0.0257,0.006 -0.05411,1.6e-4 -0.08008,0.006 -0.02797,0.005 -0.05425,0.0198 -0.08203,0.0273 -0.07317,0.0189 -0.146208,0.0288 -0.220703,0.041 -0.02041,0.005 -0.04029,0.005 -0.06055,0.01 -0.02041,0.005 -0.04014,0.009 -0.06055,0.01 -0.01965,7.4e-4 -0.03763,-0.0124 -0.05664,-0.01 -0.02305,0.004 -0.04159,0.0259 -0.06445,0.0293 -0.0189,0.003 -0.0374,-0.0105 -0.05664,-0.01 -0.02041,5.9e-4 -0.04014,0.007 -0.06055,0.01 -0.006,2e-4 -0.01115,-0.005 -0.01758,-0.004 -0.01398,0.002 -0.02662,0.0159 -0.04102,0.0137 -0.0057,-9.5e-4 -0.0035,-0.0146 0.002,-0.0195 0.0053,-0.003 0.01462,0.007 0.01953,0.004 0.0053,-0.003 -0.0035,-0.0146 0.002,-0.0195 0.0053,-0.003 0.01462,0.007 0.01953,0.004 0.0053,-0.003 6.98e-4,-0.0142 0.0039,-0.0195 0.01058,-0.014 0.03227,-0.0185 0.04297,-0.0332 0.0033,-0.005 -0.0015,-0.0127 0.0039,-0.0176 0.01172,-0.008 0.02775,-0.008 0.04102,-0.0137 0.06845,-0.0314 -0.0082,2.1e-4 0.02539,-0.0352 0.01285,-0.0136 0.03158,-0.0184 0.04492,-0.0312 0.0036,-0.003 0.01409,-0.0188 0.02539,-0.0351 z m 3.478516,0.0801 c -0.0097,-0.004 -0.0035,-0.004 0.0957,0.002 0.03213,0.001 0.062,0.0107 0.09375,0.0156 l 0.152344,0.0234 0.380859,0.0625 0.875,0.14453 c -0.02684,0.003 -0.05351,0.004 -0.08008,0.008 -9.49e-4,0.006 0.0035,0.0146 -0.002,0.0195 -0.0053,0.003 -0.0799,-0.0171 -0.0957,-0.0156 -0.01399,0.002 -0.02662,0.008 -0.04102,0.0117 -0.02154,0.004 -0.05478,-0.0163 -0.07617,-0.0117 -0.01398,0.002 -0.02662,0.0122 -0.04102,0.0137 -0.01285,0.002 -0.02633,-0.006 -0.03906,-0.008 -0.0189,-0.003 -0.03854,-8.9e-4 -0.05664,-0.008 -0.0189,-0.007 -0.03327,-0.024 -0.05273,-0.0293 -0.03099,-0.009 -0.06396,-0.0107 -0.0957,-0.0156 l -0.05664,-0.01 c -0.0072,-10e-4 -0.01348,-0.003 -0.01953,-0.002 -0.0087,0.003 -0.01317,0.013 -0.02148,0.0156 -0.006,9.7e-4 -0.01311,-0.005 -0.01953,-0.004 -0.07559,0.0121 -0.01096,0.0271 -0.121094,0.0195 -0.04479,-0.004 -0.08776,-0.02 -0.132813,-0.0215 -0.06542,-0.003 -0.131917,0.009 -0.197265,0.006 -0.05133,-0.003 -0.09971,-0.0151 -0.150391,-0.0234 l -0.228516,-0.0391 -0.208984,-0.0332 -0.03906,-0.006 c -0.0072,-10e-4 -0.01575,6.8e-4 -0.01953,-0.004 -0.02041,-0.0287 0.06507,-0.0462 0.06836,-0.0469 0.01398,-0.006 0.02699,-0.008 0.04102,-0.0137 0.0013,-0.008 -0.0035,-0.0146 0.002,-0.0195 0.0053,-0.003 0.01348,0.005 0.01953,0.004 0.0087,-0.003 0.01317,-0.013 0.02148,-0.0156 0.01247,-0.004 0.0267,0.01 0.03906,0.006 0.04076,-0.0127 0.01552,-0.0216 0.0059,-0.0254 z"
-         style="fill:#ffffff;fill-opacity:0.68131899;stroke:none;stroke-width:0.30836901px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path1155" />
-      <path
-         style="fill:#ffffff;fill-opacity:0.214286;stroke:none;stroke-width:0.0815893px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 22.18858,-70.523904 c 0.0111,0.01764 0.03541,-4.9e-4 0.04981,0.0082 0.0074,0.0044 0.01198,0.01267 0.01902,0.01775 0.0105,0.0076 0.02201,0.01359 0.03323,0.02009 0.0066,0.0037 0.01405,0.006 0.02019,0.01063 0.01612,0.01163 0.02557,0.02692 0.03684,0.04261 0.0059,0.0083 0.01363,0.01556 0.01785,0.02487 8.75e-4,0.0022 -0.0024,0.0052 -0.0012,0.0071 0.0015,0.0023 0.0058,-0.0011 0.0071,0.0012 0.0012,0.0023 -0.0027,0.0052 -0.0012,0.0071 0.0012,0.0023 0.0058,-0.0011 0.0071,0.0012 0.0013,0.0018 -0.0046,0.0183 -0.0035,0.02135 0.001,0.0033 0.0054,0.005 0.0059,0.0083 7.72e-4,0.0048 -0.0015,0.0095 -0.0023,0.01423 -4.19e-4,0.0025 -0.0018,0.0049 -0.0012,0.0071 0.001,0.0033 0.004,0.0054 0.0059,0.0083 0.002,0.0029 0.0035,0.006 0.006,0.0083 0.0039,0.0038 0.0092,0.0057 0.01306,0.0095 0.005,0.0045 0.0064,0.01259 0.01189,0.01658 0.002,0.0014 0.0058,-0.0011 0.0071,0.0012 0.0015,0.0023 -0.0031,0.0057 -0.0012,0.0071 0.0039,0.0027 0.0095,0.0015 0.01424,0.0023 0.01661,0.0027 0.0332,0.0055 0.04981,0.0082 0.0047,7.73e-4 0.0095,0.0015 0.01424,0.0023 0.0024,4.02e-4 0.0052,-1.97e-4 0.0071,0.0012 0.0028,0.002 0.0032,0.0063 0.0059,0.0083 0.002,0.0014 0.01814,0.003 0.02136,0.0035 0.01661,0.0027 0.03321,0.0055 0.04981,0.0082 0.004,6.7e-4 0.03112,0.0067 0.03558,0.0059 0.0054,-0.0012 0.01005,-0.0043 0.01541,-0.0048 0.0096,-0.001 0.01885,0.0057 0.02845,0.0047 0.0053,-1.7e-4 0.01009,-0.0039 0.01541,-0.0048 0.0036,-4.48e-4 0.04092,0.0062 0.0427,0.007 0.003,0.0015 0.0029,0.0067 0.0059,0.0083 0.0043,0.0023 0.0095,0.0015 0.01424,0.0023 0.0024,4.02e-4 0.0052,-1.97e-4 0.0071,0.0012 0.0028,0.002 0.0032,0.0063 0.0059,0.0083 0.0053,0.0035 0.01606,3.3e-5 0.02136,0.0035 0.0028,0.002 0.004,0.0054 0.0059,0.0083 0.0047,7.73e-4 0.01,7.8e-5 0.01424,0.0023 0.003,0.0015 0.0032,0.0063 0.0059,0.0083 0.0053,0.0035 0.01606,3.3e-5 0.02136,0.0035 0.004,0.0027 0.02109,0.03036 0.02376,0.03315 0.0037,0.0038 0.0092,0.0057 0.01306,0.0095 0.0057,0.0056 0.01203,0.02067 0.01784,0.02487 0.002,0.0014 0.0058,-0.0011 0.0071,0.0012 0.0015,0.0023 -0.0024,0.0052 -0.0012,0.0071 0.0032,0.0042 0.0092,0.0057 0.01307,0.0095 0.0024,0.0025 0.0032,0.0063 0.0059,0.0083 0.002,0.0014 0.0047,7.73e-4 0.0071,0.0012 0.0043,0.0033 0.0092,0.0057 0.01307,0.0095 0.0024,0.0025 0.0032,0.0063 0.0059,0.0083 0.0025,0.002 0.02015,0.0018 0.02136,0.0035 0.0013,0.0018 -0.0046,0.0183 -0.0035,0.02135 0.0033,0.01072 0.01149,0.0092 0.02019,0.01063 0.0024,4.01e-4 0.0052,-1.97e-4 0.0071,0.0012 0.0028,0.002 0.0032,0.0063 0.006,0.0083 0.002,0.0014 0.0047,7.73e-4 0.0071,0.0012 0.01424,0.0023 0.02845,0.0047 0.0427,0.007 0.0024,4.02e-4 0.0051,0.0029 0.0071,0.0012 0.0019,-0.0018 -9.27e-4,-0.0057 0.0012,-0.0071 0.0019,-0.0018 0.0051,0.0029 0.0071,0.0012 0.0019,-0.0018 -9.27e-4,-0.0057 0.0012,-0.0071 0.0019,-0.0018 0.0091,-5.67e-4 0.0071,0.0012 -0.0088,0.0063 -0.02128,0.0045 -0.03079,0.0096 -0.01791,0.0093 -0.03181,0.02635 -0.04972,0.03567 -0.0047,0.0024 -0.01049,0.0025 -0.01541,0.0048 -0.0031,0.0016 -0.0055,0.0038 -0.0083,0.0059 -0.0028,0.0022 -0.0059,0.0032 -0.0083,0.0059 -0.0038,0.0041 -0.0051,0.0099 -0.0095,0.01306 -0.0019,0.0018 -0.0048,-0.0019 -0.0071,-0.0012 -0.0033,0.001 -0.005,0.0049 -0.0083,0.0059 -0.003,0.0011 -0.01965,-0.0048 -0.02136,-0.0035 -0.0019,0.0018 9.28e-4,0.0057 -0.0012,0.0071 -0.0019,0.0018 -0.0047,-7.73e-4 -0.0071,-0.0012 -0.0047,-7.73e-4 -0.0096,-0.0037 -0.01424,-0.0023 -0.0023,6.7e-4 6.18e-4,0.0057 -0.0012,0.0071 -0.0022,0.0018 -0.0051,-0.0029 -0.0071,-0.0012 -0.0022,0.0018 0.0011,0.0064 -0.0012,0.0071 -0.04033,-0.0066 -0.0017,-0.005 -0.01541,0.0048 -0.0019,0.0018 -0.0051,-0.0029 -0.0071,-0.0012 -0.0019,0.0018 9.28e-4,0.0057 -0.0012,0.0071 -0.0043,0.0029 -0.01105,0.0019 -0.01541,0.0048 -0.0022,0.0018 6.18e-4,0.0057 -0.0012,0.0071 -0.0022,0.0018 -0.0051,-0.0029 -0.0071,-0.0012 -0.0018,0.0013 -0.0015,0.0188 -0.0035,0.02135 -0.002,0.0028 -0.0063,0.0031 -0.0083,0.0059 -0.0015,0.0019 3.84e-4,0.0053 -0.0012,0.0071 -0.01043,0.01441 -0.0047,0.0013 -0.01541,0.0048 -0.0033,0.001 -0.005,0.0049 -0.0083,0.0059 -0.0023,6.7e-4 -0.0047,-7.72e-4 -0.0071,-0.0012 -0.0024,-4.01e-4 -0.0075,0.0014 -0.0071,-0.0012 5.67e-4,-0.0036 0.0055,-0.0038 0.0083,-0.0059 0.01701,-0.01218 -0.002,-0.0014 0.02253,-0.0036 0.0053,-1.7e-4 0.01009,-0.0039 0.01541,-0.0048 0.0022,-1.57e-4 0.0048,0.0019 0.0071,0.0012 0.0033,-0.001 0.005,-0.0049 0.0083,-0.0059 0.0023,-6.7e-4 0.0047,7.72e-4 0.0071,0.0012 0.0047,7.72e-4 0.0095,0.0031 0.01424,0.0023 0.0033,-4.98e-4 0.005,-0.0049 0.0083,-0.0059 0.0023,-6.7e-4 0.0047,7.73e-4 0.0071,0.0012 0.0047,7.73e-4 0.0095,0.0031 0.01424,0.0023 0.0033,-4.9e-4 0.0052,-0.0046 0.0083,-0.0059 0.0049,-0.0023 0.01009,-0.0039 0.01541,-0.0048 0.0067,-9.79e-4 0.0146,0.0045 0.02136,0.0035 0.0033,-4.89e-4 0.005,-0.0049 0.0083,-0.0059 0.0023,-6.69e-4 0.0048,0.0019 0.0071,0.0012 0.0033,-0.001 0.0052,-0.0046 0.0083,-0.0059 0.0014,-8.24e-4 0.03026,-0.0092 0.03079,-0.0096 0.0022,-0.0018 -9.27e-4,-0.0057 0.0012,-0.0071 0.0043,-0.0029 0.01049,-0.0025 0.01541,-0.0048 0.0031,-0.0016 0.005,-0.0049 0.0083,-0.0059 0.0045,-0.0013 0.0096,0.0037 0.01424,0.0023 0.0033,-0.001 0.005,-0.0049 0.0083,-0.0059 0.0023,-6.7e-4 0.0051,0.0029 0.0071,0.0012 0.0019,-0.0018 -9.27e-4,-0.0057 0.0012,-0.0071 0.01715,-0.01232 -0.0043,0.02237 0.01541,-0.0048 0.0028,-0.0037 -4.95e-4,-0.01031 0.0023,-0.01423 0.0024,-0.0032 0.01404,-0.0084 0.01658,-0.01189 0.0015,-0.0019 -3.83e-4,-0.0053 0.0012,-0.0071 0.002,-0.0028 0.0063,-0.0031 0.0083,-0.0059 0.002,-0.0023 0.0018,-0.02018 0.0035,-0.02135 0.0019,-0.0018 0.0051,0.0029 0.0071,0.0012 0.0041,-0.003 -6.18e-4,-0.01838 0.0035,-0.02135 0.0019,-0.0018 0.0047,7.73e-4 0.0071,0.0012 4.18e-4,-0.0025 -6.18e-4,-0.0057 0.0012,-0.0071 0.0022,-0.0018 0.0051,0.0029 0.0071,0.0012 0.0022,-0.0018 -6.18e-4,-0.0057 0.0012,-0.0071 0.0014,-8.24e-4 0.01842,0.0041 0.02136,0.0035 0.0054,-0.0012 0.01009,-0.0039 0.01541,-0.0048 0.0022,-1.57e-4 0.0048,0.0013 0.0071,0.0012 0.0054,-0.0012 0.01004,-0.0046 0.01541,-0.0048 0.01204,-6.18e-4 0.0237,0.0039 0.03558,0.0059 0.0075,0.0012 0.02876,0.0031 0.03558,0.0059 0.0071,0.0027 0.01287,0.0086 0.02019,0.01063 0.01389,0.0039 0.02868,0.0037 0.0427,0.007 0.111911,0.02813 -0.02886,0.0026 0.08422,0.02117 0.0012,2.01e-4 0.04683,0.0061 0.04981,0.0082 0.0079,0.0055 0.01,0.01919 0.01784,0.02487 0.002,0.0014 0.0053,-1.7e-4 0.0071,0.0012 0.005,0.0045 0.0072,0.01167 0.0119,0.01658 0.0037,0.0038 0.0093,0.0057 0.01306,0.0095 0.0047,0.0049 0.0074,0.0115 0.01189,0.01658 0.01242,0.01379 0.01851,0.0174 0.03206,0.0272 0.0043,0.0033 0.0087,0.0061 0.01306,0.0095 0.0043,0.0033 0.008,0.0076 0.01307,0.0095 0.0091,0.0036 0.02489,0.0041 0.03558,0.0059 0.0237,0.0039 0.04744,0.0078 0.07116,0.01171 0.01186,0.002 0.02419,0.0019 0.03558,0.0059 0.0052,0.0014 0.0085,0.0067 0.01307,0.0095 0.0066,0.0037 0.01364,0.0069 0.02019,0.01063 0.0092,0.0057 0.01625,0.01463 0.02611,0.01892 0.0044,0.0018 0.0098,5.67e-4 0.01424,0.0023 0.0071,0.0027 0.01307,0.0079 0.02019,0.01063 0.0045,0.0018 0.0098,5.67e-4 0.01424,0.0023 0.005,0.0019 0.0083,0.0069 0.01307,0.0095 0.0043,0.0023 0.0095,0.0015 0.01424,0.0023 0.0095,0.0015 0.01898,0.0031 0.02845,0.0047 0.02136,0.0035 0.0427,0.007 0.06404,0.01054 0.02136,0.0035 0.0427,0.007 0.06404,0.01054 0.0037,6.18e-4 0.02643,0.0054 0.02845,0.0047 0.0033,-10e-4 0.005,-0.0049 0.0083,-0.0059 0.0061,-0.0016 0.01522,0.0051 0.02136,0.0035 0.0033,-0.001 0.0049,-0.0054 0.0083,-0.0059 0.0048,-7.73e-4 0.0095,0.0031 0.01424,0.0023 0.0033,-4.98e-4 0.005,-0.0049 0.0083,-0.0059 0.0023,-6.69e-4 0.0048,0.0019 0.0071,0.0012 0.0065,-0.0021 0.0098,-0.01133 0.01658,-0.01189 0.0072,-8.76e-4 0.01411,0.0039 0.02136,0.0035 0.0054,-1.61e-4 0.01005,-0.0043 0.01541,-0.0048 0.0047,-2.64e-4 0.0095,0.0031 0.01424,0.0023 0.0033,-4.98e-4 0.005,-0.0049 0.0083,-0.0059 0.0023,-6.7e-4 0.0048,0.0019 0.0071,0.0012 0.0033,-10e-4 0.005,-0.0049 0.0083,-0.0059 0.0048,-0.0013 0.02367,0.006 0.02848,0.0047 0.01703,-0.0053 0.0029,-0.0042 0.0095,-0.01306 0.002,-0.0028 0.0055,-0.0038 0.0083,-0.0059 0.0028,-0.0022 0.0055,-0.0038 0.0083,-0.0059 0.0032,-0.0042 0.0051,-0.0099 0.0095,-0.01306 0.0019,-0.0018 0.0048,0.0019 0.0071,0.0012 0.0061,-0.0016 0.01042,-0.01 0.01658,-0.01189 0.0045,-0.0013 0.0096,0.0037 0.01424,0.0023 0.0033,-0.001 0.005,-0.0049 0.0083,-0.0059 0.0023,-6.69e-4 0.0047,7.73e-4 0.0071,0.0012 0.0052,-0.0018 0.01049,-0.0025 0.01541,-0.0048 0.0031,-0.0016 0.0052,-0.0046 0.0083,-0.0059 0.0049,-0.0023 0.01105,-0.0019 0.01541,-0.0048 0.01106,-0.0079 -0.01397,-0.0093 0.0095,-0.01306 0.0048,-7.72e-4 0.0095,0.0031 0.01424,0.0023 0.0067,-9.79e-4 0.01009,-0.0099 0.01658,-0.01189 0.002,-7.21e-4 0.03765,0.0062 0.0427,0.007 0.0024,4.01e-4 0.0051,0.0029 0.0071,0.0012 0.0022,-0.0018 -6.18e-4,-0.0057 0.0012,-0.0071 0.0022,-0.0018 0.0048,0.0019 0.0071,0.0012 0.0065,-0.0021 0.01037,-0.0091 0.01658,-0.01189 0.0049,-0.0023 0.01049,-0.0025 0.01541,-0.0048 0.0031,-0.0016 0.005,-0.0049 0.0083,-0.0059 0.0045,-0.0013 0.01031,0.0054 0.01424,0.0023 0.0019,-0.0018 -9.27e-4,-0.0057 0.0012,-0.0071 0.0039,-0.003 0.01031,0.0054 0.01424,0.0023 0.0019,-0.0018 -9.27e-4,-0.0057 0.0012,-0.0071 0.0019,-0.0018 0.0051,0.0029 0.0071,0.0012 0.0018,-0.0013 0.0015,-0.0188 0.0035,-0.02135 0.002,-0.0028 0.0063,-0.0031 0.0083,-0.0059 0.0012,-0.0014 0.0044,-0.02679 0.0047,-0.02847 0.0011,-0.0067 0.0067,-0.03126 0.0059,-0.03558 -7.22e-4,-0.0032 -0.0049,-0.005 -0.0059,-0.0083 -8.25e-4,-0.0027 0.0055,-0.01988 0.0035,-0.02135 -0.01103,-0.008 -0.01913,0.0015 -0.02962,0.0024 -0.0047,2.64e-4 -0.0096,-0.0037 -0.01424,-0.0023 -0.01752,0.0054 -0.01791,0.02075 -0.04026,0.02261 -0.0047,2.64e-4 -0.0095,-0.0031 -0.01424,-0.0023 -0.0033,4.9e-4 -0.0052,0.0046 -0.0083,0.0059 -0.0049,0.0023 -0.01025,0.003 -0.01541,0.0048 -0.0052,0.0018 -0.01016,0.0036 -0.01541,0.0048 -0.0074,0.0014 -0.01541,6.19e-4 -0.02253,0.0036 -0.0063,0.0026 -0.01054,0.0088 -0.01658,0.01189 -0.0052,0.0018 -0.01025,0.003 -0.01541,0.0048 -0.0024,-4.01e-4 -0.0048,-0.0019 -0.0071,-0.0012 -0.0033,10e-4 -0.005,0.0049 -0.0083,0.0059 -0.0023,6.7e-4 -0.0051,-0.0029 -0.0071,-0.0012 -0.0019,0.0018 0.0011,0.0064 -0.0012,0.0071 -0.0045,0.0013 -0.0095,-0.0015 -0.01424,-0.0023 -0.0047,-7.72e-4 -0.0098,-5.66e-4 -0.01424,-0.0023 -0.005,-0.0019 -0.0083,-0.0069 -0.01307,-0.0095 -0.0021,-8.76e-4 -0.0052,1.97e-4 -0.0071,-0.0012 -0.0028,-0.002 -0.0032,-0.0063 -0.006,-0.0083 -0.002,-0.0014 -0.0047,-7.72e-4 -0.0071,-0.0012 -0.0071,-0.0012 -0.01424,-0.0023 -0.02136,-0.0035 -0.0047,-7.72e-4 -0.0098,-5.66e-4 -0.01424,-0.0023 -0.0071,-0.0027 -0.01349,-0.0069 -0.02019,-0.01063 -0.0095,-0.0015 -0.01925,-0.0021 -0.02845,-0.0047 -0.0073,-0.0022 -0.01298,-0.0081 -0.02019,-0.01063 -0.0069,-0.0022 -0.01424,-0.0023 -0.02136,-0.0035 -0.02136,-0.0035 -0.0427,-0.007 -0.06404,-0.01054 -0.004,-6.7e-4 -0.03113,-0.0067 -0.03558,-0.0059 -0.0054,0.0012 -0.01009,0.0039 -0.01541,0.0048 -0.0048,7.73e-4 -0.01031,-0.0054 -0.01424,-0.0023 -0.0019,0.0018 0.0011,0.0064 -0.0012,0.0071 -0.0045,0.0013 -0.0096,-0.0037 -0.01424,-0.0023 -0.0065,0.0021 -0.01053,0.0087 -0.01658,0.01189 -0.01398,0.0073 -0.0224,0.0036 -0.03792,0.0084 -0.0033,0.001 -0.0055,0.0038 -0.0083,0.0059 -0.0052,0.0018 -0.01016,0.0036 -0.01541,0.0048 -0.0074,0.0014 -0.01515,0.0022 -0.02253,0.0036 -0.0053,0.0012 -0.01004,0.0046 -0.01541,0.0048 -0.0072,3.78e-4 -0.01412,-0.0044 -0.02136,-0.0035 -0.0068,4.53e-4 -0.01009,0.0099 -0.01659,0.01189 -0.0045,0.0013 -0.0095,-0.0031 -0.01424,-0.0023 -0.0054,0.0012 -0.01006,0.0043 -0.01541,0.0048 -0.0072,8.75e-4 -0.01412,-0.0044 -0.02136,-0.0035 -0.0076,8.24e-4 -0.0149,0.0036 -0.02253,0.0036 -0.0072,-1.41e-4 -0.01411,-0.0039 -0.02136,-0.0035 -0.0054,1.6e-4 -0.01004,0.0046 -0.01541,0.0048 -0.0078,2.89e-4 -0.03952,-0.0065 -0.04981,-0.0082 -0.0083,-0.0013 -0.02937,-0.0032 -0.03558,-0.0059 -0.005,-0.0019 -0.0083,-0.0069 -0.01306,-0.0095 -0.0048,-0.0024 -0.0269,-0.0023 -0.02845,-0.0047 -0.0015,-0.0023 0.0021,-0.0049 0.0012,-0.0071 -10e-4,-0.0033 -0.0049,-0.005 -0.0059,-0.0083 -8.76e-4,-0.0022 7.73e-4,-0.0046 0.0012,-0.0071 -0.0017,-0.005 -0.0026,-0.0105 -0.0048,-0.0154 -0.0014,-0.0028 -0.0046,-0.0049 -0.0059,-0.0083 -0.0052,-0.01151 -0.002,-0.01557 -0.01073,-0.02369 -0.0039,-0.0038 -0.0099,-0.0053 -0.01307,-0.0095 -0.0012,-0.0023 0.0014,-0.005 0.0012,-0.0071 -6.7e-4,-0.0053 -0.0039,-0.0101 -0.0048,-0.0154 -2.75e-4,-0.0021 7.73e-4,-0.0046 0.0012,-0.0071 7.73e-4,-0.0046 0.0015,-0.0095 0.0023,-0.01423 7.73e-4,-0.0046 0.0028,-0.0094 0.0023,-0.01423 -3.75e-4,-0.0053 -0.0043,-0.01006 -0.0048,-0.0154 -4.66e-4,-0.0048 0.0015,-0.0095 0.0023,-0.01423 7.72e-4,-0.0046 0.0015,-0.0095 0.0023,-0.01423 4.18e-4,-0.0025 7.73e-4,-0.0046 0.0012,-0.0071 4.18e-4,-0.0025 -9.28e-4,-0.0057 0.0012,-0.0071 6.69e-4,-4.08e-4 0.01127,0.0024 0.01424,0.0023 0.0099,-4.55e-4 0.01972,-0.0027 0.02965,-0.0024 0.0072,1.4e-4 0.01424,0.0023 0.02136,0.0035 0.0071,0.0012 0.01461,8.24e-4 0.02136,0.0035 0.005,0.0019 0.0081,0.0073 0.01307,0.0095 0.0044,0.0018 0.01898,0.0031 0.01424,0.0023 -0.01661,-0.0027 -0.03321,-0.0055 -0.04981,-0.0082 -0.0095,-0.0015 -0.01918,-0.0021 -0.02845,-0.0047 -0.01185,-0.003 -0.02252,-0.0099 -0.03441,-0.01297 -0.02794,-0.0072 -0.05744,-0.0068 -0.08539,-0.01405 -0.01422,-0.0034 -0.02735,-0.01061 -0.04152,-0.01414 -0.01401,-0.0033 -0.02845,-0.0047 -0.0427,-0.007 -0.01661,-0.0027 -0.0332,-0.0055 -0.04981,-0.0082 -0.01424,-0.0023 -0.02845,-0.0047 -0.0427,-0.007 -0.007,-0.0011 -0.02124,-0.0035 -0.01424,-0.0023 0.08216,0.01352 -0.04193,-0.0048 0.04387,-9e-5 0.0144,8.25e-4 0.02828,0.0073 0.0427,0.007 0.01298,-4.74e-4 0.02502,-0.0073 0.03792,-0.0084 0.0072,-8.76e-4 0.01427,0.0044 0.02136,0.0035 0.0085,-0.0012 0.01514,-0.0094 0.0237,-0.01072 0.0071,-9.27e-4 0.01412,0.0044 0.02136,0.0035 0.0068,-4.53e-4 0.0098,-0.01081 0.01658,-0.01189 0.0048,-7.73e-4 0.0096,0.0037 0.01424,0.0023 0.0023,-6.7e-4 -8.76e-4,-0.0061 0.0012,-0.0071 0.0086,-0.02088 0.02014,7.21e-4 0.02962,-0.0024 0.0033,-10e-4 0.005,-0.0049 0.0083,-0.0059 0.0023,-6.7e-4 0.0048,0.0019 0.0071,0.0012 0.0033,-0.001 0.005,-0.0049 0.0083,-0.0059 0.0023,-6.7e-4 0.0047,7.72e-4 0.0071,0.0012 0.0047,7.73e-4 0.0095,0.0031 0.01424,0.0023 0.0033,-4.98e-4 0.005,-0.0049 0.0083,-0.0059 0.0023,-6.7e-4 0.0047,7.73e-4 0.0071,0.0012 0.0071,0.0012 0.01411,0.0039 0.02136,0.0035 0.0054,-1.6e-4 0.0105,-0.0025 0.01541,-0.0048 0.03704,-0.01677 -0.03021,0.0048 0.02253,-0.0036 0.0149,-0.0023 0.0044,-0.0061 0.0095,-0.01306 0.002,-0.0028 0.0063,-0.0031 0.0083,-0.0059 0.0015,-0.0019 -9.27e-4,-0.0057 0.0012,-0.0071 0.0019,-0.0018 0.0051,0.0029 0.0071,0.0012 0.0041,-0.003 -6.18e-4,-0.01838 0.0035,-0.02135 0.0019,-0.0018 0.0048,0.0019 0.0071,0.0012 0.0033,-0.001 0.0055,-0.0038 0.0083,-0.0059 0.0028,-0.0022 0.01105,-0.0039 0.0083,-0.0059 -0.0059,-0.0041 -0.01478,-3.46e-4 -0.02136,-0.0035 -0.0031,-0.0015 -0.004,-0.0054 -0.006,-0.0083 -0.0067,-0.0037 -0.01298,-0.0081 -0.02019,-0.01063 -0.0069,-0.0022 -0.0145,-0.0013 -0.02136,-0.0035 -0.01437,-0.005 -0.02596,-0.01639 -0.04035,-0.02126 -0.0069,-0.0022 -0.01518,1.12e-4 -0.02136,-0.0035 -0.0058,-0.0036 -0.0064,-0.01259 -0.01189,-0.01658 -0.0039,-0.0027 -0.0098,-5.67e-4 -0.01424,-0.0023 -0.005,-0.0019 -0.008,-0.0076 -0.01307,-0.0095 -0.0067,-0.0027 -0.01494,-3.71e-4 -0.02136,-0.0035 -0.0021,-8.76e-4 0.0027,-0.0052 0.0012,-0.0071 -0.0032,-0.0042 -0.0092,-0.0057 -0.01306,-0.0095 -0.0024,-0.0025 -0.0035,-0.006 -0.006,-0.0083 -0.0039,-0.0038 -0.0092,-0.0057 -0.01307,-0.0095 -0.0024,-0.0025 -0.0035,-0.0059 -0.0059,-0.0083 -0.0039,-0.0038 -0.0092,-0.0057 -0.01307,-0.0095 -0.0024,-0.0025 -0.0032,-0.0063 -0.0059,-0.0083 -0.0042,-0.0028 -0.02307,-0.0017 -0.02845,-0.0047 -0.0047,-0.0029 -0.0083,-0.0069 -0.01307,-0.0095 -0.0046,-0.0023 -0.0175,-7.73e-4 -0.02136,-0.0035 -0.0028,-0.002 -0.004,-0.0054 -0.006,-0.0083 -0.002,-0.0029 -0.0049,-0.005 -0.0059,-0.0083 -8.75e-4,-0.0022 7.73e-4,-0.0046 0.0012,-0.0071 0.0021,-0.01241 -3.83e-4,-0.0053 0.01064,-0.02018 0.0032,-0.0042 0.0046,-0.01058 0.0095,-0.01306 0.0067,-0.0036 0.01522,-0.0011 0.02253,-0.0036 0.01179,-0.0037 0.0077,-0.01179 0.01775,-0.019 0.0022,-0.0018 0.0048,0.0019 0.0071,0.0012 0.0065,-0.0021 0.01009,-0.0099 0.01658,-0.01189 0.0023,-6.7e-4 0.0051,0.0029 0.0071,0.0012 0.0039,-0.003 -0.0022,-0.01279 0.0023,-0.01423 0.0045,-0.0013 0.0096,0.0037 0.01424,0.0023 0.0023,-6.7e-4 0.0031,-0.0057 0.0012,-0.0071 -0.0039,-0.0027 -0.0098,-5.67e-4 -0.01424,-0.0023 -0.005,-0.0019 -0.0079,-0.0078 -0.01306,-0.0095 -0.08647,-0.02723 0.0026,0.0082 -0.05693,-0.0094 -0.105903,-0.03993 0.02671,0.0075 -0.06287,-0.01765 -0.01185,-0.003 -0.02272,-0.0093 -0.03441,-0.01297 -0.0085,-0.0024 -0.01947,-0.0032 -0.02845,-0.0047 -0.0024,-4.01e-4 -0.0047,-7.73e-4 -0.0071,-0.0012 -0.0024,-4.01e-4 -0.0048,-0.0019 -0.0071,-0.0012 -0.01885,0.0135 0.0012,0.0023 -0.01541,0.0048 -0.0054,0.0012 -0.01009,0.0039 -0.01541,0.0048 -0.0022,1.57e-4 -0.0048,-0.0019 -0.0071,-0.0012 -0.0033,0.001 -0.0049,0.0054 -0.0083,0.0059 -0.0045,8.25e-4 -0.03429,-0.0056 -0.04269,-0.007 -0.0071,-0.0012 -0.01424,-0.0023 -0.02136,-0.0035 -0.0024,-4.02e-4 -0.0091,5.66e-4 -0.0071,-0.0012 0.0043,-0.0029 0.01043,-0.003 0.01541,-0.0048 0.0081,-0.0033 0.01541,-0.0082 0.0237,-0.01072 0.0073,-0.0025 0.01508,-0.0022 0.02253,-0.0036 0.01271,-0.0026 0.02514,-0.0064 0.03792,-0.0084 0.0098,-0.0015 0.01998,1.55e-4 0.02962,-0.0024 0.0084,-0.0023 0.01565,-0.0075 0.0237,-0.01072 0.0049,-0.0018 0.01105,-0.0019 0.01541,-0.0048 0.0019,-0.0018 -3.84e-4,-0.0053 0.0012,-0.0071 0.002,-0.0028 0.0055,-0.0038 0.0083,-0.0059 0.0028,-0.0022 0.01025,-0.003 0.0083,-0.0059 -0.0028,-0.0041 -0.0095,-0.0015 -0.01424,-0.0023 -0.01898,-0.0031 -0.03795,-0.0062 -0.05693,-0.0094 -0.0427,-0.007 -0.08539,-0.01405 -0.128085,-0.02108 -0.01187,-0.002 -0.0236,-0.0049 -0.03558,-0.0059 -0.01453,-0.0013 -0.02928,0.0011 -0.04387,9e-5 -0.01198,-9.27e-4 -0.0237,-0.0039 -0.03558,-0.0059 -0.0047,-7.73e-4 -0.0095,-0.0031 -0.01424,-0.0023 -0.0033,4.99e-4 -0.005,0.0049 -0.0083,0.0059 -0.0023,6.7e-4 -0.0048,-0.0019 -0.0071,-0.0012 -0.03204,0.0099 0.0077,7.22e-4 -0.0095,0.01306 -0.0019,0.0018 -0.0047,-7.73e-4 -0.0071,-0.0012 -0.0024,-4.02e-4 -0.0047,-7.73e-4 -0.0071,-0.0012 -0.0071,-0.0012 -0.01424,-0.0023 -0.02136,-0.0035 -0.01898,-0.0031 -0.03795,-0.0062 -0.05693,-0.0094 -0.01186,-0.002 -0.02437,-0.0014 -0.03558,-0.0059 -0.005,-0.0019 -0.0081,-0.0073 -0.01307,-0.0095 -0.0044,-0.0018 -0.0095,-0.0015 -0.01424,-0.0023 -0.01661,-0.0027 -0.03321,-0.0055 -0.04981,-0.0082 -0.0019,-3.01e-4 -0.02108,-0.0037 -0.02136,-0.0035 -0.0039,0.003 0.0015,0.01143 -0.0023,0.01423 -0.0043,0.0029 -0.01049,0.0025 -0.01541,0.0048 -0.0031,0.0016 -0.0052,0.0046 -0.0083,0.0059 -0.0049,0.0023 -0.01009,0.0039 -0.01541,0.0048 -0.0022,1.56e-4 -0.0047,-0.0013 -0.0071,-0.0012 -0.0076,8.24e-4 -0.01491,0.0036 -0.02253,0.0036 -0.01445,2.33e-4 -0.02825,-0.0073 -0.0427,-0.007 -0.0076,-2e-4 -0.01493,0.0033 -0.02253,0.0036 -0.0048,2.47e-4 -0.0095,-0.0015 -0.01424,-0.0023 -0.01661,-0.0027 -0.03321,-0.0055 -0.04981,-0.0082 -0.0071,-0.0012 -0.01427,-0.0044 -0.02136,-0.0035 -0.0033,4.98e-4 -0.005,0.0049 -0.0083,0.0059 -0.0023,6.7e-4 -0.0048,-0.0019 -0.0071,-0.0012 -0.0033,10e-4 -0.0063,0.0031 -0.0083,0.0059 -3.88e-4,4.58e-4 -0.0049,0.0278 -0.0047,0.02847 0.001,0.0033 0.0045,0.0054 0.006,0.0083 0.0023,0.0051 8.76e-4,0.01174 0.0048,0.0154 0.0036,0.0032 0.01,7.7e-5 0.01424,0.0023 0.003,0.0015 0.0032,0.0063 0.0059,0.0083 0.002,0.0014 0.0052,-1.96e-4 0.0071,0.0012 0.0016,0.0013 0.01719,0.02283 0.01785,0.02487 8.76e-4,0.0022 -0.0027,0.0052 -0.0012,0.0071 0.0015,0.0023 0.0058,-0.0011 0.0071,0.0012 0.0028,0.0041 -0.0038,0.0096 -0.0023,0.01423 0.001,0.0033 0.0087,0.0061 0.006,0.0083 -0.0062,0.0044 -0.01522,0.0011 -0.02253,0.0036 -0.0033,0.001 -0.0049,0.0057 -0.0083,0.0059 -0.0072,8.76e-4 -0.01431,-0.0049 -0.02136,-0.0035 -0.0067,0.0015 -0.0099,0.01043 -0.01658,0.01189 -0.007,0.0014 -0.01411,-0.0039 -0.02136,-0.0035 -0.0054,1.6e-4 -0.01009,0.0039 -0.01541,0.0048 -0.0098,0.0015 -0.0198,0.0014 -0.02962,0.0024 -0.0075,8.24e-4 -0.01493,0.0033 -0.02253,0.0036 -0.0048,2.47e-4 -0.0095,-0.0015 -0.01424,-0.0023 -0.0075,0.0014 -0.01493,0.0033 -0.02253,0.0036 -2.49e-4,1.6e-5 -0.02129,-0.0036 -0.02136,-0.0035 -0.0022,0.0018 0.0011,0.0064 -0.0012,0.0071 -0.0045,0.0013 -0.0095,-0.0015 -0.01424,-0.0023 -0.0024,-4.02e-4 -0.0051,-0.0029 -0.0071,-0.0012 -0.0019,0.0018 0.0011,0.0064 -0.0012,0.0071 -0.0045,0.0013 -0.0096,-0.0037 -0.01424,-0.0023 -0.0023,6.7e-4 6.18e-4,0.0057 -0.0012,0.0071 -0.0022,0.0018 -0.0051,-0.0029 -0.0071,-0.0012 -0.0022,0.0018 3.83e-4,0.0053 -0.0012,0.0071 -0.002,0.0028 -0.0215,0.0163 -0.02487,0.01783 -0.0049,0.0023 -0.01009,0.0039 -0.01541,0.0048 -0.0093,0.0016 -0.0068,-0.0071 -0.01541,0.0048 -0.0015,0.0019 -7.73e-4,0.0046 -0.0012,0.0071 -0.0032,0.0042 -0.0058,0.0091 -0.0095,0.01306 -0.0023,0.0022 -0.0063,0.0031 -0.0083,0.0059 -0.01165,0.01609 0.02172,-0.003 -0.01063,0.02018 -0.0022,0.0018 -0.0051,-0.0029 -0.0071,-0.0012 -0.004,0.003 0.0022,0.01279 -0.0023,0.01423 -0.0297,0.0092 -5.66e-4,-0.03388 -0.02605,0.02495 z"
-         id="path1193"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path1195"
-         d="m 27.6994,-71.687969 c -0.04135,8.6e-5 -0.08272,2.21e-4 -0.124071,2.55e-4 -0.02684,-0.0044 -0.05331,-0.01295 -0.08051,-0.01325 -0.06268,-6.69e-4 -0.125084,0.01131 -0.187767,0.01045 -0.434436,-0.0062 -0.01331,-0.0403 -0.456033,0.0076 -0.04921,0.0053 -0.09818,0.01303 -0.147514,0.01707 -0.03455,0.0028 -0.06971,-0.0019 -0.103943,0.0036 -0.009,0.0011 -0.01403,0.01231 -0.02233,0.01585 0.02013,0.0023 0.0404,0.004 0.05927,0.0108 0.02014,0.0075 0.03656,0.02361 0.05707,0.03006 0.02598,0.0079 0.05367,0.0088 0.08051,0.01325 0.324398,0.05339 -0.120975,-0.01469 0.285085,0.02624 0.05415,0.0053 0.107342,0.01766 0.161013,0.0265 0.03355,0.0055 0.06671,0.01464 0.100633,0.01656 0.02801,0.0015 0.05581,-0.006 0.08382,-0.0069 0.01356,-3.78e-4 0.02687,0.0086 0.04025,0.0066 0.01499,-0.0022 0.02855,-0.01112 0.04357,-0.0135 0.02012,-0.0032 0.04002,0.01181 0.06038,0.0099 0.01513,-0.0012 0.02855,-0.01112 0.04357,-0.0135 0.02767,-0.0044 0.05614,-0.0025 0.08382,-0.0069 0.01499,-0.0022 0.02842,-0.01224 0.04357,-0.0135 0.01353,-9.27e-4 0.02673,0.0075 0.04025,0.0066 0.01513,-0.0012 0.02855,-0.01112 0.04357,-0.01351 0.01339,-0.002 0.02725,0.01065 0.04025,0.0066 0.0092,-0.0027 0.0143,-0.01394 0.02342,-0.01682 l -0.362279,-0.05962 c 0.01499,-0.0022 0.02843,-0.01229 0.04357,-0.0135 0.01352,-9.27e-4 0.02684,0.0044 0.04025,0.0066 0.0067,0.0011 0.01378,0.0059 0.02014,0.0033 0.03159,-0.0125 0.0603,-0.03142 0.09044,-0.04713 z m 0.167891,0.110324 0.02014,0.0033 c 0.0067,0.0011 -0.01362,-0.0054 -0.02014,-0.0033 z m -1.290039,-0.06875 c -0.0071,-8.76e-4 -0.01426,-0.0013 -0.02125,-0.0025 -0.0067,-0.0011 0.01362,0.0054 0.02012,0.0033 3.39e-4,-1.63e-4 7.72e-4,-9.27e-4 0.0011,-8.76e-4 z m -1.87596,-0.16291 c 0.02463,0.01783 0.047,0.03932 0.07388,0.05351 0.01052,0.0054 0.103688,0.01707 0.120758,0.01987 l 0.03601,0.0059 c -0.05465,-0.0095 -0.04814,-0.01414 -0.230649,-0.07931 z m 0,0 c -0.04031,-0.0092 -0.08275,0.0019 -0.12407,2.55e-4 -0.01358,-6.7e-4 -0.02689,-0.0039 -0.04025,-0.0066 0.02492,0.0041 0.05604,0.0134 0.0805,0.01325 0.02804,-8.4e-5 0.05587,-0.0045 0.08382,-0.0069 z m 0.230649,0.07931 c 0.02117,0.0037 0.05023,0.0083 0.104878,0.01726 z m -0.432565,-0.09473 c -0.0016,5.4e-5 -0.0023,6.69e-4 -0.0026,0.0022 -0.0011,0.0067 0.01345,0.0022 0.02011,0.0033 -0.005,-8.25e-4 -0.01326,-0.0058 -0.0175,-0.0055 z m 0.656462,0.128714 c -0.0039,-0.0017 -0.01332,4.18e-4 -0.01834,-4.08e-4 0.0067,0.0011 0.01901,0.01002 0.02012,0.0033 2.51e-4,-0.0015 -4.97e-4,-0.0027 -0.0017,-0.0029 z m 0.958634,0.59478 c -0.135124,-0.01274 -0.265469,0.03312 -0.398971,0.0377 -0.102829,0.0036 -0.205628,-0.0092 -0.308522,-0.0094 -0.183825,-4.42e-4 -0.367567,0.0069 -0.55136,0.01181 0.04433,0.0052 0.08811,0.01555 0.132227,0.02281 l 0.12076,0.01987 c 0.03354,0.0055 0.06667,0.01567 0.100631,0.01656 0.01518,4.11e-4 0.02842,-0.01224 0.04357,-0.0135 0.01352,-9.27e-4 0.02684,0.0044 0.04025,0.0066 0.0067,0.0011 0.01362,0.0054 0.02014,0.0033 0.0092,-0.0027 0.01428,-0.01399 0.02342,-0.01682 0.0065,-0.0021 0.01342,0.0043 0.02012,0.0033 0.01499,-0.0022 0.02854,-0.01107 0.04357,-0.0135 0.0067,-9.79e-4 0.01338,0.0038 0.02011,0.0033 0.02141,-0.0018 0.04221,-0.0094 0.06369,-0.01019 0.02284,-9.27e-4 0.09287,0.01529 0.120758,0.01987 0.01342,0.0022 0.02687,0.0086 0.04025,0.0066 0.0095,-0.0015 0.01389,-0.01604 0.02342,-0.01682 0.02037,-0.0019 0.03998,0.01076 0.06038,0.0099 0.0152,-6.18e-4 0.02833,-0.01283 0.04354,-0.01335 0.02042,-8.24e-4 0.04024,0.01315 0.06038,0.0099 0.0067,-9.79e-4 -0.0022,-0.01633 0.0033,-0.02028 0.0064,-0.0046 0.06869,0.01689 0.08051,0.01325 0.0092,-0.0027 0.01777,-0.0089 0.0234,-0.01667 0.0095,0.0015 0.0143,-0.01394 0.02342,-0.01682 0.0086,-0.0027 0.0556,0.01333 0.06038,0.0099 0.0055,-0.0038 0.0022,-0.01347 0.0033,-0.02013 0.02905,-0.009 0.05809,-0.018 0.08713,-0.02701 z m -1.258852,0.04008 c -0.0096,-0.0013 -0.01909,-0.0035 -0.02877,-0.0037 -0.04921,-0.0023 -0.09833,0.003 -0.147504,0.0072 0.05875,-6.69e-4 0.117499,-0.0017 0.176255,-0.0033 z m -0.176255,0.0033 c -0.01942,4.59e-4 -0.03876,-1.14e-4 -0.05814,-1.4e-5 0.006,0.001 0.0119,0.0023 0.01788,0.0032 0.01335,-4.13e-4 0.02685,-0.0021 0.04026,-0.0032 z m -0.05814,-1.4e-5 c -0.05433,-0.0095 -0.108467,-0.02046 -0.163264,-0.02656 -0.296723,-0.03291 -0.106787,-0.0052 -0.372217,7.73e-4 -0.02743,7.21e-4 -0.02018,3.33e-4 -0.04207,4.9e-4 0.02078,8.24e-4 0.04149,0.0016 0.0622,0.0028 0.129714,0.0068 0.259155,0.02036 0.38903,0.02268 0.0421,7.22e-4 0.08423,-2.5e-5 0.126324,-1.97e-4 z m -0.577553,-0.02529 c -0.04451,-0.0021 -0.089,-0.0043 -0.133517,-0.0062 -0.06592,0.0052 -0.118948,0.01097 0.133517,0.0062 z m -0.133517,-0.0062 c 0.04335,-0.0034 0.0386,-0.0045 -0.04632,-0.0022 0.01549,4.61e-4 0.03089,0.0014 0.04632,0.0022 z m -0.04632,-0.0022 c -0.03557,-0.0017 -0.07117,-0.0031 -0.106739,-0.005 -0.06824,-0.0036 -0.136469,-0.0075 -0.204579,-0.013 l 0.100633,0.01656 c 0.02012,0.0033 0.04003,0.0092 0.06038,0.0099 0.02805,4.4e-4 0.0558,-0.0059 0.08382,-0.0069 0.04925,-0.0016 0.04105,-9.78e-4 0.06649,-0.0016 z m -0.311318,-0.01798 c -0.01342,-0.0022 -0.03804,-0.02004 -0.04025,-0.0066 -0.0022,0.01342 0.02673,0.0054 0.04025,0.0066 z m 2.390972,0.04225 c 0.0041,6.7e-4 -2.73e-4,0.0074 -0.003,0.01292 -1.82e-4,-0.0065 -0.0018,-0.01372 0.003,-0.01292 z m 1.572982,0.58882 c 0.01229,0.0036 0.02879,0.01137 -0.05939,0.01152 -0.02043,2.93e-4 -0.04025,-0.0066 -0.06038,-0.0099 -0.03354,-0.0055 -0.06678,-0.0136 -0.100634,-0.01656 -0.04794,-0.0037 -0.09613,-0.0027 -0.144198,-0.003 -0.339487,-0.0022 -0.191331,0.0026 -0.580109,0.0079 -0.08271,0.0011 -0.165562,-0.0041 -0.248145,5.09e-4 -0.950279,0.05285 0.2867,0.01419 -0.606859,0.04482 -0.07597,0.0026 -0.152007,0.0037 -0.228016,0.0038 -0.04807,7.6e-5 -0.09616,-0.0012 -0.1442,-0.003 l 0.08051,0.01325 c 0.03354,0.0055 0.06668,0.01515 0.100633,0.01656 0.06929,0.0027 0.138812,-0.01313 0.207893,-0.0071 0.05418,0.0047 0.106709,0.02336 0.161013,0.0265 0.07588,0.0044 0.152255,0.0024 0.228017,-0.0038 0.06428,-0.0052 0.127385,-0.02039 0.191077,-0.03057 0.02122,-0.0034 0.04219,-0.01013 0.06369,-0.01019 0.02043,-2.93e-4 0.03998,0.01076 0.06038,0.0099 0.03641,-0.0013 0.0943,-0.03926 0.130695,-0.0405 0.02042,-8.24e-4 0.04004,0.0092 0.06038,0.0099 0.02805,4.4e-4 0.05584,-0.0087 0.08382,-0.0069 0.08821,0.0056 0.173483,0.03669 0.261647,0.04306 0.02795,0.002 0.05582,-0.0084 0.08382,-0.0069 0.05432,0.0028 0.107343,0.01766 0.161014,0.0265 l 0.04025,0.0066 c 0.0067,0.0011 0.01362,0.0054 0.02011,0.0033 0.0092,-0.0027 0.01431,-0.01399 0.02343,-0.01682 0.0065,-0.0021 0.01362,0.0054 0.02012,0.0033 0.0092,-0.0027 0.01427,-0.01379 0.02343,-0.01666 0.0065,-0.0021 0.01345,0.0022 0.02012,0.0033 0.01427,0.0024 0.115139,0.02156 0.120761,0.01987 0.0092,-0.0027 0.01491,-0.01216 0.02327,-0.01685 0.02965,-0.01663 0.0603,-0.03142 0.09044,-0.04713 l 1.84e-4,-1.31e-4 c -0.105151,-0.0173 -0.0971,-0.01807 -0.08483,-0.01448 z m -2.209516,0.02687 c -0.0016,5.4e-5 -0.0023,6.7e-4 -0.0026,0.0022 -0.0011,0.0067 0.01345,0.0022 0.02014,0.0033 -0.005,-8.24e-4 -0.01326,-0.0058 -0.0175,-0.0055 z m 2.187719,2.51169 c 0.03805,0.0073 0.08929,0.02117 -0.06262,0.01152 -0.149518,-0.0095 -0.09217,-0.03731 -0.244833,-0.01962 -0.05771,0.0067 -0.113384,0.02603 -0.170948,0.03389 -0.03435,0.0047 -0.06999,-0.0035 -0.103946,0.0036 -0.202282,0.04186 -0.247282,0.05603 -0.240375,0.05927 -0.01064,8.75e-4 -0.0031,-1.98e-4 -0.01773,0.0018 -0.01152,0.0012 -0.09066,0.01175 -0.107258,0.0237 -0.0055,0.0038 -0.0073,0.01457 -0.0033,0.02013 0.004,0.0059 0.08546,0.0086 0.100633,0.01656 0.01349,0.0069 0.02269,0.02143 0.03694,0.02676 0.01908,0.0073 0.04026,0.0066 0.06038,0.0099 0.361791,0.05954 -0.171215,-0.02295 0.285085,0.02624 0.06757,0.0075 0.133288,0.0317 0.201266,0.03312 0.07751,0.0016 0.153923,-0.01962 0.231329,-0.02394 0.048,-0.0026 0.09638,0.008 0.144199,0.003 0.03025,-0.0031 0.05745,-0.02046 0.08713,-0.02701 0.0067,-0.0015 0.01342,0.0022 0.02012,0.0033 0.0078,-0.0056 0.01427,-0.01399 0.02342,-0.01682 0.0065,-0.0021 0.01464,0.0071 0.02012,0.0033 0.0055,-0.0038 -7.21e-4,-0.01463 0.0033,-0.02013 0.05386,-0.07437 -0.0069,0.04073 0.04688,-0.03363 0.004,-0.0055 -0.0022,-0.01613 0.0033,-0.02013 0.0055,-0.0038 0.01465,0.0071 0.02012,0.0033 0.0055,-0.0038 0.0088,-0.0162 0.0033,-0.02013 -0.02203,-0.01595 -0.05554,-0.0025 -0.08051,-0.01325 -0.03947,-0.01704 -0.07609,-0.04009 -0.114133,-0.06013 -0.204699,-0.03369 -0.179944,-0.03223 -0.141975,-0.02441 z m -3.973455,-0.342738 c -0.129361,0.05477 -0.268551,0.05933 -0.405437,0.07798 -0.0426,0.0058 -0.08492,0.01359 -0.127384,0.02039 -0.04247,0.0068 -0.0854,0.01111 -0.127387,0.02038 -0.02967,0.0066 -0.05731,0.02111 -0.08713,0.02701 -0.05478,0.01087 -0.09485,7.21e-4 -0.147512,0.01707 -0.0092,0.0027 -0.01566,0.0112 -0.02342,0.01682 -0.0078,0.0056 -0.02187,0.0074 -0.02343,0.01682 -0.0011,0.0067 0.01345,0.0022 0.02012,0.0033 l 0.04025,0.0066 0.161014,0.0265 0.140886,0.02319 0.04025,0.0066 c 0.01342,0.0022 0.02686,0.0086 0.04025,0.0066 0.019,-0.003 0.02936,-0.02571 0.04688,-0.03363 0.02769,-0.01251 0.05809,-0.01801 0.08713,-0.02701 0.02905,-0.009 0.05744,-0.02046 0.08713,-0.02701 0.02098,-0.0046 0.0427,-0.0056 0.06369,-0.01019 0.02967,-0.0066 0.0571,-0.02219 0.08713,-0.02701 0.0067,-9.79e-4 0.01342,0.0043 0.02012,0.0033 0.01499,-0.0022 0.02855,-0.01112 0.04357,-0.0135 0.0067,-9.79e-4 0.01461,0.0071 0.02012,0.0033 0.03125,-0.02242 -0.03022,-0.02565 0.02343,-0.01682 l 0.02011,0.0033 c 0.0067,0.0011 0.01468,0.0071 0.02014,0.0033 0.0055,-0.0038 -0.0022,-0.01613 0.0033,-0.02013 0.0055,-0.0038 0.01362,0.0054 0.02012,0.0033 0.0092,-0.0027 0.01412,-0.01402 0.02327,-0.01685 0.0065,-0.0021 0.01362,0.0054 0.02011,0.0033 0.0092,-0.0027 0.0143,-0.01394 0.02343,-0.01682 0.0065,-0.0021 0.01904,0.01002 0.02014,0.0033 0.0062,-0.03757 -0.06267,-0.02284 -0.07719,-0.03338 -0.01982,-0.01438 -0.03571,-0.0335 -0.0536,-0.05017 z m 1.524415,0.912385 c -0.09791,-0.01042 -0.194394,0.01066 -0.291709,0.014 -0.04133,0.0014 -0.08273,-4.06e-4 -0.124074,2.55e-4 -0.262922,0.0044 0.07417,-0.0011 -0.231328,0.02394 -0.15422,0.01268 -0.106098,-0.01955 -0.271584,0.01731 -0.02394,0.0053 -0.04422,0.02128 -0.06701,0.03032 -0.02828,0.01116 -0.05943,0.0145 -0.08713,0.02701 -0.0066,0.0031 -0.01531,0.01059 -0.02327,0.01685 0.01699,0.0031 0.03736,0.0072 0.04009,0.0066 0.01499,-0.0022 0.02855,-0.01107 0.04357,-0.0135 0.02767,-0.0044 0.05602,-0.0033 0.08382,-0.0069 0.04265,-0.0055 0.08453,-0.01689 0.127387,-0.02039 0.417638,-0.03427 -0.16607,0.02652 0.244832,0.01962 0.0366,-6.18e-4 0.07134,-0.01656 0.107256,-0.0237 0.0211,-0.0042 0.0427,-0.0056 0.06369,-0.01019 0.01486,-0.0033 0.02843,-0.01229 0.04357,-0.0135 0.01352,-9.27e-4 0.02686,0.0086 0.04025,0.0066 0.019,-0.003 0.0285,-0.02794 0.04688,-0.03363 0.0065,-0.0021 0.01362,0.0054 0.02011,0.0033 0.06643,-0.0206 -0.03419,-0.02202 0.067,-0.03032 0.01352,-9.27e-4 0.02687,0.0086 0.04026,0.0066 0.0095,-0.0015 0.01567,-0.01126 0.02346,-0.01682 0.03465,-0.0012 0.0693,-0.0024 0.103946,-0.0036 z m -1.096113,0.129679 c -0.0086,-0.0015 -0.02025,-0.0037 -0.0203,-0.0033 -0.0033,0.01998 0.0075,0.0133 0.0203,0.0033 z"
-         style="fill:#ffffff;fill-opacity:0.214286;stroke:none;stroke-width:0.0815893px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-      <path
-         id="path1284"
-         d="m 28.284634,-72.044083 c -0.0207,2.47e-4 -0.04136,8.4e-5 -0.06204,1.27e-4 -0.01401,0.0013 -0.0279,0.0034 -0.04191,0.0035 -0.02744,1.83e-4 -0.05485,-0.0054 -0.08216,-0.0032 -0.02896,0.0024 -0.05665,0.01339 -0.08547,0.01694 -0.08719,0.01076 -0.09235,0.0029 -0.176046,0.0021 -0.06277,-6.18e-4 -0.125051,0.01288 -0.187765,0.01045 -0.02037,-7.22e-4 -0.02778,-0.002 -0.0325,-0.0027 -0.0031,0.0011 -0.0057,0.0022 -0.01945,0.0044 l 0.02013,0.0033 c 0.0067,0.0011 0.01387,7.21e-4 0.02013,0.0033 0.0069,0.0032 0.01128,0.01094 0.01847,0.01338 0.0129,0.0042 0.02684,0.0044 0.04025,0.0066 l 0.04025,0.0066 c 0.01676,0.0028 0.03334,0.0076 0.05032,0.0083 0.0107,7.21e-4 0.02123,-0.0034 0.03185,-0.0051 0.01065,-0.0019 0.02122,-0.0034 0.03185,-0.0051 0.01065,-0.0019 0.02109,-0.0047 0.03185,-0.0051 0.0067,6.4e-5 0.01344,0.0022 0.02013,0.0033 0.01401,-0.0013 0.02799,-0.0018 0.04191,-0.0035 0.02135,-0.0025 0.04221,-0.0094 0.06369,-0.01019 0.01356,-3.78e-4 0.02687,0.0086 0.04025,0.0066 0.0048,-7.73e-4 0.007,-0.0076 0.01172,-0.0084 0.0067,-9.78e-4 0.01328,0.0022 0.01997,0.0033 0.0033,5.67e-4 0.007,0.0027 0.01022,0.0017 0.0045,-0.0013 0.0071,-0.007 0.01172,-0.0084 0.0033,-0.001 0.0067,0.0011 0.01007,0.0016 l 0.01007,0.0016 0.05032,0.0083 0.01007,0.0016 c 0.0033,5.67e-4 0.0068,0.0027 0.01007,0.0016 0.04984,-0.01545 -0.04336,-0.0029 0.0335,-0.01516 0.0041,-3.73e-4 0.02839,0.0062 0.03019,0.0049 0.0028,-0.0022 -8.2e-5,-0.0071 0.0016,-0.01007 0.0079,-0.01301 0.01785,-0.02463 0.02675,-0.03695 z m -0.66791,0.02719 c 0.0098,-0.0036 -0.01282,-0.0023 0,0 z m -1.514818,0.109698 c -0.0047,-7.72e-4 -0.0071,0.007 -0.01172,0.0084 -0.0033,0.001 -0.0067,-0.0011 -0.01007,-0.0016 l -0.01006,-0.0016 -0.03396,-0.0056 c 0.01403,0.006 0.02654,0.02066 0.04071,0.02738 0.0087,0.004 0.01594,0.0016 0.02179,-0.0068 0.002,-0.0028 0.0011,-0.0067 0.0016,-0.01007 5.67e-4,-0.0036 0.005,-0.0095 0.0016,-0.01007 z m -0.06581,-4.93e-4 c -0.0052,-0.0024 -0.01057,-0.0038 -0.01635,-0.0027 z m -0.01635,-0.0027 c -0.0207,2.48e-4 -0.04144,-0.0021 -0.06204,1.28e-4 -0.06439,0.0066 -0.04756,0.02047 -0.117321,0.02204 -0.119653,0.0027 -0.0851,-0.01192 -0.202923,-0.02306 -0.619402,-0.03252 0.2304,0.01892 -0.355528,-0.03784 -0.04452,-0.0042 -0.08955,0.002 -0.134136,-0.0014 -0.05088,-0.0037 -0.100635,-0.01656 -0.15095,-0.02485 l -0.05032,-0.0083 c -0.01007,-0.0016 -0.02043,-0.0081 -0.03019,-0.0049 -0.0045,0.0013 0.0045,0.0089 0.0084,0.01172 0.0028,0.002 0.0067,0.0011 0.01006,0.0016 l 0.01007,0.0016 c 0.02361,0.0039 -0.0043,-0.0033 0.01847,0.01338 0.0028,0.002 0.0067,0.0011 0.01007,0.0016 l 0.05032,0.0083 c 0.103627,0.01706 -0.04508,-0.01055 0.05872,0.02 0.01631,0.0048 0.03354,0.0055 0.05032,0.0083 l 0.05032,0.0083 0.130823,0.02153 c 0.02012,0.0033 0.04,0.0087 0.06038,0.0099 0.02896,0.01145 0.05579,-0.0075 0.08382,-0.0069 0.01363,1.56e-4 0.02684,0.0044 0.04025,0.0066 l 0.05032,0.0083 c 0.01342,0.0022 0.02669,0.007 0.04025,0.0066 0.02148,-6.18e-4 0.0422,-0.0099 0.06369,-0.01019 0.02895,-4.56e-4 0.05241,0.01176 0.08051,0.01325 0.02063,0.0013 0.04137,-9.28e-4 0.06204,-1.27e-4 0.01925,5.66e-4 0.05359,0.013 0.07044,0.01159 0.0047,-2.63e-4 0.007,-0.0076 0.01172,-0.0084 0.0067,-9.79e-4 0.0134,0.0038 0.02013,0.0033 0.0076,-8.24e-4 0.01421,-0.0061 0.02178,-0.0068 0.0068,-4.52e-4 0.01344,0.0022 0.02013,0.0033 0.01401,-0.0013 0.02799,-0.0018 0.04191,-0.0035 0.01069,-0.0014 0.02491,0.003 0.03185,-0.0051 0.0088,-0.01035 -0.0068,-0.03813 0.0066,-0.04026 z m 2.25022,0.897464 c -0.07727,0.0063 -0.0066,-0.0026 -0.08548,0.01694 -0.02254,0.0056 -0.05598,0.0047 -0.07541,0.0186 -0.01237,0.0089 -0.01367,0.02923 -0.02675,0.03695 -0.01207,0.0071 -0.02825,5.67e-4 -0.04191,0.0035 -0.02228,0.0049 -0.04382,0.01273 -0.06535,0.02026 -0.0187,0.0065 -0.03686,0.01461 -0.05529,0.02191 -0.03686,0.01461 -0.07398,0.02855 -0.11057,0.04381 -0.01131,0.0047 -0.0214,0.01323 -0.0335,0.01516 -0.02041,0.0032 -0.04137,-6.18e-4 -0.06204,1.28e-4 -0.01399,3.07e-4 -0.02799,0.0018 -0.04191,0.0035 -0.01058,0.0014 -0.02088,0.0045 -0.03151,0.005 0.01506,0.002 0.03912,0.0085 0.04997,0.0084 0.02148,-6.18e-4 0.04234,-0.0078 0.06369,-0.01019 0.01401,-0.0013 0.02794,-0.0023 0.04191,-0.0035 0.0073,-0.0025 0.01431,-0.0056 0.02179,-0.0068 0.01387,-0.0024 0.02808,-0.0012 0.04191,-0.0035 0.0075,-0.0014 0.01418,-0.0061 0.02179,-0.0068 0.0068,-4.53e-4 0.01343,0.0022 0.02013,0.0033 0.0073,-0.0025 0.01431,-0.0056 0.02179,-0.0068 0.0033,-4.89e-4 0.0068,0.0027 0.01007,0.0016 0.0045,-0.0013 0.0071,-0.007 0.01172,-0.0084 0.0033,-0.001 0.0067,0.0022 0.01007,0.0016 0.0075,-0.0014 0.01431,-0.0056 0.02178,-0.0068 0.0033,-4.97e-4 0.0067,0.0022 0.01006,0.0016 0.0075,-0.0014 0.01486,-0.0036 0.02179,-0.0068 0.0044,-0.0019 0.007,-0.0077 0.01171,-0.0084 0.0067,-9.79e-4 0.01344,0.0043 0.02013,0.0033 0.0048,-7.73e-4 0.007,-0.0076 0.01171,-0.0084 0.0067,-9.79e-4 0.01344,0.0043 0.02013,0.0033 0.0048,-7.73e-4 0.007,-0.0076 0.01172,-0.0084 0.0067,-9.79e-4 0.01343,0.0043 0.02013,0.0033 0.0048,-7.72e-4 0.0074,-0.0062 0.01171,-0.0084 0.01087,-0.0057 0.02181,-0.01155 0.0335,-0.01516 0.0033,-0.001 0.0067,0.0011 0.01007,0.0016 0.0073,-0.0025 0.01483,-0.0036 0.02179,-0.0068 0.02042,-0.0092 0.003,-0.01271 0.0335,-0.01516 0.0068,-4.53e-4 0.01337,0.0038 0.02012,0.0033 0.0076,-8.24e-4 0.01421,-0.0061 0.02179,-0.0068 0.01655,-0.0014 0.03918,0.0159 0.05197,-0.0018 0.0125,-0.01726 -0.01037,-0.0022 -0.01682,-0.02344 -10e-4,-0.0033 0.0011,-0.0067 0.0016,-0.01007 -0.0079,-0.01508 -0.0157,-0.03015 -0.02356,-0.04523 z m -0.629704,0.185609 c -0.0033,-4.14e-4 -0.0085,-0.0017 -0.01041,-0.0015 0.0033,8.76e-4 0.0067,0.0016 0.01007,0.0016 8.5e-5,-1.2e-5 1.83e-4,-1.11e-4 3.61e-4,-1.08e-4 z m -0.01041,-0.0015 c -0.0033,-8.76e-4 -0.0067,-0.0022 -0.01007,-0.0016 -0.03935,0.0063 0.01059,0.01208 -0.02178,0.0068 0.0067,0.0011 0.01343,0.0043 0.02013,0.0033 0.0048,-7.73e-4 0.007,-0.0076 0.01172,-0.0084 z m -0.03185,0.0051 c -0.0034,-5.67e-4 -0.0095,-0.0052 -0.01007,-0.0016 -5.67e-4,0.0036 0.0067,0.0011 0.01007,0.0016 z m -2.466014,-0.653911 c -0.03077,-0.0014 -0.06148,-0.0032 -0.09223,-0.0048 -0.03465,0.0012 -0.0693,0.0047 -0.103946,0.0036 -0.0443,-0.0015 -0.08818,-0.0098 -0.132479,-0.01147 -0.18635,-0.0072 -0.04347,0.01671 -0.246489,-0.0096 -0.05398,-0.0068 -0.106843,-0.02176 -0.161013,-0.0265 -0.03125,-0.0025 -0.06255,0.0045 -0.09388,0.0052 -0.02406,7.21e-4 -0.04814,3.79e-4 -0.0721,-0.0015 -0.02892,-0.0022 -0.03851,-0.0037 -0.05011,-0.0056 -0.0011,0.0019 -0.0044,0.0035 -0.01193,0.0058 -0.0033,0.001 -0.0073,-0.0038 -0.01006,-0.0016 -0.0028,0.0022 -0.0044,0.008 -0.0016,0.01007 0.0083,0.0061 0.02012,0.0033 0.03019,0.0049 l 0.06038,0.0099 0.09057,0.01491 c 0.02011,0.0033 0.03999,0.0087 0.06038,0.0099 0.02066,0.0013 0.04142,-0.0018 0.06204,-1.27e-4 0.04763,0.0037 0.09307,0.02064 0.140886,0.02319 0.15874,0.0083 0.04794,-0.0131 0.176045,-0.0021 0.05152,0.0043 0.06676,0.0063 0.07639,0.0079 0.0115,-1.95e-4 0.0099,-4.66e-4 0.03599,1.29e-4 0.01363,1.55e-4 0.02687,0.0086 0.04025,0.0066 0.0048,-7.73e-4 0.0071,-0.007 0.01172,-0.0084 0.0069,-0.002 0.04328,0.01026 0.05032,0.0083 0.0046,-0.0013 0.0071,-0.007 0.01171,-0.0084 0.0065,-0.0021 0.01463,0.0071 0.02013,0.0033 0.02424,-0.01742 -0.03199,-0.0042 0.01338,-0.01847 0.0033,-10e-4 0.0068,0.0027 0.01007,0.0016 0.0045,-0.0013 0.0071,-0.007 0.01172,-0.0084 0.0033,-10e-4 0.0073,0.0038 0.01007,0.0016 0.0028,-0.0022 -0.0012,-0.0081 0.0016,-0.01007 0.0011,-8.75e-4 0.01591,0.0037 0.02013,0.0033 0.01399,-3.07e-4 0.02794,-0.0023 0.04191,-0.0035 z m -0.279045,0.03224 c -0.06189,-6e-6 0.0301,0.0049 0,0 z m -0.673189,-0.08302 c 0.0055,-0.008 -0.04449,-0.0063 0,0 z m 3.003519,0.398544 -2.6e-5,1.58e-4 c -0.04444,0.01378 -0.07391,0.0249 -0.118978,0.0321 -0.02442,0.0039 -0.04917,0.0057 -0.07376,0.0085 -0.02459,0.0028 -0.04907,0.0068 -0.07376,0.0085 -0.04856,0.0035 -0.09724,0.0047 -0.145856,0.007 -0.04862,0.0023 -0.09721,0.0086 -0.145855,0.007 -0.145896,-0.0049 -0.04131,-0.03019 -0.134136,-0.0014 -0.0073,0.0025 -0.01431,0.0056 -0.02179,0.0068 l 0.322025,0.053 c 0.05702,0.0094 0.113479,0.02337 0.171077,0.02815 0.0279,0.0025 0.0558,-0.0063 0.08382,-0.0069 0.02055,-2.73e-4 0.116801,0.0066 0.144199,0.003 0.0211,-0.0027 0.0439,-0.01554 0.06535,-0.02026 0.01052,-0.0024 0.02137,-0.0027 0.03185,-0.0051 0.0074,-0.0014 0.01418,-0.0065 0.02179,-0.0068 0.05723,0.0094 0.0059,0.0057 0.05197,-0.0018 0.0067,-9.78e-4 0.01463,0.0071 0.02012,0.0033 0.0028,-0.0022 -0.0012,-0.0081 0.0016,-0.01007 0.0028,-0.0022 0.0095,0.0052 0.01007,0.0016 7.72e-4,-0.0046 -0.007,-0.0073 -0.0084,-0.01187 -10e-4,-0.0033 0.0041,-0.0078 0.0016,-0.01007 -0.04327,-0.04038 -0.01237,5.67e-4 -0.04866,-0.01834 -0.0043,-0.0023 -0.0045,-0.0089 -0.0084,-0.01172 -0.0055,-0.004 -0.01464,7.21e-4 -0.02013,-0.0033 -0.0039,-0.0027 -0.0045,-0.0089 -0.0084,-0.01172 -0.0028,-0.002 -0.05615,-0.0092 -0.06038,-0.0099 -0.0067,-0.0011 -0.01363,-0.0054 -0.02013,-0.0033 -0.0033,10e-4 0.0011,0.01209 -0.0016,0.01007 -0.01376,-0.01 -0.02353,-0.02455 -0.03528,-0.03682 z m -2.219443,0.23437 c -0.01403,-2.2e-4 -0.02791,0.0027 -0.04191,0.0035 -0.01898,0.001 -0.09866,0.0035 -0.11401,0.0019 -0.03381,-0.0035 -0.06664,-0.01661 -0.100633,-0.01656 -0.02902,-7.7e-5 -0.05698,0.0113 -0.08547,0.01694 -0.038,6.18e-4 -0.07605,0.0039 -0.114009,0.0019 -0.02375,-0.0013 -0.04666,-0.01029 -0.07044,-0.01159 -0.0352,0.0056 -0.02125,0.0068 -0.04191,0.0035 l 0.201265,0.03312 0.05032,0.0083 c 0.01342,0.0022 0.02668,0.006 0.04025,0.0066 0.01406,2.25e-4 0.02789,-0.0038 0.04191,-0.0035 0.0102,1.12e-4 0.02002,0.0048 0.03019,0.0049 0.0108,-3.11e-4 0.02118,-0.0039 0.03185,-0.0051 0.01388,-0.0014 0.02815,-6.7e-4 0.04191,-0.0035 0.01491,-0.0029 0.02843,-0.01229 0.04357,-0.0135 0.01352,-9.27e-4 0.02663,0.0065 0.04025,0.0066 0.01075,2.02e-4 0.02109,-0.0047 0.03185,-0.0051 0.0037,8.6e-5 0.03544,0.0079 0.04025,0.0066 0.0045,-0.0013 0.0071,-0.007 0.01172,-0.0084 0.0033,-0.001 0.0068,0.0022 0.01006,0.0016 0.01486,-0.0033 0.02905,-0.0091 0.04357,-0.0135 -0.0303,-2.88e-4 -0.06032,-0.01411 -0.09057,-0.01491 z m 1.897653,0.653233 -2.7e-5,1.63e-4 c -0.04207,0.0035 -0.137432,0.012 -0.177702,0.0121 -0.03081,1.51e-4 -0.06143,-0.0065 -0.09223,-0.0048 -0.03546,0.0016 -0.07012,0.01273 -0.105603,0.01363 -0.03753,9.28e-4 -0.07486,-0.0061 -0.112352,-0.0082 -3.42e-4,-1e-5 -0.348693,-0.01604 -0.348778,-0.01605 -0.04737,-0.0047 -0.09336,-0.02069 -0.140887,-0.02319 -0.07483,-0.004 -0.21117,0.02062 -0.283302,0.02573 -0.103731,0.0074 -0.03887,-0.0054 -0.132479,-0.01147 -0.03797,-0.0026 -0.03346,-0.0029 -0.05363,0.01185 -0.0022,0.0018 -0.01955,0.0098 -0.01338,0.01847 0.002,0.0029 0.0067,0.0011 0.01007,0.0016 l 0.05032,0.0083 0.140886,0.02319 c 0.02684,0.0044 0.05347,0.01036 0.08051,0.01325 0.02732,0.0024 0.05479,0.0019 0.08216,0.0032 0.03074,0.0014 0.06149,0.0032 0.09223,0.0048 0.03354,0.0055 0.06672,0.01411 0.100633,0.01656 0.04462,0.0031 0.08957,-0.0022 0.134136,0.0014 0.03727,0.003 0.07351,0.01419 0.110697,0.01822 0.181167,0.02057 0.01466,-1.98e-4 0.155918,-0.0054 0.01356,-3.78e-4 0.02663,0.0065 0.04025,0.0066 0.01075,2.03e-4 0.0211,-0.0047 0.03185,-0.0051 0.0067,6.5e-5 0.01337,0.0038 0.02013,0.0033 0.05059,-0.0042 1.94e-4,-0.0047 0.0335,-0.01516 0.0033,-0.001 0.0068,0.0027 0.01007,0.0016 0.0045,-0.0013 0.0071,-0.007 0.01172,-0.0084 0.0061,-0.0016 0.04145,0.0094 0.05032,0.0083 0.0075,-0.0014 0.01421,-0.0061 0.02179,-0.0068 0.01352,-9.27e-4 0.02666,0.007 0.04025,0.0066 0.01074,-3.21e-4 0.02114,-0.0042 0.03185,-0.0051 0.0099,-9.78e-4 0.02031,0.006 0.03019,0.0049 0.01513,-0.0012 0.02854,-0.01107 0.04357,-0.01351 0.01961,-0.0031 0.0023,0.01614 0.03185,-0.0051 0.0028,-0.0022 -0.0012,-0.0081 0.0016,-0.01007 0.0028,-0.0022 0.0073,0.0038 0.01007,0.0016 0.0028,-0.0022 -0.0012,-0.0081 0.0016,-0.01007 0.0055,-0.0038 0.01363,0.0054 0.02013,0.0033 0.0045,-0.0013 0.0071,-0.007 0.01172,-0.0084 0.0065,-0.0021 0.01463,0.0071 0.02013,0.0033 0.0028,-0.0022 -0.0011,-0.0082 0.0017,-0.01022 0.0059,-0.0043 0.02434,0.0092 0.03019,0.0049 0.0028,-0.0022 -0.0012,-0.0081 0.0016,-0.01007 0.0028,-0.0022 0.0067,0.0011 0.01007,0.0016 0.01382,0.0023 0.03171,0.01065 0.04191,-0.0035 0.002,-0.0028 0.0027,-0.0068 0.0016,-0.01007 -0.01677,-0.0075 -0.03134,-0.01894 -0.04701,-0.02841 z m 0.04701,0.02841 c 0.0044,0.0018 -0.0045,-0.01452 -0.0084,-0.01172 -0.0039,0.003 0.007,0.0072 0.0084,0.01172 z m -2.133319,-0.288924 c -0.01735,8.24e-4 -0.03469,0.003 -0.05197,0.0018 -0.09397,-0.0068 -0.0312,-0.01933 -0.142542,-0.01312 -0.08755,0.0048 -0.09766,0.0105 -0.105023,0.01404 0.01554,0.0031 0.03249,0.0074 0.03967,0.0062 0.0048,-7.73e-4 0.007,-0.0076 0.01172,-0.0084 0.0067,-9.79e-4 0.01338,0.0032 0.02013,0.0033 0.01074,-3.21e-4 0.02108,-0.005 0.03185,-0.0051 0.01017,1.07e-4 0.06482,0.01328 0.07044,0.01159 0.0045,-0.0013 0.0071,-0.007 0.01172,-0.0084 0.0033,-0.001 0.05615,0.0092 0.06038,0.0099 0.0033,5.66e-4 0.0068,0.0022 0.01007,0.0016 0.01486,-0.0033 0.02905,-0.0091 0.04357,-0.0135 z m -0.299539,0.0027 c -0.0078,-0.0016 -0.01631,-0.0037 -0.0207,-0.0037 -0.01074,3.2e-4 -0.02109,0.0047 -0.03185,0.0051 -0.01356,3.78e-4 -0.02683,-0.0044 -0.04025,-0.0066 l -0.100633,-0.01656 -0.04025,-0.0066 c -0.01007,-0.0016 -0.02,-0.0054 -0.03019,-0.0049 -0.0076,3.17e-4 -0.01421,0.0061 -0.02178,0.0068 -0.0067,4.58e-4 -0.01343,-0.0022 -0.02013,-0.0033 -0.0033,-5.66e-4 -0.0068,-0.0027 -0.01007,-0.0016 -0.0041,0.0014 -0.0066,0.0053 -0.01025,0.0073 0.0159,0.0016 0.03063,0.0035 0.171266,0.01915 0.141845,0.01071 0.145391,0.0097 0.154841,0.0051 z m -0.326107,-0.02428 c -0.0021,-1.67e-4 -0.01991,-0.0022 -0.02171,-0.0025 0.0034,7.72e-4 0.0068,0.0011 0.01022,0.0017 0.0033,5.66e-4 0.0068,0.0027 0.01006,0.0016 6.18e-4,-1.72e-4 9.79e-4,-8.76e-4 0.0014,-8.24e-4 z m -0.02171,-0.0025 c -0.0033,-7.22e-4 -0.0066,-0.0016 -0.0099,-0.0016 -0.0024,1.24e-4 -0.0048,7.73e-4 -0.0073,8.76e-4 0.0016,5.4e-5 0.01565,4.87e-4 0.01716,7.21e-4 z m -0.01716,-7.22e-4 c -0.01521,-4.14e-4 -0.0263,3.71e-4 -0.157072,-0.0073 -0.07159,-0.0042 -0.143366,-0.0067 -0.214642,-0.01465 -0.09799,-0.01085 -0.193781,-0.03779 -0.291836,-0.04803 -0.06557,0.0023 -0.03487,0.0046 -0.09223,-0.0048 l 0.241519,0.03975 0.08051,0.01325 c 0.03018,0.0049 0.06004,0.01301 0.09057,0.01491 0.03461,0.0021 0.06934,-0.0056 0.103946,-0.0036 0.153284,0.0089 0.02804,0.02304 0.172733,0.01809 0.02226,-5.14e-4 0.04429,-0.0056 0.0665,-0.0076 z m 4.183524,0.686431 c -0.02804,8.3e-5 -0.05579,0.0068 -0.08382,0.0069 -0.02744,1.83e-4 -0.05499,-0.007 -0.08216,-0.0032 -0.01963,0.0027 -0.03571,0.01877 -0.05529,0.02191 -0.02376,0.0038 -0.04813,-0.0027 -0.0721,-0.0015 -0.0387,0.0022 -0.07692,0.01063 -0.115665,0.01198 -0.203116,-0.01067 0.01524,-0.0068 -0.177702,0.0121 -0.02391,0.0023 -0.04836,-0.0053 -0.0721,-0.0015 -0.01959,0.0031 -0.03636,0.01605 -0.05529,0.02191 -0.0202,0.0185 -0.04186,-0.0043 -0.06204,1.27e-4 -0.0094,0.0021 -0.0147,0.01288 -0.02344,0.01681 -0.0031,0.0016 -0.0067,-0.0022 -0.01006,-0.0016 -0.04682,0.0075 -0.0108,-7.21e-4 -0.02344,0.01682 -0.01654,0.0228 -0.0095,-0.0052 -0.01337,0.01847 -5.67e-4,0.0036 -0.0044,0.008 -0.0016,0.01007 0.0055,0.004 0.01344,0.0022 0.02013,0.0033 l 0.06038,0.0099 c 0.0067,0.0011 0.01372,0.0012 0.02013,0.0033 0.01007,0.0038 0.01822,0.01198 0.02853,0.01503 0.01631,0.0048 0.03354,0.0055 0.05032,0.0083 l 0.05032,0.0083 c 0.01676,0.0028 0.03335,0.0071 0.05032,0.0083 0.02398,0.0019 0.04808,0.0023 0.0721,0.0015 0.028,-9.28e-4 0.05579,-0.0059 0.08382,-0.0069 0.024,-7.72e-4 0.04815,-5.15e-4 0.0721,0.0015 0.02033,0.0018 0.04025,0.0066 0.06038,0.0099 0.01676,0.0028 0.0333,0.0081 0.05032,0.0083 0.0076,2.05e-4 0.01421,-0.0061 0.02179,-0.0068 0.0068,-4.52e-4 0.01364,0.0054 0.02013,0.0033 0.0033,-0.001 0.0011,-0.0067 0.0016,-0.01007 0.0023,-0.01372 8.3e-5,-0.02175 0.01503,-0.02854 0.0069,-0.003 0.01486,-0.0036 0.02178,-0.0068 0.0044,-0.0019 0.0071,-0.0071 0.01175,-0.0086 0.0033,-0.001 0.0068,0.0027 0.01007,0.0016 0.0045,-0.0013 0.0071,-0.007 0.01172,-0.0084 0.0033,-0.001 0.0068,0.0027 0.01007,0.0016 0.0045,-0.0013 0.0071,-0.007 0.01172,-0.0084 0.02684,-0.0083 -0.0139,0.02773 0.03185,-0.0051 0.0062,-0.0044 0.0072,-0.01401 0.01337,-0.01847 0.02757,-0.01979 0.016,0.0063 0.04357,-0.0135 0.0028,-0.0022 -0.0012,-0.0081 0.0016,-0.01007 0.0028,-0.0022 0.0073,0.0038 0.01007,0.0016 0.0028,-0.0022 -3.62e-4,-0.0073 0.0016,-0.01007 0.0028,-0.0037 0.0089,-0.0045 0.01172,-0.0084 0.01242,-0.01717 -0.02295,-0.01098 -0.02853,-0.01503 -0.0028,-0.002 0.0011,-0.0067 0.0016,-0.01007 z m -3.161407,-0.44795 c -0.03706,0.0072 -0.06592,-5.12e-4 -0.102289,-0.0065 -0.01342,-0.0022 -0.02673,-0.0075 -0.04025,-0.0066 -0.02895,0.0023 -0.05653,0.01456 -0.08548,0.01694 -0.01352,9.28e-4 -0.02668,-0.006 -0.04025,-0.0066 -0.01735,-7.72e-4 -0.03468,0.0029 -0.05197,0.0018 -0.01695,-0.0012 -0.03354,-0.0055 -0.05032,-0.0083 -0.01007,-0.0016 -0.02002,-0.0048 -0.03019,-0.0049 -0.02936,-1.33e-4 -0.02864,0.0063 -0.05363,0.01185 -0.05165,0.01139 -0.01337,-0.0011 -0.07376,0.0085 -0.0075,0.0014 -0.01421,0.0061 -0.02179,0.0068 -0.0068,4.52e-4 -0.0134,-0.0038 -0.02013,-0.0033 -0.01004,9.78e-4 -0.03854,0.01433 -0.04523,0.02357 0.0028,-0.0022 0.0067,0.0022 0.01006,0.0016 0.0075,-0.0014 0.01421,-0.0065 0.02178,-0.0068 0.01019,-4.11e-4 0.02012,0.0033 0.03019,0.0049 0.03354,0.0055 0.06676,0.0136 0.100633,0.01656 0.02732,0.0024 0.0549,4.21e-4 0.08216,0.0032 0.02703,0.0029 0.05341,0.01088 0.08051,0.01325 0.01721,0.0018 0.03468,-0.0029 0.05197,-0.0018 0.07403,0.0047 0.02928,0.01677 0.112353,0.0082 0.01819,-0.0017 0.03567,-0.0083 0.05363,-0.01185 0.0105,-0.0019 0.02122,-0.0034 0.03185,-0.0051 0.08728,-0.01394 -0.02179,6.8e-5 0.06204,-1.27e-4 0.02152,-1.13e-4 0.04221,-0.0094 0.06369,-0.01019 0.0067,6.5e-5 0.01344,0.0022 0.02013,0.0033 0.0073,-0.0025 0.01431,-0.0056 0.02179,-0.0068 l -0.06038,-0.0099 c -0.0067,-0.0011 -0.01404,-2.23e-4 -0.02013,-0.0033 -0.01654,-0.0079 -0.03133,-0.01899 -0.04701,-0.02841 z m -0.615266,0.03311 c -0.0028,0.0022 -0.005,0.0095 -0.0016,0.01007 0.0033,5.66e-4 -3.71e-4,-0.0073 0.0016,-0.01007 z m 0.754495,1.48e-4 c -0.0028,0.0022 0.0012,0.008 -0.0016,0.01007 l 0.01007,0.0016 c 0.0067,0.0011 0.01364,0.0054 0.02013,0.0033 0.0033,-0.001 0.0011,-0.0067 0.0016,-0.01007 l -0.02013,-0.0033 c -0.0034,-5.67e-4 -0.0072,-0.0038 -0.01007,-0.0016 z m -2.676629,0.229378 c -0.0124,-0.0031 -0.02485,-0.0052 -0.03744,-0.0041 -0.01514,6.18e-4 -0.02847,0.01176 -0.04357,0.0135 -0.0101,9.28e-4 -0.02001,-0.0043 -0.03019,-0.0049 -0.0206,-0.0013 -0.04139,0.0012 -0.06204,1.27e-4 l 0.06038,0.0099 0.07044,0.01159 c 0.0067,0.0011 0.0134,0.0038 0.02013,0.0033 0.0076,-8.24e-4 0.01421,-0.0061 0.02179,-0.0068 0.01431,-0.0013 0.04753,0.012 0.06038,0.0099 0.0015,-2.74e-4 0.0025,-0.0017 0.0037,-0.0025 -0.02105,-0.01229 -0.04206,-0.0241 -0.06356,-0.02983 z m 0.06356,0.02983 c 0.06354,0.03719 0.125354,0.08722 0.186542,0.05587 -0.0109,-0.0021 -0.02174,-0.0046 -0.0327,-0.0064 -0.0037,-7.22e-4 -0.01983,-0.0031 -0.01997,-0.0033 -0.002,-0.0029 0.0037,-0.0072 0.0016,-0.01007 -0.002,-0.0029 -0.0082,0.0012 -0.01022,-0.0017 -0.002,-0.0029 0.0027,-0.0068 0.0016,-0.01007 -0.0061,-0.01986 -0.0065,-0.0071 -0.01831,-0.01335 -0.0067,-0.0037 -0.01175,-0.0098 -0.01847,-0.01338 -0.006,-0.0031 -0.01344,-0.0022 -0.02013,-0.0033 -0.0034,-5.66e-4 -0.03447,-0.0078 -0.04025,-0.0066 -0.0075,0.0014 -0.01486,0.0036 -0.02179,0.0068 -0.003,0.0016 -0.0055,0.0038 -0.0081,0.0058 z m -0.307219,-0.03699 c -0.0028,0.0022 -0.005,0.0095 -0.0016,0.01007 0.0075,0.0012 0.0143,-0.0055 0.02179,-0.0068 -0.0033,-6.18e-4 -0.007,-0.0011 -0.01007,-0.0016 -0.0033,-5.66e-4 -0.0073,-0.0038 -0.01007,-0.0016 z m 1.667693,0.552079 c -0.02855,-0.001 -0.05705,0.01034 -0.08547,0.0081 -0.02708,-0.0024 -0.0534,-0.01088 -0.08051,-0.01325 -0.02061,-0.0018 -0.04146,0.0022 -0.06204,1.27e-4 -0.03382,-0.0035 -0.0668,-0.01308 -0.100633,-0.01656 -0.130021,-0.0144 -0.05374,-0.0032 -0.177701,0.0121 -0.03111,0.0039 -0.06268,0.0023 -0.09388,0.0052 -0.261214,0.02468 0.02361,-2.91e-4 -0.181014,0.03223 -0.0171,0.0027 -0.03469,3.47e-4 -0.05197,0.0018 -0.07198,0.0059 -0.01845,-0.0056 -0.0335,0.01516 -0.0028,0.0037 -0.01451,0.0045 -0.01172,0.0084 0.004,0.0054 0.01344,0.0022 0.02013,0.0033 l 0.15095,0.02484 0.100633,0.01656 c 0.01342,0.0022 0.02668,0.006 0.04025,0.0066 0.01734,7.73e-4 0.03469,-0.003 0.05197,-0.0018 0.02039,0.0013 0.03997,0.01076 0.06038,0.0099 0.0152,-6.19e-4 0.02842,-0.01224 0.04357,-0.0135 0.01352,-9.27e-4 0.02668,0.006 0.04025,0.0066 0.02803,9.79e-4 0.0558,-0.0075 0.08382,-0.0069 0.0102,1.12e-4 0.02,0.0054 0.03019,0.0049 0.0076,-3.13e-4 0.01421,-0.0061 0.02178,-0.0068 0.0068,-4.53e-4 0.01344,0.0022 0.02013,0.0033 l 0.06038,0.0099 c 0.01007,0.0016 0.02002,0.0048 0.03019,0.0049 0.0108,-3.11e-4 0.0211,-0.0047 0.03185,-0.0051 0.01356,-3.79e-4 0.02687,0.0086 0.04025,0.0066 0.0048,-7.72e-4 0.0071,-0.007 0.01171,-0.0084 0.0033,-10e-4 0.0073,0.0038 0.01007,0.0016 0.0072,-0.0052 0.01293,-0.02492 0.0251,-0.02688 0.01127,-0.0018 0.01377,-0.0014 0.01709,-8.24e-4 0.0021,-0.0028 0.005,-0.0063 0.01642,-0.01443 0.0028,-0.0022 0.0073,0.0038 0.01007,0.0016 0.0028,-0.0022 0.0037,-0.0073 0.0016,-0.01007 -0.0044,-0.0062 -0.01686,-0.0059 -0.01847,-0.01338 -0.0029,-0.01328 0.0044,-0.02684 0.0066,-0.04026 -0.0095,-0.0042 -0.01903,-0.0057 -0.02852,-0.0063 z m 0.01225,0.0826 c -0.0067,0.009 0.01133,0.0015 0,0 z m -1.474728,-0.311509 c -0.01734,-7.73e-4 -0.03466,0.0027 -0.05197,0.0018 -0.01358,-6.7e-4 -0.02673,-0.0054 -0.04025,-0.0066 -0.123678,-0.0079 -0.0036,0.0025 -0.115666,0.01198 -0.0201,-0.0033 -0.02887,-0.0053 -0.03537,-0.0069 0.0063,0.0021 0.01184,0.0061 0.0035,0.01206 0.01014,0.0013 0.02047,0.0018 0.03019,0.0049 0.06187,0.01947 0.03958,0.02009 0.107383,0.03835 0.01319,0.0032 0.02684,0.0044 0.04025,0.0066 l 0.12076,0.01987 0.08051,0.01325 0.02013,0.0033 c 0.0067,0.0011 0.01343,0.0043 0.02013,0.0033 0.03935,-0.0063 -0.01059,-0.01208 0.02178,-0.0068 0.0279,0.0046 -0.01631,-0.0011 0.03185,-0.0051 -0.0028,-0.0041 -0.004,-0.0098 -0.0084,-0.01172 -0.0093,-0.0042 -0.02067,-0.0013 -0.03019,-0.0049 -0.01419,-0.0055 -0.02269,-0.02143 -0.03694,-0.02675 -0.0095,-0.0037 -0.02084,-8.24e-4 -0.03019,-0.0049 -0.0044,-0.0018 -0.0056,-0.0078 -0.0084,-0.01172 -0.01283,-0.0058 -0.02507,-0.01305 -0.0386,-0.01669 l -0.04025,-0.0066 c -0.01338,-0.0027 -0.02667,-0.006 -0.04025,-0.0066 z m -0.243244,1.68e-4 c -0.0076,-0.0028 -0.01303,-0.0032 0,0 z m 1.837077,0.726916 c 0.0062,0.0015 0.01443,0.0055 -0.0297,0.0058 -0.01017,-1.07e-4 -0.02001,-0.0043 -0.03019,-0.0049 -0.04398,-0.0025 -0.09012,9.27e-4 -0.134135,-0.0014 -0.24114,-0.01264 0.01995,-0.01624 -0.23133,0.02394 -0.04479,0.0071 -0.09055,0.0053 -0.135792,0.0087 -0.180204,0.01331 -0.14284,0.01492 -0.313493,0.02076 -0.208002,0.0071 -0.02407,-0.0081 -0.209548,0.0172 -0.0139,0.0019 -0.0279,0.003 -0.04191,0.0035 l 0.04025,0.0066 c 0.01007,0.0016 0.02035,0.0023 0.03019,0.0049 0.01993,0.0054 0.03867,0.01498 0.05872,0.02 0.01972,0.0053 0.04025,0.0066 0.06038,0.0099 l 0.08051,0.01325 c 0.02684,0.0044 0.05341,0.01088 0.08051,0.01325 0.01721,0.0018 0.03468,-0.0029 0.05197,-0.0018 0.01692,0.0012 0.03334,0.0076 0.05032,0.0083 0.0107,7.22e-4 0.02114,-0.0042 0.03185,-0.0051 0.0034,-4.81e-4 0.0067,0.0022 0.01006,0.0016 0.0075,-0.0014 0.01436,-0.0051 0.02179,-0.0068 0.0224,-0.0049 0.0515,-0.0073 0.07375,-0.0085 0.01729,-8.24e-4 0.03464,-0.0015 0.05197,-0.0018 0.02067,-2.53e-4 0.04143,0.0015 0.06204,-1.28e-4 0.02142,-0.0018 0.0423,-0.008 0.06369,-0.01019 0.01724,-0.0019 0.03475,2.37e-4 0.05197,-0.0018 0.0075,-8.25e-4 0.01421,-0.0061 0.02179,-0.0068 0.0068,-4.52e-4 0.01343,0.0022 0.02013,0.0033 0.0033,5.67e-4 0.0068,0.0027 0.01006,0.0016 0.0092,-0.0027 0.01428,-0.01394 0.02345,-0.01681 0.0033,-0.001 0.0068,0.0027 0.01007,0.0016 0.03321,-0.0103 -0.01708,-0.01106 0.0335,-0.01516 0.0068,-4.52e-4 0.0134,0.0043 0.02013,0.0033 0.03313,-0.0053 -0.0023,-0.0073 0.01338,-0.01847 0.0028,-0.0022 0.0073,0.0038 0.01007,0.0016 0.0028,-0.0022 -3.62e-4,-0.0073 0.0016,-0.01007 0.0028,-0.0037 0.0089,-0.0045 0.01172,-0.0084 0.002,-0.0028 -3.62e-4,-0.0073 0.0016,-0.01007 0.0056,-0.0078 0.01782,-0.0091 0.02344,-0.01681 0.002,-0.0028 -0.0016,-0.009 0.0016,-0.01007 0.0046,-0.0013 0.04188,0.0069 0.05032,0.0083 0.0033,5.67e-4 0.0073,0.0038 0.01007,0.0016 0.0028,-0.0022 -0.0012,-0.0081 0.0016,-0.01007 0.0028,-0.0022 0.0343,0.0077 0.04025,0.0066 0.01486,-0.0033 0.02905,-0.009 0.04357,-0.0135 -0.05258,-0.0087 -0.04855,-0.009 -0.0424,-0.0073 z"
-         style="fill:#ffffff;fill-opacity:0.65384605;stroke:none;stroke-width:0.0815893px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         transform="scale(0.26458333)"
-         d="m 88.365234,-273.58594 c -0.06928,4.4e-4 -0.134375,0.0368 -0.203125,0.0449 -0.0257,0.004 -0.05089,-0.01 -0.07617,-0.0137 -0.01247,-0.002 -0.03691,-0.0195 -0.03906,-0.006 -0.0102,0.063 0.04941,0.0357 0.07031,0.0508 0.01474,0.0102 0.01538,0.0365 0.03125,0.0449 0.02268,0.0117 0.05263,0.002 0.07617,0.0117 0.05276,0.0223 0.08794,0.0787 0.140625,0.10156 0.02381,0.01 0.05089,0.01 0.07617,0.0137 l 0.228516,0.0371 0.113281,0.0176 c 0.03806,0.006 0.07473,0.0192 0.113281,0.0195 0.05303,8.3e-4 0.10529,-0.0163 0.158204,-0.0137 0.06429,0.003 0.127116,0.0286 0.191406,0.0312 0.105864,0.006 0.210504,-0.0216 0.316406,-0.0254 0.01361,2.2e-4 0.108746,0.021 0.113281,0.0176 0.01058,-0.008 -0.0028,-0.0297 0.0078,-0.0371 2.15e-4,-1.5e-4 0.111769,0.018 0.113281,0.0176 0.04059,-10e-4 0.08039,-0.0192 0.121094,-0.0195 0.03844,4.1e-4 0.07473,0.0192 0.113281,0.0195 0.05303,8.4e-4 0.10529,-0.0148 0.158203,-0.0137 0.04566,-3.8e-4 0.234784,0.0458 0.265625,0.043 0.04615,-0.006 0.08277,-0.043 0.126953,-0.0566 0.03874,-0.0113 0.08092,-0.0131 0.121094,-0.0195 0.04025,-0.007 0.08046,-0.018 0.121094,-0.0195 0.02532,2.4e-4 0.05085,0.0174 0.07617,0.0137 0.01814,-0.003 0.02539,-0.0275 0.04297,-0.0332 0.01247,-0.004 0.02633,0.008 0.03906,0.006 0.233235,-0.0723 -0.05912,0.004 0.158203,-0.0137 0.02872,-0.003 0.05376,-0.0205 0.08203,-0.0254 0.0121,-0.002 0.02464,0.004 0.03711,0.006 -0.01474,-0.0102 -0.02067,-0.0281 -0.03125,-0.043 -0.0463,-0.0336 -0.09237,-0.0679 -0.138672,-0.10156 v 0.004 c -0.169247,0.006 -0.257333,0.01 -0.431641,0.006 -0.103748,-10e-4 -0.206912,-0.0159 -0.310547,-0.0117 -0.09335,0.002 -0.185791,0.0313 -0.279297,0.0332 -0.23263,0.005 -0.464564,-0.0337 -0.697265,-0.0371 -0.14366,-0.002 -0.286035,0.009 -0.429688,0.008 -0.103521,-10e-4 -0.207441,-0.004 -0.310547,-0.0137 -0.0895,-0.009 -0.175596,-0.0439 -0.265625,-0.043 z m 5.535157,2.20117 c -0.06875,0.006 -0.134073,0.0413 -0.203125,0.0449 -0.05133,0.003 -0.0991,-0.0231 -0.150391,-0.0254 -0.05314,-8.5e-4 -0.107243,0.0156 -0.160156,0.0137 -0.05133,-0.003 -0.09906,-0.0231 -0.150391,-0.0254 -0.05314,-8.6e-4 -0.10529,0.0106 -0.158203,0.0137 -0.06535,0.003 -0.131804,0.008 -0.197266,0.006 -0.07669,-0.003 -0.187438,-0.0522 -0.197265,0.008 -0.0042,0.0253 0.05089,0.008 0.07617,0.0117 l 0.152343,0.0254 0.38086,0.0625 c 0.240869,0.0396 0.479145,0.10157 0.722656,0.11914 0.09316,0.008 0.185754,-0.0343 0.279297,-0.0332 0.07434,3.9e-4 0.332718,0.0661 0.417969,0.0703 0.05295,0.003 0.105289,-0.0163 0.158203,-0.0137 0.06429,0.003 0.126032,0.0207 0.189453,0.0312 l 0.496094,0.082 0.15039,0.0234 c 0.02532,0.004 0.05062,0.0156 0.07617,0.0137 0.02872,-0.003 0.05658,-0.0167 0.08398,-0.0254 0.03806,0.006 0.07484,0.0172 0.113281,0.0176 0.04082,-10e-4 0.08046,-0.0195 0.121093,-0.0195 0.0528,8e-4 0.202659,0.0344 0.265626,0.0449 0.01247,0.002 0.02437,0.008 0.03711,0.006 0.02835,-0.005 0.05571,-0.0209 0.08398,-0.0254 0.02532,-0.004 0.05085,0.008 0.07617,0.0117 l 0.03711,0.006 c 0.01247,0.002 0.02664,0.0142 0.03711,0.006 0.01058,-0.008 -0.0028,-0.0297 0.0078,-0.0371 0.01058,-0.008 0.02475,0.01 0.03711,0.006 0.01701,-0.005 0.02619,-0.0256 0.04297,-0.0312 -0.07117,-0.0106 -0.03777,-0.009 -0.08789,-0.17187 -0.198539,0.0378 -0.381186,-0.0392 -0.576172,-0.0547 -0.07809,-0.005 -0.156517,0.007 -0.234375,0 -0.102463,-0.009 -0.203245,-0.034 -0.304687,-0.0508 -0.08878,-0.0147 -0.175748,-0.04 -0.265626,-0.043 -0.105826,-0.004 -0.212419,0.0277 -0.318359,0.0254 -0.07691,-0.003 -0.15048,-0.0246 -0.226562,-0.0371 -0.101443,-0.0166 -0.202187,-0.0398 -0.304688,-0.0488 -0.02684,-0.002 -0.46109,-0.0108 -0.507812,-0.006 z m 10.515629,0.67579 c -0.0859,0.007 -0.16263,0.0646 -0.24805,0.0762 -0.25104,0.0344 -0.26579,-0.0257 -0.5,-0.043 -0.0653,-0.005 -0.13177,0.007 -0.19727,0.008 -0.0781,9.6e-4 -0.15651,-0.008 -0.23437,0 -0.0687,0.006 -0.13404,0.0411 -0.20313,0.0449 -0.0515,0.003 -0.0991,-0.0231 -0.15039,-0.0254 -0.0655,-0.003 -0.1318,0.0101 -0.19726,0.008 -0.0383,-0.002 -0.0749,-0.0192 -0.11328,-0.0195 -0.34303,7.7e-4 0.0554,0.0232 -0.20313,0.0449 -0.0348,0.002 -0.11818,-0.0296 -0.15234,-0.0254 -0.0284,0.005 -0.0538,0.0208 -0.082,0.0254 -0.0125,0.002 -0.0263,-0.006 -0.0391,-0.006 -0.0529,10e-4 -0.10555,0.007 -0.1582,0.0137 -0.17443,0.0204 -0.34356,0.0606 -0.51953,0.0703 -0.0653,0.003 -0.12981,0.0101 -0.19531,0.008 -0.0383,-0.002 -0.0771,-0.0233 -0.11524,-0.0195 -0.057,0.006 -0.10831,0.0372 -0.16406,0.0508 -0.0393,0.009 -0.0805,0.018 -0.12109,0.0195 -0.0513,10e-4 -0.10174,-0.0329 -0.15235,-0.0254 -0.0181,0.003 -0.0255,0.0279 -0.043,0.0332 l 0.49414,0.0801 0.15235,0.0254 c 0.0507,0.008 0.10105,0.0231 0.15234,0.0254 0.11913,0.0196 0.23514,-0.0245 0.35352,-0.0195 0.0513,0.003 0.10083,0.025 0.15234,0.0254 0.0406,7.6e-4 0.0804,-0.0192 0.12109,-0.0195 0.0641,7e-4 0.12539,0.0324 0.18946,0.0312 0.0406,-0.001 0.0804,-0.0195 0.12109,-0.0195 0.0641,6.9e-4 0.12543,0.0365 0.18945,0.0312 0.0287,-0.003 0.0534,-0.0242 0.082,-0.0254 0.0385,-0.002 0.0772,0.0135 0.11523,0.0195 l 0.11328,0.0176 c 0.0381,0.006 0.0767,0.0192 0.11524,0.0195 0.053,8.3e-4 0.10525,-0.0144 0.1582,-0.0137 0.0386,4.3e-4 0.0752,0.0115 0.11328,0.0176 l 0.26562,0.0449 c 0.0253,0.004 0.0507,0.0113 0.0762,0.0117 0.0406,-10e-4 0.0805,-0.018 0.12109,-0.0195 0.0253,2.4e-4 0.0509,0.01 0.0762,0.0137 l 0.15039,0.0234 c 0.0125,0.002 0.0263,0.008 0.0391,0.006 0.0283,-0.005 0.0536,-0.0209 0.082,-0.0254 0.0125,-0.002 0.0263,0.006 0.0391,0.008 l 0.18945,0.0312 c 0.0253,0.004 0.0505,0.0113 0.0762,0.0117 0.0528,7.9e-4 0.10529,-0.0133 0.15821,-0.0137 0.0257,2.6e-4 0.0507,0.01 0.0762,0.0137 l 0.22851,0.0371 c 0.0125,0.002 0.0267,0.01 0.0391,0.006 0.017,-0.005 0.0255,-0.026 0.043,-0.0312 0.0246,-0.008 0.0508,0.0155 0.0762,0.0117 0.0283,-0.005 0.0537,-0.0205 0.082,-0.0254 0.0125,-0.002 0.0267,0.01 0.0391,0.006 0.017,-0.005 0.0271,-0.0282 0.0449,-0.0312 0.0223,-0.004 0.19429,0.0318 0.22657,0.0371 0.0125,0.002 0.0286,0.0142 0.0391,0.006 0.0106,-0.008 -0.005,-0.0316 0.006,-0.0391 0.0106,-0.008 0.0286,0.0161 0.0391,0.008 0.0106,-0.008 -0.005,-0.0316 0.006,-0.0391 0.0106,-0.008 0.0247,0.01 0.0371,0.006 0.0174,-0.005 0.0275,-0.026 0.0449,-0.0312 0.0125,-0.004 0.0247,0.01 0.0371,0.006 0.14691,-0.10545 -0.0389,0.0117 0.082,-0.0254 0.017,-0.005 0.0275,-0.026 0.0449,-0.0312 0.0125,-0.004 0.0286,0.0142 0.0391,0.006 0.0106,-0.008 -0.006,-0.035 0.006,-0.0391 0.0246,-0.008 0.0516,0.0216 0.0762,0.0137 0.0125,-0.004 -0.005,-0.0316 0.006,-0.0391 0.0106,-0.008 0.0244,0.008 0.0371,0.006 0.0283,-0.005 0.0538,-0.0208 0.082,-0.0254 0.0155,-0.001 0.10843,0.0245 0.11523,0.0195 0.0106,-0.008 -0.005,-0.0316 0.006,-0.0391 0.009,-0.006 0.0969,0.0248 0.11328,0.0195 0.017,-0.005 0.0275,-0.0279 0.0449,-0.0332 0.0125,-0.004 0.0247,0.01 0.0371,0.006 0.017,-0.005 0.0555,-0.0161 0.0449,-0.0312 -0.0151,-0.0204 -0.0554,0.002 -0.0762,-0.0137 -0.0106,-0.008 0.007,-0.0244 0.006,-0.0371 -0.002,-0.0522 -0.007,-0.10429 -0.0117,-0.15625 -0.13927,0.0493 -0.25323,-0.0204 -0.38671,-0.0234 -0.053,-8.3e-4 -0.10529,0.0163 -0.15821,0.0137 -0.0643,-0.003 -0.1252,-0.0286 -0.18945,-0.0312 -0.0529,-0.003 -0.10529,0.0144 -0.1582,0.0117 -0.0643,-0.003 -0.12712,-0.0286 -0.19141,-0.0312 -0.0529,-0.003 -0.10529,0.0106 -0.1582,0.0137 -0.0654,0.003 -0.12993,0.004 -0.19532,0.008 -0.0529,0.003 -0.10731,0.0147 -0.16015,0.0117 -0.0769,-0.005 -0.14961,-0.0443 -0.22656,-0.0371 z m -7.289067,0.59765 c 0.06611,0.006 0.164372,0.024 -0.162109,0.0508 -0.09052,0.008 -0.183107,-0.0146 -0.273438,-0.006 -0.109228,0.0106 -0.212848,0.0555 -0.322265,0.0645 -0.103219,0.008 -0.207328,-0.0178 -0.310547,-0.0117 -0.121625,0.008 -0.239741,0.0484 -0.361328,0.0566 -0.173254,0.0723 -0.332605,-0.0486 -0.5,-0.043 -0.02532,-2.4e-4 0.01165,0.072 -0.01367,0.0762 -0.03802,0.006 -0.07477,-0.0233 -0.113282,-0.0195 -0.01776,9.9e-4 -0.02825,0.0256 -0.04492,0.0332 -0.02608,0.0113 -0.05338,0.0228 -0.08203,0.0254 -0.0257,0.002 -0.05074,-0.008 -0.07617,-0.0117 -0.02759,0.009 -0.05365,0.0205 -0.08203,0.0254 -0.04717,0.008 -0.107065,-0.0395 -0.152344,-0.0254 -0.01247,0.004 0.0062,0.0331 -0.0059,0.0371 -0.02457,0.008 -0.05149,-0.0197 -0.07617,-0.0117 -0.01247,0.004 -0.0138,0.0266 -0.0059,0.0371 0.0076,0.011 0.02437,0.006 0.03711,0.008 l 0.191407,0.0312 c 0.03806,0.006 0.07484,0.0172 0.113281,0.0176 0.04082,-0.001 0.08077,-0.015 0.121093,-0.0195 0.10526,-0.0121 0.210807,-0.0167 0.316407,-0.0254 0.05295,-0.005 0.105289,-0.0148 0.158203,-0.0137 0.03855,4.3e-4 0.07522,0.0135 0.113281,0.0195 l 0.152344,0.0234 0.191406,0.0312 c 0.03806,0.006 0.07484,0.0192 0.113281,0.0195 0.04082,-10e-4 0.08046,-0.021 0.121094,-0.0195 0.06418,0.003 0.12539,0.0267 0.189453,0.0312 0.06557,0.003 0.131767,-0.008 0.197266,-0.006 0.03832,0.002 0.07473,0.0172 0.113281,0.0176 0.05303,8.3e-4 0.10529,-0.0133 0.158203,-0.0137 0.0257,2.6e-4 0.05089,0.01 0.07617,0.0137 l 0.115235,0.0176 c 0.01247,0.002 0.02479,0.01 0.03711,0.006 0.01701,-0.005 0.02746,-0.026 0.04492,-0.0312 0.02079,-0.006 0.197372,0.038 0.228515,0.0371 0.04059,-10e-4 0.07851,-0.018 0.119141,-0.0195 0.02532,2.4e-4 0.05074,0.01 0.07617,0.0137 0.03806,0.006 0.07672,0.0195 0.115234,0.0176 0.02872,-10e-4 0.05338,-0.0243 0.08203,-0.0254 0.03851,-0.002 0.07522,0.0135 0.113282,0.0195 0.01247,0.002 0.02859,0.0142 0.03906,0.006 0.01058,-0.008 0.004,-0.0263 0.0059,-0.0391 0.0021,-0.0136 0.01002,-0.0248 0.0059,-0.0371 -0.0053,-0.0166 -0.01651,-0.0343 -0.03125,-0.0449 -0.04815,-0.0348 -0.04219,0.0403 -0.07031,-0.0508 -0.0038,-0.0125 0.01644,-0.0293 0.0059,-0.0371 -0.02079,-0.0151 -0.05263,-0.004 -0.07617,-0.0137 -0.02608,-0.0121 -0.04503,-0.0372 -0.07031,-0.0508 -0.01134,-0.006 -0.02437,-0.004 -0.03711,-0.006 -0.04416,-0.0461 -0.08873,-0.0907 -0.132812,-0.13672 -0.451181,-0.0176 -0.41767,-0.0235 -0.351563,-0.0176 z m 4.812497,0.40039 c 0.10242,0.007 0.21059,0.0276 -0.20312,0.084 -0.10258,0.014 -0.20737,-0.02 -0.31055,-0.0117 -0.10942,0.009 -0.21349,0.0496 -0.32226,0.0644 -0.0713,0.009 -0.37412,0.005 -0.43164,0.006 -0.0655,10e-4 -0.12982,0.0101 -0.19532,0.008 -0.077,-0.003 -0.15137,-0.0404 -0.22851,-0.0371 -0.0287,10e-4 -0.0533,0.0243 -0.082,0.0254 -0.064,10e-4 -0.12799,-0.0207 -0.191411,-0.0312 l -0.226562,-0.0371 -0.03906,-0.008 c -0.01247,-0.002 -0.02475,-0.01 -0.03711,-0.006 -0.01701,0.005 -0.02746,0.0279 -0.04492,0.0332 l 0.607423,0.0996 c 0.076,0.0125 0.1519,0.0284 0.22851,0.0371 0.1793,0.0197 0.35983,0.0291 0.53906,0.0488 0.12677,0.0132 0.25488,0.0417 0.38086,0.0625 0.0381,0.006 0.0748,0.0233 0.11328,0.0195 0.0287,-0.003 0.0538,-0.0208 0.082,-0.0254 0.0378,-0.006 0.20195,0.0448 0.22852,0.0371 0.017,-0.005 0.0276,-0.0256 0.0449,-0.0312 0.0246,-0.008 0.0516,0.0193 0.0762,0.0117 0.017,-0.005 0.0255,-0.026 0.043,-0.0312 0.0125,-0.004 0.0261,0.004 0.0391,0.006 l 0.0391,0.006 0.22656,0.0371 0.0391,0.006 c 0.0125,0.002 0.0248,0.012 0.0371,0.008 0.017,-0.005 0.0275,-0.0279 0.0449,-0.0332 0.0125,-0.004 0.0264,0.008 0.0391,0.006 0.0432,-0.007 0.0389,-0.008 0.0566,-0.0117 0.0208,0.003 0.0473,0.007 0.13867,0.006 0.0408,-10e-4 0.0806,-0.0161 0.12109,-0.0195 0.16876,-0.014 0.13963,-0.0158 0.23438,0 0.0125,0.002 0.0266,0.0142 0.0371,0.006 0.0106,-0.008 0.0172,-0.0312 0.006,-0.0371 -0.0344,-0.0174 -0.0773,-0.006 -0.11328,-0.0195 -0.0268,-0.0102 -0.0471,-0.0339 -0.0703,-0.0508 -0.0507,-0.008 -0.10336,-0.01 -0.15234,-0.0254 -0.0387,-0.0121 -0.069,-0.0434 -0.10742,-0.0566 -0.0367,-0.0117 -0.0779,-0.002 -0.11328,-0.0176 -0.0166,-0.007 -0.0185,-0.0343 -0.0332,-0.0449 -0.0178,-0.0128 -0.0889,-0.012 -0.11328,-0.0195 -0.0497,-0.0181 -0.0978,-0.0415 -0.14648,-0.0625 -0.43939,9e-4 -0.34265,-0.007 -0.24024,0 z m -11.716794,0.26172 c -0.05745,0.002 -0.107256,0.0416 -0.164062,0.0508 -0.06467,0.0106 -0.132182,-0.002 -0.197266,0.006 -0.02835,0.003 -0.05327,0.0228 -0.08203,0.0254 -0.0257,0.002 -0.0516,-0.0197 -0.07617,-0.0117 -0.01247,0.004 0.0016,0.0286 -0.0059,0.0391 -0.01058,0.014 -0.06291,0.0282 -0.04492,0.0312 0.05235,0.009 0.105289,-0.0133 0.158203,-0.0137 0.0257,2.7e-4 0.05089,0.008 0.07617,0.0117 l 0.115234,0.0195 c 0.02532,0.004 0.0507,0.0113 0.07617,0.0117 0.04059,-10e-4 0.07847,-0.0192 0.119141,-0.0195 0.06414,6.9e-4 0.127343,0.0324 0.191406,0.0312 0.04059,-0.001 0.07851,-0.0191 0.11914,-0.0176 0.06418,0.003 0.127155,0.0286 0.191407,0.0312 0.09581,0.0238 0.185829,-0.037 0.279297,-0.0332 0.06414,0.003 0.125163,0.0286 0.189453,0.0312 0.05295,0.003 0.105252,-0.0144 0.158203,-0.0137 0.03855,4.2e-4 0.07484,0.0191 0.113281,0.0195 0.04082,-0.001 0.08046,-0.018 0.121094,-0.0195 0.04415,-6.2e-4 0.106611,0.0178 0.152344,0.0254 l 0.07617,0.0117 c 0.02532,0.004 0.05089,0.0174 0.07617,0.0137 0.01814,-0.003 0.02555,-0.0279 0.04297,-0.0332 0.01323,-0.004 0.157428,0.0256 0.191406,0.0312 l 0.150391,0.0254 0.03906,0.006 c 0.01247,0.002 0.03695,0.0214 0.03906,0.008 0.0102,-0.063 -0.04953,-0.0357 -0.07031,-0.0508 -0.01474,-0.0102 -0.01651,-0.0343 -0.03125,-0.0449 -0.02192,-0.0155 -0.130346,-0.01 -0.152343,-0.0254 -0.01474,-0.0102 -0.01651,-0.0323 -0.03125,-0.043 -0.01058,-0.008 -0.02633,-0.006 -0.03906,-0.008 -0.02532,-0.004 -0.05542,0.003 -0.07617,-0.0117 -0.03848,-0.028 0.01021,-0.0411 0.03516,-0.0469 0.02532,-0.006 0.0264,-0.004 -0.105469,-0.004 -0.0528,-7.9e-4 -0.105403,0.009 -0.158203,0.0137 -0.505758,-0.0832 0.04741,-0.014 -0.310547,-0.0137 -0.03844,-4e-4 -0.07473,-0.0172 -0.113281,-0.0176 -0.05303,-8.4e-4 -0.10529,0.0156 -0.158203,0.0137 -0.05133,-0.003 -0.101056,-0.0231 -0.152344,-0.0254 -0.05314,-8.6e-4 -0.105403,0.009 -0.158203,0.0137 -0.08428,0.007 -0.27848,0.0252 -0.355469,0.0195 -0.07707,-0.005 -0.151413,-0.0404 -0.228516,-0.0371 z m 17.029294,0.12695 c -0.072,0.0102 -0.14435,0.017 -0.21679,0.0215 -0.1434,0.009 -0.28848,-0.006 -0.43164,0.006 -0.12148,0.01 -0.23775,0.0504 -0.35938,0.0586 -0.10333,0.007 -0.20744,-0.0219 -0.31055,-0.0117 -0.20254,0.0197 -0.33908,0.1037 -0.5332,0.14649 -0.0517,0.0113 -0.10673,6e-4 -0.1582,0.0137 -0.0448,0.0102 -0.082,0.0455 -0.12696,0.0566 -0.0515,0.0125 -0.10615,0.003 -0.1582,0.0137 -0.0845,0.017 -0.16377,0.0506 -0.24609,0.0762 -0.0276,0.009 -0.0773,-0.003 -0.082,0.0254 -0.004,0.0253 0.0489,0.01 0.0742,0.0137 l 0.0762,0.0117 c 0.0633,0.0106 0.12749,0.0244 0.1914,0.0312 0.49096,0.0477 0.98454,0.0174 1.47657,0.0469 0.18017,0.01 0.35877,0.0523 0.53906,0.0508 0.0896,-7.7e-4 0.17746,-0.0248 0.26562,-0.043 z m -16.378903,0.66211 c -0.241436,0.12307 -0.46575,0.28879 -0.724609,0.36914 -0.123364,0.0383 -0.257648,-0.0205 -0.386719,-0.0254 -0.181531,-0.007 -0.363475,-0.002 -0.544922,-0.0117 -0.314797,0.0351 -0.609941,-0.0918 -0.917969,-0.11133 -0.118223,-0.008 -0.237018,0.018 -0.355469,0.0195 -0.21993,0.003 -0.438416,-0.0369 -0.658203,-0.0293 -0.08118,0.002 -0.161343,0.0288 -0.242187,0.0371 -0.06516,0.007 -0.129814,0.008 -0.195313,0.008 -0.01285,-1.3e-4 -0.02859,-0.0142 -0.03906,-0.006 -0.01058,0.008 -0.0138,0.0266 -0.0059,0.0371 0.05254,0.0732 0.07615,0.0385 0.146485,0.0625 0.07952,0.0268 0.07357,0.0288 0.09961,0.0391 0.04811,0.009 0.119291,0.0207 0.3125,0.0684 0.724698,0.17295 -0.244301,-3e-4 0.564453,0.13281 l 0.494141,0.082 c 0.114066,0.0185 0.226597,0.0456 0.341797,0.0547 0.07809,0.005 0.156214,-0.002 0.234375,0 0.103748,10e-4 0.207366,0.02 0.310547,0.0117 0.109417,-0.009 0.215557,-0.0469 0.324218,-0.0625 1.515583,-0.15688 -0.361893,0.058 0.720703,-0.11523 0.06467,-0.0106 0.132523,0.003 0.197266,-0.008 0.03591,-0.006 0.0532,-0.0538 0.08789,-0.0645 0.05677,-0.0178 0.02809,0.052 0.08398,-0.0254 0.0076,-0.0106 -0.0047,-0.0297 0.0059,-0.0371 0.02343,-0.0166 0.05856,-0.008 0.08203,-0.0254 0.01058,-0.008 -0.0047,-0.0316 0.0059,-0.0391 0.01058,-0.008 0.02664,0.0142 0.03711,0.006 0.01058,-0.008 0.0059,-0.0244 0.0078,-0.0371 0.0021,-0.0136 0.02457,-0.15057 0.02344,-0.15234 -0.0076,-0.011 -0.02966,0.005 -0.03711,-0.006 -0.0076,-0.011 0.004,-0.0263 0.0059,-0.0391 0.0072,-0.0444 0.01468,-0.0884 0.02148,-0.13282 z m -3.824219,0.38868 c -0.144869,-0.0249 0.120794,0.0489 0,0 z m 10.746094,-0.25391 c -0.242734,0.0326 -0.474358,0.1485 -0.71875,0.16211 -0.12892,0.007 -0.258445,-0.009 -0.386719,-0.0234 -0.140561,-0.0151 -0.276856,-0.0609 -0.417969,-0.0703 -0.143395,-0.01 -0.287984,0.008 -0.43164,0.008 -0.09097,8.2e-4 -0.182616,-0.003 -0.273438,-0.006 -0.103559,-0.003 -0.207592,-0.0219 -0.310547,-0.0117 -0.04607,0.004 -0.08191,0.0397 -0.125,0.0566 -0.228132,0.0903 0.05275,-0.0207 -0.160156,0.0137 -0.01814,0.003 -0.02551,0.026 -0.04297,0.0312 -0.02835,0.009 -0.110095,-0.0471 -0.121093,0.0195 -0.0021,0.0136 0.02636,0.004 0.03906,0.006 l 0.07617,0.0137 0.341797,0.0566 c 0.745395,0.12268 -0.41594,-0.0503 0.544922,0.01 0.153902,0.009 0.304036,0.0569 0.457031,0.0762 0.204359,0.0257 0.409036,0.0359 0.613281,0.0625 0.178318,0.0234 0.354224,0.0702 0.533203,0.0879 0.478439,0.0452 0.656995,-0.007 1.128907,0.0293 0.500916,0.0824 0.171114,0.0426 0.613281,0.0606 0.0076,8e-5 0.02217,0.005 0.03906,0.008 0.0102,-0.0615 0.01941,-0.0853 0.02734,-0.0977 -0.0035,-0.009 -0.0052,-0.003 -0.0098,-0.0176 -0.0038,-0.0125 0.01575,-0.0266 0.0078,-0.0371 -0.04124,-0.0575 -0.08624,-0.0526 -0.146484,-0.0625 -0.01247,-0.002 -0.02746,-0.002 -0.03906,-0.008 -0.02532,-0.014 -0.0419,-0.0373 -0.06836,-0.0488 -0.02986,-0.0129 -0.188717,-0.0326 -0.228516,-0.0391 -0.02532,-0.004 -0.05338,-1.3e-4 -0.07617,-0.0117 -0.01625,-0.009 -0.01651,-0.0343 -0.03125,-0.0449 -0.02041,-0.0151 -0.0907,-0.004 -0.115234,-0.0176 -0.02532,-0.014 -0.04491,-0.0372 -0.07031,-0.0508 -0.02268,-0.0117 -0.05085,-0.008 -0.07617,-0.0117 l -0.150391,-0.0254 c -0.01247,-0.002 -0.02822,-3.2e-4 -0.03906,-0.006 -0.0486,-0.0317 -0.0911,-0.0733 -0.136718,-0.10938 -0.08437,-0.0149 -0.165183,-0.0128 -0.246094,-0.002 z m 1.398437,0.58984 c 0.01663,0.003 0.03571,0.007 0.03711,0.006 0.01058,-0.008 0.01871,-0.0369 0.0059,-0.0391 -0.01776,-0.003 -0.04595,0.0513 -0.04297,0.0332 z m -12.324218,0.41797 c -0.192152,0.11634 -0.370917,0.25841 -0.576172,0.34961 -0.04702,0.0208 -0.101245,-0.0208 -0.152344,-0.0254 -0.07797,-0.005 -0.156214,-1.6e-4 -0.234375,0 -0.07824,9.4e-4 -0.156441,-0.005 -0.234375,0.002 -0.509843,0.0418 -0.299047,0.0791 -0.830078,0.0586 -0.167395,-0.007 -0.334448,-0.0406 -0.501953,-0.0449 -0.727601,-0.02 -0.01547,0.0424 -0.632813,0.0527 -0.247672,0.004 -0.05634,-0.0679 -0.310547,-0.0117 -0.01776,0.005 -0.02746,0.026 -0.04492,0.0312 -0.01247,0.004 -0.02664,-0.0142 -0.03711,-0.006 -0.01058,0.008 0.0016,0.0266 -0.0059,0.0371 -0.01058,0.014 -0.03011,0.0226 -0.04492,0.0332 -0.01474,0.0113 -0.02746,0.026 -0.04492,0.0312 -0.01247,0.004 -0.02399,-0.008 -0.03711,-0.006 -0.04044,0.003 -0.08137,0.0105 -0.121094,0.0195 -0.02797,0.005 -0.05361,0.022 -0.08203,0.0254 -0.06493,0.007 -0.131956,0.002 -0.197266,0.008 -0.09328,0.008 -0.183914,0.0267 -0.277344,0.0312 -0.09078,0.005 -0.182653,-0.009 -0.273437,-0.006 -0.04059,10e-4 -0.07866,0.0161 -0.119141,0.0195 -0.01285,0.002 -0.04643,-0.0172 -0.03906,-0.006 0.08935,0.12461 0.175418,0.1192 0.324218,0.16992 0.147969,0.0504 0.293309,0.10655 0.44336,0.15039 0.260182,0.076 0.521851,0.15332 0.787109,0.20899 0.301758,0.0635 0.607824,0.0984 0.912109,0.14844 l 0.91211,0.15039 0.761719,0.12695 c 0.152126,0.0249 0.301141,0.0667 0.455078,0.0742 0.06913,0.004 0.134186,-0.0393 0.203125,-0.0449 0.03851,-0.004 0.07672,0.0214 0.115234,0.0195 0.02872,-0.001 0.05372,-0.0224 0.08203,-0.0274 0.01247,-0.002 0.02475,0.01 0.03711,0.006 0.01701,-0.005 0.02822,-0.0237 0.04492,-0.0312 0.07427,-0.0336 0.120693,-0.0266 0.203125,-0.0449 0.02797,-0.005 0.05395,-0.019 0.08203,-0.0254 0.07929,-0.0174 0.160902,-0.0217 0.240234,-0.0391 0.02797,-0.005 0.05463,-0.0167 0.08203,-0.0254 0.02759,-0.009 0.05851,-0.0118 0.08398,-0.0254 0.03213,-0.0166 0.05569,-0.0457 0.08789,-0.0625 0.02532,-0.0136 0.05644,-0.0137 0.08203,-0.0274 0.04834,-0.0253 0.08319,-0.0713 0.132812,-0.0937 0.02608,-0.0113 0.05588,-0.0152 0.08203,-0.0273 0.01663,-0.007 0.02746,-0.026 0.04492,-0.0312 0.05677,-0.0174 0.02613,0.052 0.08203,-0.0254 0.0091,-0.0121 0.02671,-0.16292 0.03125,-0.18945 0.0021,-0.0136 0.0138,-0.0286 0.0059,-0.0391 -0.06006,-0.0837 -0.06754,-0.0285 -0.144531,-0.0625 -0.197745,-0.14324 0.05383,0.0213 -0.146485,-0.0644 -0.02608,-0.0121 -0.04571,-0.0341 -0.07031,-0.0488 -0.06951,-0.042 -0.144873,-0.0774 -0.216797,-0.11523 -0.03591,-0.0197 -0.07019,-0.0404 -0.107422,-0.0566 -0.07298,-0.0317 -0.0052,0.039 -0.113281,-0.0176 -0.01625,-0.009 -0.01651,-0.0343 -0.03125,-0.0449 -0.02079,-0.0151 -0.05338,-1.3e-4 -0.07617,-0.0117 -0.02532,-0.014 -0.04503,-0.0373 -0.07031,-0.0508 -0.02268,-0.0117 -0.05542,0.003 -0.07617,-0.0117 -0.01474,-0.0102 -0.01538,-0.0365 -0.03125,-0.0449 -0.02268,-0.0117 -0.05342,-0.002 -0.07617,-0.0137 -0.01625,-0.009 -0.01802,-0.0304 -0.03125,-0.043 -0.171062,-0.15976 -4.43e-4,-0.002 -0.107422,-0.0586 -0.07257,-0.0384 -0.09164,-0.0913 -0.177735,-0.10547 l -0.03906,-0.006 c -0.02532,-0.004 -0.07508,0.012 -0.07617,-0.0137 -0.0019,-0.0461 0.112757,-0.10069 0.07031,-0.11914 z m 0,0 c -0.06833,-0.0291 -0.143815,0.0422 -0.216797,0.0566 0.01247,0.003 0.0267,0.008 0.03906,0.006 0.06164,-0.0121 0.118396,-0.0415 0.177735,-0.0625 z m 8.054687,0.59766 c -0.08115,-0.002 -0.15905,0.0361 -0.240234,0.0391 -0.05125,0.001 -0.101661,-0.0171 -0.152344,-0.0254 -0.01247,-0.002 -0.02859,-0.0142 -0.03906,-0.006 -0.01058,0.008 0.0062,0.0331 -0.0059,0.0371 -0.02457,0.008 -0.05089,-0.0155 -0.07617,-0.0117 -0.01814,0.003 -0.02551,0.026 -0.04297,0.0312 -0.01247,0.004 -0.02633,-0.004 -0.03906,-0.006 -0.01474,0.0113 -0.02746,0.026 -0.04492,0.0312 -0.01247,0.004 -0.02664,-0.0142 -0.03711,-0.006 -0.01058,0.008 -0.0138,0.0286 -0.0059,0.0391 0.02495,0.0344 0.07134,-0.022 0.08203,-0.0254 0.01247,-0.004 0.02437,0.004 0.03711,0.006 l 0.07617,0.0117 0.685547,0.11328 c 0.955022,0.15719 -0.202017,-0.008 0.773437,0.0488 0.115389,0.007 0.226635,0.0456 0.341797,0.0566 0.358753,0.0363 0.175494,-0.0183 0.507813,0.006 0.06406,0.005 0.125087,0.0305 0.189453,0.0312 0.02872,7.7e-4 0.05327,-0.0247 0.08203,-0.0273 0.0257,-0.002 0.05066,0.0156 0.07617,0.0137 0.02872,-0.003 0.05338,-0.0227 0.08203,-0.0254 0.0257,-0.002 0.05085,0.008 0.07617,0.0117 0.05295,-0.005 0.106197,-0.003 0.158203,-0.0137 0.05639,-0.0113 0.108567,-0.0506 0.166016,-0.0508 0.102916,-8.3e-4 0.201292,0.034 0.302734,0.0508 0.604392,0.0995 -0.112582,-0.003 0.425781,0.0312 0.06395,0.005 0.125277,0.0286 0.189454,0.0312 0.07544,0.0283 0.133921,-0.0448 0.203124,-0.0449 0.05129,5.6e-4 0.100867,0.025 0.152344,0.0254 0.04063,7.7e-4 0.08043,-0.0192 0.121094,-0.0195 0.03844,4.1e-4 0.07522,0.0115 0.113281,0.0176 l 0.228516,0.0371 0.607422,0.10156 c 0.07604,0.0125 0.151494,0.0326 0.228514,0.0371 0.0654,0.005 0.13181,-0.0101 0.19727,-0.008 0.0383,0.002 0.0752,0.0135 0.11328,0.0195 0.0125,0.002 0.0267,0.01 0.0391,0.006 0.017,-0.005 0.0255,-0.026 0.043,-0.0312 0.0246,-0.008 0.0508,0.0155 0.0762,0.0117 0.0423,-0.007 0.0389,-0.007 0.0567,-0.0117 0.0208,0.003 0.0485,0.005 0.14062,0.004 0.0408,-10e-4 0.0804,-0.0192 0.12109,-0.0195 0.0384,4e-4 0.24439,0.0513 0.26563,0.0449 0.017,-0.005 0.0275,-0.0279 0.0449,-0.0332 0.0174,-0.005 0.17441,0.0286 0.18945,0.0312 l 0.3418,0.0566 0.22852,0.0371 c 0.0253,0.004 0.0506,0.0156 0.0762,0.0137 0.0287,-0.003 0.0534,-0.0227 0.082,-0.0254 0.0257,-0.002 0.0508,0.008 0.0762,0.0117 0.0276,-0.009 0.0536,-0.0205 0.082,-0.0254 0.0125,-0.002 0.0267,0.01 0.0391,0.006 0.0348,-0.0102 0.0533,-0.0537 0.0879,-0.0644 0.0125,-0.004 0.0267,0.012 0.0391,0.008 0.017,-0.005 0.0255,-0.0279 0.043,-0.0332 0.0125,-0.004 0.0286,0.0142 0.0391,0.006 0.0106,-0.008 -0.005,-0.0297 0.006,-0.0371 0.0106,-0.008 0.0266,0.0142 0.0371,0.006 0.0208,-0.0144 -0.007,-0.0612 0.0137,-0.0762 0.0106,-0.008 0.0266,0.0142 0.0371,0.006 0.0106,-0.008 -0.002,-0.0266 0.006,-0.0371 0.0106,-0.014 0.0343,-0.0185 0.0449,-0.0332 0.008,-0.0106 -0.005,-0.0297 0.006,-0.0371 0.0106,-0.008 0.0286,0.0142 0.0391,0.006 0.0208,-0.0144 -0.003,-0.0554 0.0117,-0.0762 0.0106,-0.014 0.0343,-0.0165 0.0449,-0.0312 0.008,-0.0106 -0.004,-0.0305 0.006,-0.0391 0.0531,-0.0478 0.11557,-0.0815 0.17383,-0.12305 -0.064,-0.002 -0.3793,-0.0119 -0.4668,0.002 -0.0967,0.0155 -0.1855,0.0649 -0.2832,0.0703 -0.14169,0.008 -0.28392,-0.0309 -0.42578,-0.0312 -0.1714,4e-4 -0.34283,0.0192 -0.51367,0.0332 -0.50518,0.0414 -0.8184,0.1011 -1.341802,0.0918 -0.283767,-0.005 -0.565881,-0.0547 -0.84961,-0.0625 -0.574401,-0.0159 -1.150215,0.0453 -1.724609,0.0293 -0.283729,-0.008 -0.566406,-0.0433 -0.84961,-0.0625 -0.25765,-0.0174 -0.514011,-0.0288 -0.771484,-0.0488 -0.192756,-0.014 -0.386303,-0.034 -0.578125,-0.0566 -0.08927,-0.0106 -0.17571,-0.042 -0.265625,-0.043 z m 11.964842,0.40625 c -0.27371,0.037 -0.54915,0.0241 -0.82422,0.0215 -0.0782,-0.001 -0.15716,-0.0126 -0.23437,0 -0.0851,0.0136 -0.16068,0.0646 -0.2461,0.0762 -0.09,0.0121 -0.1834,-0.0183 -0.27343,-0.006 -0.36647,0.11354 -0.1177,0.0567 -0.4043,0.0899 -0.0404,0.005 -0.0822,0.007 -0.12109,0.0195 -0.20123,0.0624 -0.0471,0.0598 -0.2461,0.0762 -0.0652,0.005 -0.13384,-0.009 -0.19726,0.008 -0.0622,0.0163 -0.1107,0.0631 -0.16992,0.0879 -0.053,0.0219 -0.1111,0.0357 -0.16602,0.0527 -0.007,0.003 -0.10978,0.0393 -0.16602,0.0488 0,0 0.002,0.002 0.002,0.002 l 0.0371,0.006 0.45703,0.0742 1.21679,0.20117 c 0.15818,0.0261 0.36803,0.0828 0.53907,0.0488 0.0453,-0.008 0.0828,-0.043 0.12695,-0.0566 0.0387,-0.0113 0.0814,-0.0105 0.12109,-0.0195 0.028,-0.005 0.0546,-0.0167 0.082,-0.0254 0.0276,-0.009 0.0558,-0.0133 0.082,-0.0254 0.0966,-0.0437 -0.0186,-0.0353 0.12695,-0.0586 0.0125,-0.002 0.0244,0.004 0.0371,0.006 0.0147,-0.0113 0.0275,-0.026 0.0449,-0.0312 0.0125,-0.004 0.0266,0.0142 0.0371,0.006 0.0106,-0.008 -0.005,-0.0297 0.006,-0.0371 0.0106,-0.008 0.0267,0.01 0.0391,0.006 0.0348,-0.0102 0.0533,-0.0538 0.0879,-0.0645 0.0125,-0.004 0.0267,0.01 0.0391,0.006 0.17132,-0.0531 -0.0407,-0.003 0.0508,-0.0684 0.0106,-0.008 0.0247,0.01 0.0371,0.006 0.017,-0.005 0.0275,-0.026 0.0449,-0.0312 0.0549,-0.017 0.0304,0.0428 0.043,-0.0332 0.003,-0.0174 0.012,-0.10251 0.0195,-0.11328 0.0106,-0.014 0.0343,-0.0165 0.0449,-0.0312 0.0151,-0.0208 -0.009,-0.0612 0.0117,-0.0762 0.0106,-0.008 0.0266,0.0142 0.0371,0.006 0.0306,-0.0219 -0.0159,-0.0754 -0.0254,-0.082 -0.0189,-0.0132 -0.12294,-0.0148 -0.15235,-0.0254 -0.0497,-0.0181 -0.0917,-0.0591 -0.14453,-0.0625 z m -19.376951,0.95312 c -0.05303,-8.3e-4 -0.10529,0.009 -0.158203,0.0117 -0.03439,0.002 -0.30374,0.009 -0.353516,0.0215 -0.136592,0.0355 -0.191513,0.0549 -0.222656,0.0684 -0.01776,-0.005 -0.04241,-0.0117 -0.138672,-0.0117 -0.202054,4.8e-4 -0.08712,0.0235 -0.07813,0.0254 l 0.0332,0.006 0.189453,0.0312 0.533203,0.0879 0.798828,0.13086 0.835938,0.13867 c 0.253568,0.0417 0.506313,0.0968 0.761719,0.125 0.218607,0.0242 0.438601,0.0191 0.658203,0.0312 0.14177,0.008 0.283845,0.0312 0.425781,0.0293 0.126161,0.0718 0.212848,-0.0535 0.322266,-0.0625 0.0511,-0.004 0.101773,0.031 0.152343,0.0234 0.01814,-0.003 0.02708,-0.0282 0.04492,-0.0312 0.02532,-0.004 0.05074,0.0155 0.07617,0.0117 0.01814,-0.003 0.02551,-0.026 0.04297,-0.0312 0.01247,-0.004 0.02632,0.004 0.03906,0.006 0.02759,-0.009 0.05463,-0.0167 0.08203,-0.0254 0.08228,-0.0257 0.165728,-0.0506 0.248047,-0.0762 0.02759,-0.009 0.05372,-0.0205 0.08203,-0.0254 0.05242,-0.009 0.105932,-0.005 0.158203,-0.0137 l -1.25586,-0.20508 c -0.164825,-0.0272 -0.327678,-0.0685 -0.49414,-0.082 -0.143169,-0.0117 -0.288366,0.018 -0.431641,0.008 -0.87544,-0.0636 0.04212,-0.087 -0.841797,-0.0996 -0.11845,-0.002 -0.237169,0.0252 -0.355468,0.0195 -0.102652,-0.005 -0.202489,-0.0399 -0.304688,-0.0508 -0.103294,-0.009 -0.207328,-0.003 -0.310547,-0.0117 -0.05114,-0.005 -0.101055,-0.0231 -0.152343,-0.0254 -0.05314,-8.5e-4 -0.105252,0.0118 -0.158204,0.0137 -0.01285,-1.3e-4 -0.02437,-0.004 -0.03711,-0.006 -0.06334,-0.0106 -0.127041,-0.0305 -0.191406,-0.0312 z m 5.152343,0.0273 c -0.110588,0.1361 -0.202895,0.28858 -0.324218,0.41406 0.02003,0.002 0.03883,0.007 0.05859,0.01 0.01247,0.002 0.0267,0.01 0.03906,0.006 0.01739,-0.005 0.02815,-0.0207 0.04297,-0.0312 0.01474,-0.0113 0.0343,-0.0165 0.04492,-0.0312 0.0076,-0.0106 -0.0047,-0.0316 0.0059,-0.0391 0.01058,-0.008 0.0267,0.012 0.03906,0.008 0.01701,-0.005 0.02543,-0.0275 0.04297,-0.0332 0.01247,-0.004 0.02674,0.01 0.03906,0.006 0.01701,-0.005 0.02746,-0.026 0.04492,-0.0312 0.01247,-0.004 0.02664,0.0142 0.03711,0.006 0.01058,-0.008 0.004,-0.0263 0.0059,-0.0391 0.0021,-0.0136 0.0138,-0.0266 0.0059,-0.0371 -0.0076,-0.011 -0.02966,0.005 -0.03711,-0.006 -0.0076,-0.011 0.01682,-0.0316 0.0059,-0.0391 -0.02079,-0.0151 -0.06861,0.0128 -0.07617,-0.0117 -0.01493,-0.0483 0.01661,-0.10052 0.02539,-0.15039 z m -0.324218,0.41406 c -0.0057,-5.9e-4 -0.01191,-0.002 -0.01758,-0.002 -0.02872,0.003 -0.05323,0.0239 -0.08203,0.0254 -0.03851,0.002 -0.07477,-0.0195 -0.113281,-0.0176 -0.02872,10e-4 -0.05357,0.0205 -0.08203,0.0254 l 0.07617,0.0117 c 0.05072,0.008 0.111083,0.0585 0.15039,0.0254 0.02419,-0.0204 0.04632,-0.0436 0.06836,-0.0664 z m -5.845703,-0.3418 c -0.0076,-0.003 -0.01292,-0.003 -0.01367,0.002 -0.0021,0.0136 0.02437,0.004 0.03711,0.006 -0.0068,-10e-4 -0.0155,-0.006 -0.02344,-0.008 z m 17.031249,0.6211 c -0.13603,-0.002 -0.26167,0.0396 -0.39648,0.0508 -0.0781,0.007 -0.15682,-0.006 -0.23438,0.002 -0.10908,0.0125 -0.21446,0.0597 -0.32422,0.0625 -0.16747,0.004 -0.33256,-0.0407 -0.5,-0.043 -0.17144,-0.002 -0.34226,0.0294 -0.51367,0.0332 -0.28154,0.006 -0.76622,-0.0297 -1.05273,-0.0176 -0.14635,0.006 -0.28952,0.0349 -0.43555,0.0469 -0.118073,0.01 -0.237132,0.0139 -0.355469,0.0195 -0.06546,0.003 -0.131956,3.7e-4 -0.197266,0.006 -0.400105,0.0329 0.03047,-0.009 -0.164063,0.0508 -0.01247,0.004 -0.02664,-0.0142 -0.03711,-0.006 -0.01058,0.008 0.0028,0.0316 -0.0078,0.0391 -0.01058,0.008 -0.02664,-0.0142 -0.03711,-0.006 -0.01058,0.008 -0.0138,0.0266 -0.0059,0.0371 0.0011,0.001 0.104059,0.0184 0.113281,0.0195 0.06334,0.0106 0.127306,0.0305 0.191406,0.0312 0.04082,-10e-4 0.07843,-0.0192 0.119141,-0.0195 0.03844,4e-4 0.07717,0.0115 0.115234,0.0176 0.05295,-0.005 0.105252,-0.0118 0.158204,-0.0137 0.0782,-0.003 0.156212,1.7e-4 0.234372,0 0.10145,0.0166 0.20181,0.0536 0.30469,0.0508 0.10976,-0.003 0.21455,-0.0431 0.32227,-0.0645 0.14362,-0.002 0.28806,-0.0127 0.43164,-0.008 0.44097,0.0147 0.48736,0.0731 0.93164,0.0371 0.10941,-0.009 0.21285,-0.0555 0.32226,-0.0645 0.0511,-0.004 0.1011,0.0269 0.15235,0.0254 0.0181,-9.4e-4 0.0275,-0.026 0.0449,-0.0312 0.0246,-0.008 0.0516,0.0197 0.0762,0.0117 0.017,-0.005 0.0251,-0.0282 0.043,-0.0312 0.0506,-0.008 0.10177,0.033 0.15234,0.0254 0.0181,-0.003 0.0275,-0.0279 0.0449,-0.0332 0.0125,-0.004 0.0248,0.01 0.0371,0.006 0.017,-0.005 0.0275,-0.026 0.0449,-0.0312 0.0125,-0.004 0.0244,0.008 0.0371,0.006 0.0276,-0.009 0.0566,-0.0167 0.084,-0.0254 0.0125,0.002 0.0244,0.008 0.0371,0.006 0.0284,-0.005 0.0538,-0.0209 0.082,-0.0254 0.0125,-0.002 0.0267,0.01 0.0391,0.006 0.0174,-0.005 0.0255,-0.026 0.043,-0.0312 0.0125,-0.004 0.0312,0.0164 0.0391,0.006 0.0304,-0.042 0.0115,-0.14153 0.0606,-0.14453 z m -8.095702,0.0742 c -0.146344,0.006 -0.291248,0.0359 -0.4375,0.0449 -0.143396,0.009 -0.288287,-0.003 -0.431641,0.006 -0.146268,0.009 -0.291172,0.0394 -0.4375,0.0469 -0.156132,0.008 -0.312572,-0.007 -0.46875,0 -0.158778,0.007 -0.316062,0.0273 -0.474609,0.0391 -0.170949,0.0121 -0.342826,0.0192 -0.513672,0.0332 -0.938737,0.077 -0.09034,8.2e-4 -0.640625,0.0898 -0.05242,0.009 -0.10529,0.0133 -0.158203,0.0137 -0.0257,-2.6e-4 -0.05153,-0.0216 -0.07617,-0.0137 -0.01247,0.004 -0.01644,0.0312 -0.0059,0.0391 0.02079,0.0151 0.05074,0.008 0.07617,0.0117 l 0.152344,0.0254 0.761719,0.125 c 0.253568,0.0417 0.50459,0.0948 0.759765,0.125 0.281953,0.0325 0.566508,0.0419 0.84961,0.0625 0.546104,0.0398 0.970038,0.0779 1.507812,0.0918 0.156246,0.004 0.312455,-0.003 0.46875,-0.002 0.315251,0.002 0.181989,0.0338 0.355469,-0.0195 0.02759,-0.009 0.05584,-0.0133 0.08203,-0.0254 0.03326,-0.0151 0.05409,-0.057 0.08984,-0.0625 0.02532,-0.004 0.05089,0.008 0.07617,0.0117 0.01247,0.002 0.02475,0.01 0.03711,0.006 0.03477,-0.0102 0.05327,-0.0516 0.08789,-0.0625 0.02948,-0.009 0.108848,0.0548 0.121094,-0.0195 0.0045,-0.0283 -0.04934,-0.0312 -0.07031,-0.0508 -0.06198,-0.0577 0.0046,-0.05 -0.101563,-0.0957 -0.02381,-0.01 -0.05195,-0.004 -0.07617,-0.0117 -0.03806,-0.0144 -0.0694,-0.0423 -0.107422,-0.0566 -0.02419,-0.008 -0.05263,-0.004 -0.07617,-0.0137 -0.189354,-0.0819 0.04627,-0.0308 -0.146485,-0.0625 l -0.15039,-0.0254 c -0.01247,-0.002 -0.03506,0.006 -0.03906,-0.006 -0.0155,-0.0505 -0.0091,-0.10541 -0.01367,-0.15821 -0.14109,-0.009 -0.277084,-0.057 -0.417969,-0.0684 -0.09063,-0.007 -0.1807,-0.003 -0.271485,-0.006 -0.103521,-0.003 -0.207101,-0.0159 -0.310546,-0.0117 z m 8.275392,0.0332 c -0.0147,0.0113 0.0207,0.0301 0.0312,0.0449 -0.0106,-0.0155 -0.0165,-0.0555 -0.0312,-0.0449 z"
-         style="fill:#f1f1f1;fill-opacity:1;stroke:none;stroke-width:0.30836901px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path1321" />
-      <path
-         inkscape:connector-curvature="0"
-         transform="scale(0.26458333)"
-         d="m 73.771484,-273.29297 c -0.326248,-0.003 -0.63565,0.0734 -0.957031,0.11719 -0.131074,0.0178 -0.263351,0.0299 -0.394531,0.0469 -0.05681,0.006 -0.115005,0.0103 -0.169922,0.0274 -0.06259,0.0193 -0.117023,0.0606 -0.179688,0.0801 -0.05488,0.017 -0.115005,0.0103 -0.169921,0.0273 -0.02457,0.008 -0.03797,0.0372 -0.0625,0.0449 l 0.484375,0.0801 0.429687,0.0703 0.537109,0.0879 c 0.381684,0.0628 0.53031,0.0915 0.638672,0.11328 -0.106091,-0.0314 -0.161189,-0.0714 0.240235,-0.0781 0.712645,0.11728 0.03872,0.041 0.492187,0.0254 0.0726,-0.002 0.142428,0.0428 0.214844,0.0371 0.04044,-0.003 0.07849,-0.0254 0.117188,-0.0371 0.05666,-0.008 0.112662,-0.0228 0.169921,-0.0273 0.01776,-9.9e-4 0.03673,0.007 0.05469,0.01 0.02079,-0.0144 0.03797,-0.0374 0.0625,-0.0449 0.01739,-0.005 0.03777,0.0211 0.05273,0.01 0.01474,-0.0113 -0.005,-0.0441 0.0098,-0.0547 0.01474,-0.0113 0.03983,0.0211 0.05469,0.01 0.01474,-0.0113 -0.0069,-0.0441 0.0078,-0.0547 0.01474,-0.0113 0.03972,0.0211 0.05469,0.01 0.01474,-0.0113 -0.0069,-0.0441 0.0078,-0.0547 0.01474,-0.0113 0.03689,0.0124 0.05469,0.01 0.04025,-0.007 0.08228,-0.0133 0.115235,-0.0371 0.0635,-0.0456 -0.07507,-0.14085 -0.179688,-0.25 -0.229833,-0.0242 -0.454932,-0.0835 -0.683593,-0.12109 -0.0762,-0.0129 -0.153745,-0.0245 -0.230469,-0.0312 -0.11006,-0.0102 -0.221518,0.004 -0.332031,0.002 -0.146457,-0.003 -0.292989,-0.0161 -0.439454,-0.0176 z m 0.113282,2.66992 c -0.154243,0.0178 -0.304199,0.0647 -0.457032,0.0918 -1.604235,0.28558 0.383724,-0.0528 -0.894531,0.0723 -0.154507,0.0151 -0.303201,0.069 -0.457031,0.0898 -0.16766,0.0231 -0.291439,-0.0116 -0.449219,0.0371 -0.02457,0.008 -0.03797,0.0372 -0.0625,0.0449 -0.01701,0.005 -0.03777,-0.0192 -0.05273,-0.008 -0.01474,0.0113 -0.02035,0.038 -0.0098,0.0527 0.01058,0.0155 0.03862,0.001 0.05469,0.01 0.0359,0.0197 0.06167,0.0513 0.09766,0.0703 0.01587,0.009 0.03689,0.007 0.05469,0.01 l 0.160157,0.0273 c 0.219779,0.0363 0.424429,0.0783 0.654297,0.0508 0.121096,-0.014 0.228513,-0.0934 0.349609,-0.10742 0.630126,-0.0729 0.233512,0.0496 0.708984,0.0606 0.04063,7.6e-4 0.07712,-0.0287 0.117188,-0.0352 0.0359,-0.006 0.07291,0.0278 0.107422,0.0176 0.04906,-0.0151 0.07828,-0.0687 0.125,-0.0899 0.110173,-0.0499 0.239398,-0.0575 0.349609,-0.10742 0.02343,-0.01 0.03733,-0.041 0.0625,-0.0449 0.03591,-0.006 0.07159,0.0217 0.107422,0.0156 0.02532,-0.004 0.03903,-0.0325 0.0625,-0.043 0.01096,-0.10277 0.131144,-0.0156 0.169922,-0.0273 0.02457,-0.008 0.03801,-0.0374 0.0625,-0.0449 0.01701,-0.005 0.03968,0.0211 0.05469,0.01 0.01474,-0.0113 -0.0069,-0.0441 0.0078,-0.0547 0.01852,-0.0128 0.178673,0.0468 0.214844,0.0352 0.02457,-0.008 0.03861,-0.0355 0.0625,-0.0449 0.07498,-0.0296 0.15535,-0.0486 0.232421,-0.0723 -0.113423,0.0181 -0.224908,0.0545 -0.339843,0.0547 -0.109002,-1.9e-4 -0.21368,-0.0447 -0.322266,-0.0547 -0.06195,-0.006 -0.661292,-0.0285 -0.771484,-0.0156 z m -4.47461,0.13672 c 0.0013,0.0594 -0.0081,0.11957 0.0039,0.17774 0.0053,0.0253 0.03725,0.0381 0.04492,0.0625 0.0053,0.0166 -0.0067,0.035 -0.0098,0.0527 h 0.002 l 0.160156,0.0273 c 0.326362,0.0537 0.199153,0.0636 -0.201172,-0.32031 z m 0.03906,0.29297 -0.107422,-0.0176 c 0.01474,0.008 0.04927,0.1084 0.09961,0.0723 0.01474,-0.0113 0.0048,-0.0368 0.0078,-0.0547 z m -1.410157,-0.28711 c -0.274582,0.0193 -0.548632,0.0472 -0.820312,0.0879 0.07087,0.0215 0.13425,0.0656 0.205078,0.0879 0.05197,0.0163 0.108402,0.0186 0.16211,0.0274 l 0.267578,0.0449 c 0.0359,0.006 0.07736,4.1e-4 0.109375,0.0176 0.02268,0.0117 0.02421,0.0474 0.04492,0.0625 0.01814,0.0128 0.244599,0.0431 0.267579,0.043 0.05745,-0.002 0.115068,-0.0183 0.171875,-0.0273 0.05666,-0.008 0.113796,-0.0149 0.169922,-0.0273 0.07929,-0.0174 0.151426,-0.0655 0.232421,-0.0723 0.03628,-0.004 0.07167,0.0119 0.107422,0.0176 0.01776,0.003 0.03531,0.0147 0.05273,0.01 0.02457,-0.008 0.03996,-0.0374 0.06445,-0.0449 0.0016,-4.6e-4 0.03516,0.007 0.05273,0.01 -0.03742,-0.0159 -0.06179,-0.0533 -0.09766,-0.0723 -0.03213,-0.017 -0.283135,-0.046 -0.324219,-0.0527 -0.02684,-0.005 -0.05309,-0.0151 -0.08008,-0.0234 -0.02684,-0.008 -0.05381,-0.0134 -0.08008,-0.004 -0.01701,0.005 0.008,0.0493 -0.0098,0.0547 -0.03477,0.0102 -0.07167,-0.0115 -0.107422,-0.0176 l -0.107422,-0.0176 c -0.514771,-0.0847 0.116638,0.0422 -0.259765,-0.0996 -0.0068,-0.002 -0.01468,-0.002 -0.02148,-0.004 z m -1.005859,1.54688 c 0.08391,0.0876 0.175565,0.19225 0.294922,0.21289 l -0.1875,-0.19532 c -0.03591,-0.006 -0.132518,-0.0437 -0.107422,-0.0176 z m -0.779297,0.0391 c -0.149442,-0.0106 -0.299493,0.0302 -0.449218,0.0351 -0.240681,0.008 -0.427031,-0.0251 -0.66211,0.002 -0.06425,0.007 -0.164836,0.0345 -0.125,0.0898 0.01058,0.0155 0.03792,-0.003 0.05273,0.008 0.02079,0.0151 0.02224,0.0524 0.04492,0.0645 0.02192,0.0113 0.355939,0.0571 0.376954,0.0605 0.215168,0.0355 0.429116,0.0894 0.646484,0.10743 0.11006,0.0102 0.219943,-0.0109 0.330078,-0.002 0.132472,0.0117 0.51693,0.1148 0.654297,0.0527 0.09623,-0.0435 0.106168,-0.20583 0.205078,-0.24219 -0.360189,-0.0455 -0.711747,-0.14948 -1.074219,-0.17578 z m 1.394532,0.0351 c -0.01512,-0.002 -0.03938,0.003 -0.07813,0.0156 -0.08678,0.0268 -0.150583,0.13974 -0.240234,0.125 0.102652,-0.0367 0.213302,0.0526 0.322266,0.0527 0.01814,-9.2e-4 0.0048,-0.0349 0.0078,-0.0527 l 0.05469,0.008 c 0.139653,0.0231 -0.0087,0.0147 0.06055,-0.041 -0.01776,-0.002 -0.03697,-0.004 -0.05273,-0.0117 -0.061,-0.0321 -0.02849,-0.0898 -0.07422,-0.0957 z m 0.126953,0.10743 c 0.01852,0.002 0.0362,0.003 0.05469,0.006 0.01776,0.003 -0.03788,-0.0211 -0.05273,-0.01 -0.0021,0.002 6.1e-5,0.002 -0.002,0.004 z m 2.36914,0.71679 c -0.01701,0.005 0.0066,0.0423 -0.0078,0.0527 -0.01474,0.0113 -0.03726,-0.0127 -0.05469,-0.008 -0.06985,0.0215 -0.117654,0.1131 -0.1875,0.13476 -0.01739,0.005 -0.03749,-0.0151 -0.05469,-0.01 -0.01134,0.004 -0.01827,0.0147 -0.02734,0.0234 0.337436,-0.003 0.675831,0.0179 1.005859,0.082 l -0.02734,-0.16992 c 0.0029,-0.0174 0.01839,-0.0381 0.0078,-0.0527 -0.0053,-0.007 -0.01323,-0.0101 -0.02344,-0.008 -0.0098,-4.4e-4 -0.02218,-4.8e-4 -0.03125,-0.002 -0.01776,-0.003 -0.03554,-0.0131 -0.05273,-0.008 -0.02457,0.008 -0.03695,0.0408 -0.0625,0.0449 -0.0257,0.004 -0.340518,-0.0565 -0.376953,-0.0625 -0.0359,-0.006 -0.0728,-0.0278 -0.107422,-0.0176 z m -2.123047,0.14844 c -0.149858,0.002 -0.299413,0.0337 -0.449218,0.0371 -0.146495,0.003 -0.29314,-0.0248 -0.439454,-0.0176 -0.389846,0.0185 -0.22974,0.059 -0.509765,0.082 -0.09237,0.008 -0.185048,0.002 -0.277344,0.01 -0.01776,9.8e-4 0.03478,0.005 0.05273,0.008 0.05382,0.009 0.107684,0.0323 0.162109,0.0274 0.04044,-0.003 0.07705,-0.0307 0.117187,-0.0371 0.15035,-0.0238 0.419366,-0.0217 0.554688,-0.0176 0.164485,0.005 0.329822,0.0163 0.49414,0.0254 0.14933,-0.0121 0.297427,-0.0382 0.447266,-0.0371 0.200731,0.001 0.399038,0.0476 0.59961,0.0449 0.108623,-0.002 0.216426,-0.0165 0.324218,-0.0312 -0.04626,2.8e-4 -0.105322,-0.003 -0.261718,-0.0137 -0.711931,-0.0512 0.129582,-0.0908 -0.814454,-0.0801 z m 1.263672,0.043 c -0.293518,6.2e-4 -0.161397,0.0295 -0.125,0.0449 0.0774,-0.0106 0.154602,-0.0224 0.232422,-0.0273 -0.0359,-0.008 -0.07106,-0.0176 -0.107422,-0.0176 z m 0.107422,0.0176 c 0.01776,0.004 0.03478,0.005 0.05273,0.008 0.08969,0.0147 0.178559,0.0457 0.269532,0.0449 0.03942,5.7e-4 0.06452,-0.039 0.0957,-0.0664 -0.140145,10e-4 -0.27895,0.005 -0.417969,0.0137 z m 0.222656,0.96679 c 0.0052,0.0153 0.03785,0.0471 -0.390625,0.0547 -0.07283,0.002 -0.142087,-0.0329 -0.214843,-0.0351 -0.07495,-0.003 -0.149737,0.0195 -0.22461,0.0176 -0.0545,-0.001 -0.107835,-0.0265 -0.162109,-0.0254 -0.04018,10e-4 -0.07563,0.0284 -0.115235,0.0352 0.185273,0.0265 -0.114669,-0.03 0.205079,0.0898 0.05117,0.0181 0.108402,0.0167 0.162109,0.0254 l 0.429688,0.0703 c 0.197215,0.0325 0.392317,0.085 0.591796,0.0977 0.16732,0.01 0.33443,-0.0285 0.501954,-0.0273 0.610216,0.004 0.459788,0.0842 1.048828,0.008 0.0257,-0.004 0.03903,-0.0364 0.0625,-0.0469 0.03704,-0.0166 0.07638,-0.0234 0.115234,-0.0352 0.08062,-0.042 0.16157,-0.083 0.242188,-0.125 -0.177865,-0.0333 -0.337405,0.0792 -0.509766,0.082 -0.108964,0.002 -0.21368,-0.0447 -0.322266,-0.0547 -1.057425,-0.041 0.175158,0.0267 -0.86914,-0.0859 -0.53345,-0.0576 -0.555963,-0.0602 -0.550782,-0.0449 z m 0.785157,1.29883 c -0.172347,0.004 -0.338538,0.0603 -0.509766,0.0801 -0.09199,0.0106 -0.186963,0.002 -0.279297,0.01 -0.05718,0.005 -0.1127,0.0228 -0.169922,0.0273 -0.01776,9.8e-4 -0.03531,-0.0127 -0.05273,-0.008 -0.02457,0.008 -0.08608,0.0328 -0.0625,0.043 0.08338,0.0359 0.177928,0.0302 0.267578,0.0449 0.08969,0.0147 0.179314,0.0339 0.269531,0.0449 1.219888,0.15617 1.106372,0.15317 2.232422,0.20117 0.274734,0.0117 0.549459,0.0144 0.824219,0.0254 0.164409,0.006 0.327699,0.0288 0.492187,0.0254 0.129336,-0.003 0.257875,-0.0316 0.386719,-0.043 -0.08564,-0.0121 -0.180348,-0.0269 -0.207031,-0.0371 -0.03742,-0.0159 -0.06159,-0.056 -0.09961,-0.0703 -0.0435,-0.017 -0.447907,-0.0741 -0.484376,-0.0801 -0.02268,-0.004 -0.09507,-0.0176 -0.166015,-0.0312 -0.07109,-0.0129 -0.140603,-0.0261 -0.15625,-0.0234 -0.0802,0.0129 -0.154791,0.0483 -0.232422,0.0723 l -0.537109,-0.0879 -0.539063,-0.0879 c -0.107641,-0.0178 -0.213566,-0.0447 -0.322265,-0.0527 -0.09233,-0.008 -0.184973,0.0154 -0.277344,0.008 -0.126652,-0.011 -0.24981,-0.0633 -0.376953,-0.0605 z m 3.398437,0.45117 c 0.04554,0.006 0.09585,0.0146 0.115234,0.0176 0.03591,0.006 -0.07114,-0.0214 -0.107421,-0.0176 -0.0029,2.4e-4 -0.0048,-3.1e-4 -0.0078,0 z m -0.292969,1.82618 c -0.08092,0.007 -0.152144,0.0594 -0.232421,0.0723 -0.03591,0.006 -0.07794,-0.0387 -0.107422,-0.0176 -0.01474,0.0113 0.005,0.0441 -0.0098,0.0547 -3.36e-4,2.4e-4 -0.16022,-0.0277 -0.162109,-0.0273 -0.04044,0.003 -0.07653,0.025 -0.115235,0.0371 -0.07767,0.0242 -0.153543,0.0529 -0.232422,0.0723 -0.247785,0.0612 -0.516146,0.11515 -0.78125,0.16602 0.195364,0.18448 0.407232,0.33278 0.632813,0.45312 0.355275,0.0242 -0.0745,0.009 0.775391,-0.0742 0.776167,-0.0759 0.0385,0.10187 0.673828,-0.0547 0.03934,-0.009 0.07521,-0.0287 0.115234,-0.0352 0.03591,-0.006 0.07291,0.0278 0.107422,0.0176 0.266457,-0.0826 -0.231298,-0.0165 0.179687,-0.082 0.01776,-0.003 0.03531,0.0147 0.05273,0.01 0.02457,-0.008 0.04164,-0.0299 0.0625,-0.0449 0.02079,-0.0144 0.06029,-0.0195 0.06445,-0.0449 0.01852,-0.1118 -0.07281,-0.0348 -0.09961,-0.0723 -0.01058,-0.0155 0.02413,-0.0422 0.0098,-0.0527 -0.0094,-0.008 -0.367882,-0.061 -0.376953,-0.0625 l -0.753906,-0.125 0.519531,-0.13477 c -0.08236,0.0268 -0.161721,-0.0219 -0.242187,-0.043 l 0.002,-0.002 c -0.02684,-0.006 -0.05471,-0.0128 -0.08203,-0.01 z m 3.802735,6.0957 c -0.68075,-0.0265 0.155896,0.0467 -0.394532,0.0469 -0.383576,8e-4 0.09735,-0.0867 -0.384765,-0.01 -0.0802,0.0129 -0.153052,0.0547 -0.232422,0.0723 -0.05613,0.0121 -0.117575,0.004 -0.169922,0.0273 -0.01663,0.007 -0.0067,0.0349 -0.0098,0.0527 -0.0029,0.0174 -0.0184,0.0399 -0.0078,0.0547 0.01058,0.0155 0.03493,0.007 0.05273,0.01 l 0.05469,0.008 0.267578,0.0449 0.324219,0.0527 c 0.143433,0.0234 0.284361,0.0661 0.429687,0.0703 0.207081,0.006 0.411951,-0.0621 0.619141,-0.0625 0.03628,5e-5 0.07159,0.0236 0.107422,0.0176 0.03439,-0.004 0.145169,-0.11806 0.1875,-0.13477 0.07559,-0.0299 0.15479,-0.0483 0.232422,-0.0723 l -0.861328,-0.14257 c -0.07174,-0.0117 -0.142088,-0.0329 -0.214844,-0.0352 z m 3.373047,1.32812 c -0.195629,0.0538 -0.360238,-0.0315 -0.556641,0.0195 -0.361398,0.0942 -0.372006,0.1166 -0.333984,0.11914 -0.03099,0.003 -0.06128,0.002 -0.185547,0.0176 -0.171251,0.0197 -0.340674,0.0466 -0.509766,0.0801 -0.03969,0.007 -0.07716,0.0311 -0.117187,0.0371 -0.01814,0.003 -0.03493,-0.0124 -0.05273,-0.01 -0.04025,0.007 -0.07712,0.0307 -0.117187,0.0371 -0.01814,0.003 -0.03478,-0.0128 -0.05273,-0.01 -0.04025,0.007 -0.07712,0.0287 -0.117187,0.0352 -0.01814,0.003 -0.03788,-0.0191 -0.05273,-0.008 -0.1296,0.0929 0.170002,0.0231 -0.07227,0.0977 -0.01701,0.005 -0.03983,-0.0191 -0.05469,-0.008 -0.01474,0.0113 -0.0048,0.035 -0.0078,0.0527 -0.0029,0.0174 -0.02073,0.0399 -0.0098,0.0547 0.01058,0.0155 0.03689,0.005 0.05469,0.008 l 0.107422,0.0176 0.269531,0.0449 c 0.186671,0.0306 0.17324,0.0416 0.384765,0.008 0.04025,-0.007 0.07667,-0.0336 0.117188,-0.0352 0.05439,-9.2e-4 0.106222,0.0345 0.160156,0.0254 0.06467,-0.0106 0.117061,-0.0608 0.179688,-0.0801 0.05488,-0.017 0.113796,-0.0153 0.169922,-0.0273 0.0398,-0.009 0.07475,-0.0318 0.115234,-0.0352 0.03628,-0.004 0.07305,0.0214 0.109375,0.0176 0.04044,-0.003 0.07566,-0.0268 0.115234,-0.0352 0.05613,-0.0121 0.113796,-0.0152 0.169922,-0.0273 0.0793,-0.0174 0.156744,-0.0483 0.234375,-0.0723 0.03874,-0.0113 0.07521,-0.0307 0.115235,-0.0371 0.01814,-0.003 0.03983,0.0211 0.05469,0.01 0.01474,-0.0113 0.01462,-0.0379 0.0078,-0.0547 -0.03364,-0.0844 -0.08297,-0.16153 -0.125,-0.24219 z m -4.041016,0.87891 c -0.08375,-0.006 -0.160571,0.01 -0.419922,0.0449 -0.113839,0.0155 -0.227239,0.0454 -0.341797,0.0547 -0.312567,0.0257 -0.312777,-0.0242 -0.607422,0.01 -0.04044,0.005 -0.07675,0.0341 -0.117187,0.0371 -0.03628,0.004 -0.07114,-0.0214 -0.107422,-0.0176 -0.04044,0.003 -0.07849,0.0234 -0.117187,0.0352 -0.03874,0.0113 -0.07653,0.0231 -0.115235,0.0352 -0.03874,0.0113 -0.08015,0.0185 -0.117187,0.0352 -0.02343,0.01 -0.08522,0.0349 -0.0625,0.0469 0.06436,0.034 0.143146,0.0231 0.214843,0.0352 l 0.376953,0.0625 0.53711,0.0879 c 0.05382,0.009 0.107495,0.0265 0.162109,0.0254 0.238829,-5.6e-4 0.169024,-0.0928 0.34961,-0.10742 0.03628,-0.004 0.0711,0.0213 0.107421,0.0176 0.04044,-0.003 0.07675,-0.0321 0.117188,-0.0352 0.03628,-0.004 0.07159,0.0236 0.107422,0.0176 0.02532,-0.004 0.03801,-0.0371 0.0625,-0.0449 0.03477,-0.0102 0.07291,0.0278 0.107422,0.0176 0.02457,-0.008 0.03903,-0.0344 0.0625,-0.0449 0.03704,-0.0166 0.07521,-0.0307 0.115234,-0.0371 0.01814,-0.003 0.04411,0.0238 0.05469,0.01 0.04388,-0.0607 0.0601,-0.13836 0.08984,-0.20703 -0.283842,-0.0467 -0.375558,-0.0703 -0.458984,-0.0781 z m -4.585937,0.79297 c 0.022,0.0123 0.05175,0.044 -0.22461,0.0762 -0.05427,0.007 -0.105807,-0.0284 -0.160156,-0.0254 -0.114671,0.006 -0.225551,0.041 -0.339844,0.0527 -0.09215,0.009 -0.186963,0.002 -0.279297,0.01 -0.05718,0.005 -0.1127,0.0248 -0.169922,0.0293 -0.01776,9.8e-4 -0.03784,-0.0211 -0.05273,-0.01 -0.01474,0.0113 0.0046,0.0423 -0.0098,0.0527 -0.01474,0.0113 -0.03972,-0.0191 -0.05469,-0.008 -0.0053,0.003 -0.02766,0.15842 -0.02539,0.16016 0.02948,0.0208 0.07428,0.002 0.107422,0.0176 0.03742,0.0159 0.05929,0.0593 0.09766,0.0723 0.06883,0.0231 0.1451,0.0231 0.216797,0.0352 l 0.267578,0.0449 c 0.233084,0.0384 0.463981,0.0943 0.699219,0.11524 0.07684,0.007 0.408622,-0.0183 0.501953,-0.0293 0.05703,-0.006 0.116921,-0.008 0.171875,-0.0254 0.06263,-0.0197 0.211092,-0.11241 0.294922,-0.11914 0.03628,-0.004 0.07291,0.0297 0.107422,0.0195 0.01701,-0.005 -0.0069,-0.0441 0.0078,-0.0547 0.01474,-0.0113 0.0398,0.0211 0.05469,0.01 0.01474,-0.0113 0.02413,-0.0441 0.0098,-0.0547 -0.02948,-0.0208 -0.07156,-0.0115 -0.107422,-0.0176 l -0.376953,-0.0625 c -0.03591,-0.006 -0.07605,0.001 -0.107422,-0.0176 -0.105638,-0.0608 -0.198154,-0.14138 -0.296875,-0.21289 -0.35811,-0.0589 -0.353915,-0.0701 -0.332031,-0.0586 z m 7.126953,1.06445 c -0.0013,6.7e-4 -0.0026,0.001 -0.0039,0.002 0.0013,0 0.0026,-10e-6 0.0039,0 z m -0.0039,0.002 c -0.109073,-5.2e-4 -0.219061,-0.006 -0.328125,0 -0.05722,0.002 -0.113115,0.0183 -0.169921,0.0273 -0.162218,0.0261 -0.220129,0.0389 -0.394532,0.0449 -0.363817,0.0125 -0.249468,-0.0156 -0.554687,0.0195 -0.05703,0.006 -0.115006,0.0103 -0.169922,0.0274 -0.02457,0.008 -0.08524,0.0297 -0.06445,0.0449 0.04411,0.0318 0.108289,0.0167 0.162109,0.0254 0.166337,0.0272 0.102916,0.0277 0.332031,0 0.05703,-0.006 0.112549,-0.0243 0.169922,-0.0273 0.985894,-0.0548 -0.239575,0.0252 0.601563,0.043 0.101215,0.003 0.10717,-0.0404 0.177734,-0.0801 0.07803,-0.0438 0.158953,-0.0838 0.238281,-0.125 z m 0.964844,1.20507 c -0.07495,-0.003 -0.14985,0.0158 -0.224609,0.0195 -0.472834,0.0261 -0.08562,-0.0231 -0.617188,0.0625 -0.05666,0.008 -0.113153,0.0183 -0.169922,0.0273 -0.05666,0.008 -0.112473,0.0273 -0.169921,0.0273 -0.05461,8.8e-4 -0.107496,-0.0261 -0.16211,-0.0254 -0.136138,2.8e-4 -0.27424,0.0599 -0.402344,0.0996 -0.07767,0.0242 -0.160334,0.0389 -0.234375,0.0723 -0.02343,0.01 -0.03801,0.0371 -0.0625,0.0449 -0.01701,0.005 -0.03788,-0.0211 -0.05273,-0.01 -0.01512,0.0113 0.005,0.0422 -0.0098,0.0527 -0.01474,0.0113 -0.03788,-0.0191 -0.05273,-0.008 -0.01474,0.0113 -0.02035,0.0401 -0.0098,0.0547 0.01058,0.0155 0.03987,-0.002 0.05469,0.008 0.145247,0.10518 -0.09249,0.0398 0.152344,0.0801 0.08156,0.0136 0.355563,0.0699 0.429687,0.0703 0.07295,1.6e-4 0.21288,-0.0331 0.28711,-0.0625 0.06089,-0.0242 0.117022,-0.0625 0.179687,-0.082 0.226583,-0.0703 0.134221,0.0189 0.392578,-0.0449 0.06365,-0.0155 0.117023,-0.0606 0.179688,-0.0801 0.21033,-0.0336 0.115745,-0.0112 0.287109,-0.0645 0.03874,-0.0113 0.07476,-0.0336 0.115234,-0.0351 0.05435,-9.3e-4 0.107685,0.0303 0.16211,0.0254 0.04415,-0.003 0.138895,-0.12404 0.1875,-0.13477 0.07321,-0.0162 0.149926,-0.0115 0.224609,-0.0176 -0.123023,-5.2e-4 -0.242412,-0.0426 -0.363281,-0.0644 v 0.002 c -0.04025,-0.008 -0.08043,-0.0153 -0.121094,-0.0176 z m 0.02344,2.54688 c -0.05749,4.1e-4 -0.113116,0.0183 -0.169922,0.0273 -0.09241,0.003 -0.184708,0.0105 -0.277344,0.01 -0.08973,-9.6e-4 -0.711404,-0.0326 -0.824219,-0.0254 -0.114746,0.008 -0.227504,0.0429 -0.341797,0.0547 -0.09215,0.009 -0.184707,0.008 -0.277343,0.008 -0.0223,3e-4 -0.102547,-0.0206 -0.107422,-0.0176 -0.08999,0.0645 0.09002,0.0669 0.09766,0.0723 0.02079,0.0151 0.02138,0.0523 0.04492,0.0625 0.05,0.0219 0.108251,0.0167 0.162109,0.0254 l 0.214844,0.0352 c 0.215169,0.0355 0.429022,0.0916 0.646484,0.10742 0.251037,0.0181 0.0871,-0.048 0.28711,-0.0644 0.03628,-0.004 0.07291,0.0297 0.107422,0.0195 0.01701,-0.005 -0.0069,-0.0441 0.0078,-0.0547 0.01474,-0.0113 0.03673,0.0128 0.05469,0.01 0.04025,-0.007 0.07521,-0.0307 0.115234,-0.0371 0.04006,-0.007 0.252259,0.0579 0.269531,0.0449 0.01474,-0.0113 -0.0028,-0.0401 0.0078,-0.0547 0.07903,-0.10912 0.03702,-0.0106 0.117187,-0.0352 0.04902,-0.0151 0.07485,-0.0788 0.125,-0.0898 0.07321,-0.0163 0.149926,-0.0115 0.22461,-0.0176 -0.124271,0.0204 -0.242828,-0.0367 -0.363282,-0.0645 -0.03999,-0.0106 -0.08035,-0.0149 -0.121093,-0.0156 z m -4.552735,0.35547 c -0.07166,0.0246 -0.149004,0.0387 -0.214843,0.0762 -0.344958,0.12219 -0.685391,0.26201 -1.044922,0.32422 0.0709,0.0129 0.143463,0.0227 0.158203,0.0254 l 0.05469,0.01 c 0.01776,0.003 0.03749,0.0131 0.05469,0.008 0.02457,-0.008 0.03706,-0.0388 0.0625,-0.043 0.06032,-0.01 0.154522,0.0448 0.214844,0.0352 0.04025,-0.007 0.07712,-0.0307 0.117187,-0.0371 0.01814,-0.003 0.03554,0.0151 0.05273,0.01 0.02419,-0.008 0.168565,-0.11458 0.1875,-0.13476 0.02759,-0.0299 0.03919,-0.0758 0.07227,-0.0996 0.01474,-0.0113 0.03788,0.0211 0.05273,0.01 0.02872,-0.0208 -0.01039,-0.0858 0.01758,-0.10547 0.07189,-0.0253 0.142314,-0.0532 0.214843,-0.0762 z m -2.78125,0.29492 c -0.06244,0.0163 -0.123273,0.0334 -0.189453,0.0527 0.156473,0.006 0.213739,0.0544 0.490234,0.0742 0.07487,0.005 0.149813,-0.0134 0.22461,-0.0176 0.09252,-0.005 0.185312,9.9e-4 0.277344,-0.01 0.04044,-0.005 0.07479,-0.0341 0.115234,-0.0371 0.0556,-0.005 0.219377,0.0524 0.269531,0.0449 0.02797,-0.005 0.05351,-0.0159 0.08008,-0.0254 -0.09506,-0.0253 -0.190542,-0.0586 -0.287109,-0.0644 -0.202696,-0.0136 -0.406297,0.0154 -0.609375,0.01 -0.124384,-0.003 -0.247087,-0.0168 -0.371094,-0.0273 z m 1.267578,0.082 c 0.08375,0.0215 0.168237,0.0394 0.251953,0.0254 0,0 0,-0.002 0,-0.002 -0.09523,-0.0169 -0.193114,-0.0375 -0.214843,-0.0352 -0.01247,0.002 -0.02464,0.006 -0.03711,0.0117 z m 7.460938,1.87305 c -0.01701,0.005 0.005,0.0421 -0.0098,0.0527 -0.01474,0.0113 -0.03777,-0.0191 -0.05273,-0.008 -0.01512,0.0113 -0.02035,0.0399 -0.0098,0.0547 0.01058,0.0155 0.03673,0.005 0.05469,0.008 l 0.107422,0.0176 c 0.07174,0.0117 0.145262,0.0136 0.214843,0.0351 0.07177,0.0215 0.13488,0.0697 0.207032,0.0899 0.08753,0.0242 0.177927,0.0281 0.267578,0.043 l 0.216797,0.0371 c 0.05382,0.009 0.107205,0.0384 0.160156,0.0254 0.08829,-0.0219 0.152537,-0.13974 0.242187,-0.125 l -0.591796,-0.0977 -0.269532,-0.0449 -0.429687,-0.0703 c -0.01776,-0.003 -0.03666,-0.009 -0.05469,-0.0137 -0.01814,-0.005 -0.03539,-0.009 -0.05273,-0.004 z m 1.398437,0.23047 c 0.136555,0.0223 0.22447,0.16362 0.34961,0.22265 0.01663,0.007 -0.005,-0.0423 0.0098,-0.0527 0.01474,-0.0113 0.03788,0.0191 0.05273,0.008 0.01474,-0.0113 0.0067,-0.035 0.0098,-0.0527 0.0029,-0.0174 0.01877,-0.0401 0.0078,-0.0547 -0.0057,-0.009 -0.18113,-0.0295 -0.214844,-0.0352 z m -2.076172,1.61132 c -0.03024,0.005 -0.03845,0.009 -0.125,0.0156 -0.01776,0.001 -0.0398,-0.0211 -0.05469,-0.01 0.02079,0.004 0.0746,0.0902 0.03711,0.11719 -0.01474,0.0113 -0.0398,-0.0211 -0.05469,-0.01 -0.01474,0.0113 0.0096,0.0494 -0.0078,0.0547 -0.1889,-0.031 -0.04012,-0.0343 -0.171875,0.0254 -0.03704,0.0166 -0.148191,0.0133 -0.115234,0.0371 0.05889,0.0426 0.143146,0.0231 0.214844,0.0352 l 0.269531,0.0449 0.859375,0.14063 0.753906,0.125 0.107422,0.0176 c 0.05382,0.009 0.108289,0.0364 0.162109,0.0273 0.01285,-0.002 0.01481,-0.14828 0.02539,-0.16211 0.01512,-0.0208 0.04738,-0.0241 0.0625,-0.0449 0.02721,-0.0374 4.55e-4,-0.0985 -0.03516,-0.11719 -0.03213,-0.017 -0.07428,-0.002 -0.107422,-0.0176 -0.03742,-0.0159 -0.06374,-0.0514 -0.09961,-0.0703 -0.03477,-0.0174 -0.180639,-0.0254 -0.214844,-0.0371 -0.07045,-0.0232 -0.136876,-0.0584 -0.205078,-0.0879 h -0.002 c -0.265796,0.0519 -0.49832,-0.0513 -0.759766,-0.0703 -0.09233,-0.008 -0.186812,0.0147 -0.279297,0.01 -0.165316,-0.009 -0.234291,-0.0174 -0.259766,-0.0234 z m -3.447265,4.60547 c -0.143055,0.11263 -0.286549,0.22542 -0.429688,0.33789 l -0.316406,0.13868 c 0.105789,-0.009 0.20874,-0.038 0.314453,-0.0488 0.245027,-0.0253 0.272695,0.007 0.501953,-0.0293 0.04025,-0.007 0.07716,-0.0291 0.117188,-0.0352 0.0359,-0.006 0.07291,0.0278 0.107422,0.0176 0.02457,-0.008 0.03903,-0.0342 0.0625,-0.0449 0.03704,-0.0166 0.07642,-0.0234 0.115234,-0.0352 0.03874,-0.0113 0.07667,-0.0356 0.117188,-0.0371 0.05439,-9.2e-4 0.105542,0.0281 0.160156,0.0273 0.05749,-4.1e-4 0.114615,-0.0228 0.171875,-0.0273 0.09233,-0.008 0.185274,8e-4 0.277344,-0.01 0.0404,-0.005 0.07479,-0.0321 0.115234,-0.0352 0.04766,-0.004 0.23612,0.0533 0.269531,0.043 0.02457,-0.008 0.03805,-0.0354 0.0625,-0.043 0.01701,-0.005 0.03983,0.0191 0.05469,0.008 0.01474,-0.0113 -0.0069,-0.0421 0.0078,-0.0527 0.07378,-0.053 0.161608,-0.085 0.242188,-0.12695 v -0.002 c -0.517043,0.0295 -0.0315,-0.008 -0.609375,0.0117 -0.167433,0.006 -0.334528,0.0338 -0.501953,0.0274 -0.272958,-0.0106 -0.543552,-0.045 -0.814453,-0.0801 -0.0083,-10e-4 -0.01745,-0.003 -0.02539,-0.004 z"
-         style="fill:#d3d3d3;fill-opacity:1;stroke:none;stroke-width:0.30836901px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path1367" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path1414"
-         d="m 22.262676,-71.753525 c -0.04062,0.100045 -0.09023,0.196887 -0.121859,0.300117 -0.0028,0.0092 0.01898,0.0031 0.02845,0.0047 0.222018,0.03654 -0.05548,1.1e-4 0.175466,-3.58e-4 0.02884,4.7e-5 0.05693,0.0094 0.08539,0.01405 0.02848,0.0047 0.05693,0.0094 0.08539,0.01405 0.08539,0.01405 0.170781,0.02811 0.25617,0.04216 0.02845,0.0047 0.05656,0.01505 0.08539,0.01405 0.02148,-6.18e-4 0.04018,-0.01735 0.06161,-0.0191 0.02687,-0.0022 0.10925,0.01798 0.142316,0.02342 0.01281,0.0021 0.0774,0.0086 0.08539,0.01405 0.02203,0.01595 0.02768,0.04773 0.04756,0.06629 0.110676,0.103334 -0.0073,-0.01415 0.109169,0.0472 0.01205,0.0062 0.01175,0.02678 0.02376,0.03315 0.03341,0.01761 0.106432,0.0079 0.142316,0.02342 0.01973,0.0085 0.03213,0.03025 0.05224,0.03783 0.05398,0.02037 0.116167,0.0095 0.170782,0.02811 0.02877,0.01 0.05192,0.03272 0.0807,0.04252 0.02733,0.0092 0.05693,0.0094 0.08539,0.01405 0.02848,0.0047 0.05693,0.0094 0.08539,0.01405 0.02845,0.0047 0.05656,0.01505 0.08539,0.01405 0.04297,-0.0014 0.08076,-0.0314 0.123222,-0.03818 0.0095,-0.0015 0.02065,0.01029 0.02845,0.0047 0.0078,-0.0056 -0.0031,-0.02286 0.0047,-0.02847 0.0078,-0.0056 0.01898,0.0031 0.02845,0.0047 0.05692,0.0094 0.113851,0.01874 0.170778,0.02811 0.0095,0.0015 0.01898,0.0031 0.02845,0.0047 0.0095,0.0015 0.02066,-7.73e-4 0.02845,0.0047 0.011,0.008 0.01276,0.02518 0.02379,0.03315 0.0078,0.0055 0.02063,-7.73e-4 0.02845,0.0047 0.011,0.008 0.01276,0.02518 0.02376,0.03315 0.0078,0.0055 0.02066,-7.73e-4 0.02848,0.0047 0.02203,0.01595 0.0235,0.05362 0.04756,0.06629 0.01703,0.009 0.03991,4.08e-4 0.05692,0.0094 0.01205,0.0062 0.01174,0.02683 0.02376,0.03315 0.01703,0.009 0.03891,0.0027 0.05693,0.0094 0.05824,0.0028 0.08542,0.05979 0.132948,0.08035 0.02256,0.0097 0.157512,0.01846 0.170781,0.02811 0.02203,0.01595 0.02553,0.05036 0.04755,0.06629 0.0078,0.0055 0.02066,-7.73e-4 0.02845,0.0047 0.02089,0.01513 0.02667,0.05117 0.04756,0.06629 0.04623,0.03351 0.01671,-0.04074 0.05224,0.03783 0.0089,0.01958 0.0065,0.04415 0.01908,0.06161 0.0056,0.0078 0.01998,1.55e-4 0.02848,0.0047 0.01901,0.01002 0.03322,0.02781 0.05224,0.03783 0.0085,0.0045 0.02066,-7.73e-4 0.02845,0.0047 0.011,0.008 0.01276,0.02518 0.02376,0.03315 0.01558,0.01128 0.04571,-0.0063 0.05693,0.0094 0.0056,0.0078 -0.01028,0.02065 -0.0047,0.02847 0.0056,0.0078 0.02066,-7.73e-4 0.02845,0.0047 0.011,0.008 0.01586,0.02214 0.02376,0.03315 0.0079,0.01107 0.01818,0.02074 0.02376,0.03315 0.0089,0.01958 0.0065,0.04415 0.01911,0.06161 0.01253,0.01746 0.03652,0.02319 0.05224,0.03783 0.0099,0.0093 0.01975,0.02016 0.02376,0.03315 0.0028,0.0092 -0.01247,0.0228 -0.0047,0.02847 0.01558,0.01128 0.03991,4.08e-4 0.05693,0.0094 0.02407,0.01268 0.02553,0.05036 0.04756,0.0663 0.01558,0.01128 0.04572,-0.0063 0.05693,0.0094 0.0056,0.0078 -0.0075,0.01928 -0.0047,0.02847 0.03973,0.128204 0.0032,-0.03075 0.05224,0.03783 0.0056,0.0078 -0.01028,0.02065 -0.0047,0.02847 0.0492,0.06858 0.01237,-0.0904 0.05224,0.03783 0.0028,0.0092 -0.01027,0.02065 -0.0047,0.02847 0.01253,0.01746 0.03652,0.02319 0.05224,0.03783 0.01988,0.01857 0.02553,0.05036 0.04756,0.06629 0.0078,0.0055 0.02286,-0.0031 0.02845,0.0047 0.0056,0.0078 -0.01028,0.02065 -0.0047,0.02847 0.0492,0.06859 0.01237,-0.09039 0.05224,0.03783 0.0028,0.0092 -0.0075,0.01928 -0.0047,0.02847 0.01529,0.04935 0.03227,0.01695 0.04756,0.06629 0.0025,0.0081 -0.01629,0.09897 -0.01874,0.113857 -0.0025,0.01489 -0.01375,0.106984 -0.01874,0.113847 -0.008,0.01101 -0.02517,0.01278 -0.03314,0.02378 -0.0056,0.0078 0.0031,0.02286 -0.0047,0.02847 -0.0078,0.0056 -0.02065,-0.01029 -0.02845,-0.0047 -0.0078,0.0056 0.0031,0.02286 -0.0047,0.02847 -0.0078,0.0056 -0.01932,-0.0074 -0.02845,-0.0047 -0.02599,0.008 -0.04032,0.03952 -0.0663,0.04756 -0.0092,0.0027 -0.01932,-0.0074 -0.02845,-0.0047 -0.01298,0.004 -0.02517,0.01278 -0.03313,0.02378 -0.0056,0.0078 0.0045,0.02559 -0.0047,0.02847 -0.01838,0.0057 -0.03855,-0.01506 -0.05692,-0.0094 -0.0092,0.0027 0.0031,0.02286 -0.0047,0.02847 -0.01747,0.01253 -0.04203,0.01026 -0.06161,0.0191 -0.0124,0.0056 -0.02016,0.01976 -0.03313,0.02379 -0.0092,0.0027 -0.02065,-0.01029 -0.02845,-0.0047 -0.0078,0.0056 0.0031,0.02286 -0.0047,0.02847 -0.0078,0.0056 -0.02065,-0.01029 -0.02845,-0.0047 -0.0078,0.0056 9.27e-4,0.02067 -0.0047,0.02847 -0.008,0.01101 -0.02212,0.01589 -0.03313,0.02378 -0.01106,0.0079 -0.02016,0.01976 -0.03317,0.02378 -0.02905,0.009 -0.06237,0.0019 -0.09007,0.01441 -0.0088,0.004 0.0045,0.02564 -0.0047,0.02847 -0.01838,0.0057 -0.03855,-0.01506 -0.05693,-0.0094 -0.0092,0.0027 0.0031,0.02286 -0.0047,0.02847 -0.129368,0.0928 -0.01419,-0.0091 -0.09007,0.01441 -0.01298,0.004 -0.02016,0.01976 -0.03314,0.02378 -0.0092,0.0027 -0.01932,-0.0074 -0.02845,-0.0047 -0.01298,0.004 -0.02016,0.01976 -0.03313,0.02379 -0.0092,0.0027 -0.01932,-0.0074 -0.02845,-0.0047 -0.01298,0.004 -0.02016,0.01976 -0.03313,0.02378 -0.07587,0.02349 0.03928,-0.0784 -0.09007,0.01441 -0.0078,0.0056 0.0041,0.02453 -0.0047,0.02847 -0.03443,0.08347 -0.08067,-0.002 -0.118539,0.0097 -0.01298,0.004 -0.02016,0.01976 -0.03313,0.02378 -0.01838,0.0057 -0.0413,-0.02058 -0.05693,-0.0094 -0.0078,0.0056 0.0045,0.02564 -0.0047,0.02847 -0.01837,0.0057 -0.03794,-0.01241 -0.05692,-0.0094 -0.01339,0.002 -0.02016,0.01976 -0.03313,0.02378 -0.0092,0.0027 -0.01932,-0.0074 -0.02845,-0.0047 -0.01298,0.004 -0.02016,0.01976 -0.03313,0.02379 -0.01817,0.0056 -0.06473,-0.01739 -0.08539,-0.01405 -0.04246,0.0068 -0.08036,0.03465 -0.123222,0.03819 -0.01916,0.0015 -0.03794,-0.01241 -0.05693,-0.0094 -0.01339,0.002 -0.02212,0.01589 -0.03313,0.02379 -0.02055,0.0064 -0.04038,0.0157 -0.06161,0.0191 -0.019,0.003 -0.03855,-0.01506 -0.05693,-0.0094 -0.01298,0.004 -0.02016,0.01976 -0.03314,0.02378 -0.0092,0.0027 -0.01932,-0.0074 -0.02848,-0.0047 -0.01297,0.004 -0.02016,0.01976 -0.03313,0.02379 -0.0092,0.0027 -0.01932,-0.0074 -0.02845,-0.0047 -0.013,0.004 -0.02016,0.01976 -0.03317,0.02378 -0.0092,0.0027 -0.01898,-0.0031 -0.02845,-0.0047 -0.02055,0.0064 -0.04254,0.0091 -0.06161,0.0191 -0.02413,0.01258 -0.04218,0.03498 -0.0663,0.04756 -0.01258,0.0065 -0.171864,0.05622 -0.184835,0.05729 -0.0626,0.0052 -0.05594,-0.03515 -0.118539,0.0097 -0.0078,0.0056 0.0031,0.02286 -0.0047,0.02847 -3.3e-5,2.6e-5 -0.08525,-0.01407 -0.08539,-0.01405 -0.01339,0.002 -0.01961,0.02267 -0.03313,0.02378 -0.02877,0.0024 -0.05664,-0.01642 -0.08539,-0.01405 -0.01352,9.27e-4 -0.02212,0.01589 -0.03313,0.02379 -0.01898,-0.0031 -0.03795,-0.0062 -0.05693,-0.0094 -0.04744,-0.0078 -0.09488,-0.01561 -0.142316,-0.02342 -0.0095,-0.0015 -0.01929,-0.0074 -0.02845,-0.0047 -0.01298,0.004 -0.02016,0.01976 -0.03313,0.02379 -0.0069,0.002 -0.107091,-0.01762 -0.113855,-0.01874 -0.05693,-0.0094 -0.11385,-0.01874 -0.170778,-0.02811 -0.113854,-0.01874 -0.227707,-0.03748 -0.341559,-0.05621 -0.0095,-0.0015 -0.01898,-0.0031 -0.02845,-0.0047 -0.0095,-0.0015 -0.02286,0.0031 -0.02845,-0.0047 -0.0056,-0.0078 0.0031,-0.01901 0.0047,-0.02847 0.0047,-0.02867 0.03075,-0.154174 0.02811,-0.170779 -0.0021,-0.0134 -0.01975,-0.02016 -0.02376,-0.03315 -0.0028,-0.0092 0.0063,-0.01897 0.0047,-0.02847 -0.0034,-0.02123 -0.0157,-0.04038 -0.01908,-0.06161 -0.0015,-0.0095 0.0031,-0.01901 0.0047,-0.02847 0.0031,-0.01901 0.0124,-0.03795 0.0094,-0.05693 -0.0021,-0.0134 -0.01975,-0.02016 -0.02376,-0.03315 -0.0057,-0.01838 0.01506,-0.03855 0.0094,-0.05693 -0.008,-0.02596 -0.0395,-0.04033 -0.04755,-0.06629 -0.0028,-0.0092 0.0075,-0.01928 0.0047,-0.02847 -0.004,-0.01298 -0.01975,-0.02016 -0.02376,-0.03315 -0.006,-0.01937 0.02474,-0.09449 0.01874,-0.113853 -0.004,-0.01298 -0.02164,-0.01969 -0.02376,-0.03315 -0.003,-0.01898 0.0124,-0.03795 0.0094,-0.05693 -0.0022,-0.01341 -0.01975,-0.02017 -0.02379,-0.03315 -0.0028,-0.0092 0.0063,-0.01897 0.0047,-0.02847 -0.0034,-0.02123 -0.0157,-0.04038 -0.01908,-0.0616 -0.0043,-0.02702 0.01838,-0.05837 0.01405,-0.08539 -0.0021,-0.0134 -0.02164,-0.01969 -0.02376,-0.03315 -0.003,-0.01898 0.01092,-0.03778 0.0094,-0.05693 -0.0018,-0.02144 -0.0157,-0.04038 -0.01908,-0.06161 -0.0033,-0.02065 0.01969,-0.06722 0.01405,-0.08539 -0.004,-0.01298 -0.01975,-0.02017 -0.02379,-0.03315 -0.0028,-0.0092 0.0075,-0.01928 0.0047,-0.02847 -0.004,-0.01298 -0.01975,-0.02016 -0.02376,-0.03315 -0.0028,-0.0092 0.0075,-0.01928 0.0047,-0.02847 -0.004,-0.01298 -0.01975,-0.02017 -0.02376,-0.03315 -0.0029,-0.0092 0.01028,-0.02065 0.0047,-0.02847 -0.01253,-0.01746 -0.04339,-0.01821 -0.05224,-0.03783 -0.0079,-0.01754 0.0062,-0.03797 0.0094,-0.05693 0.0015,-0.0095 0.01027,-0.02065 0.0047,-0.02847 -0.01253,-0.01746 -0.04338,-0.01826 -0.05224,-0.03783 -0.0079,-0.01754 0.0062,-0.03797 0.0094,-0.05692 0.0094,-0.05693 0.01874,-0.113858 0.02811,-0.170779 0.0031,-0.01901 0.0062,-0.03797 0.0094,-0.05693 0.0015,-0.0095 0.0063,-0.01897 0.0047,-0.02847 -0.0034,-0.02123 -0.01732,-0.04018 -0.01908,-0.06161 -0.0024,-0.02874 0.0094,-0.05693 0.01405,-0.08539 0.01093,-0.06642 0.02186,-0.132828 0.03279,-0.199244 0.01249,-0.0759 0.02498,-0.151803 0.03748,-0.227705 0.0011,-0.0068 0.02089,-0.10695 0.01874,-0.113852 -0.004,-0.01298 -0.01975,-0.02017 -0.02376,-0.03315 -0.0057,-0.01837 0.01506,-0.03855 0.0094,-0.05693 -0.004,-0.01298 -0.01975,-0.02016 -0.02376,-0.03315 -0.0057,-0.01837 0.01506,-0.03855 0.0094,-0.05693 -0.004,-0.01298 -0.01975,-0.02016 -0.02376,-0.03315 -0.0038,-0.01221 0.01891,-0.07862 0.01405,-0.08539 -0.0056,-0.0078 -0.02286,0.0031 -0.02845,-0.0047 -0.0056,-0.0078 0.0031,-0.01901 0.0047,-0.02847 0.0015,-0.0095 -0.0048,-0.03003 0.0047,-0.02847 0.0095,0.0015 -0.0031,0.01901 -0.0047,0.02847 0.01225,-0.04622 0.02456,-0.09246 0.03683,-0.138701"
-         style="fill:url(#linearGradient1422);fill-opacity:1;stroke:none;stroke-width:0.0815893px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-      <rect
-         ry="0.96645641"
-         rx="0.96645641"
-         y="-72.460014"
-         x="15.895628"
-         height="9.0284538"
-         width="12.481599"
-         id="rect1900-0"
-         style="fill:#adadad;fill-opacity:0.33847004;stroke:none;stroke-width:0.40000001;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:1" />
-    </g>
-    <g
-       transform="matrix(0.60420488,0,0,0.60420488,28.453814,317.94754)"
-       id="g1893">
-      <rect
-         ry="0.96645641"
-         rx="0.96645641"
-         y="-62.22197"
-         x="-39.054649"
-         height="9.0284538"
-         width="12.481599"
-         id="rect1900-36"
-         style="fill:#adadad;fill-opacity:1;stroke:none;stroke-width:0.40000001;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:1" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:#f1f1f1;fill-opacity:1;stroke:none;stroke-width:0.26458299px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m -37.610377,-57.345682 c 0.214357,-0.02363 1.97259,0.234693 1.97259,0.234693 l 0.992238,0.770755 -3.348667,0.483481 z"
-         id="path1652" />
-      <path
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc"
-         d="m -26.573049,-61.255514 v 4.265539 h -12.481599 l -0.03864,-3.468429 z"
-         style="fill:url(#linearGradient3886);fill-opacity:1;stroke:none;stroke-width:0.40000001;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:1"
-         id="path1642" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path1631"
-         style="fill:#1d1d1d;fill-opacity:1;stroke:none;stroke-width:0.26458299px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m -39.054494,-59.001664 v 4.13308 l 1.278474,-0.03824 0.192236,-1.398881 -0.26665,-1.489313 z" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:#f1f1f1;fill-opacity:1;stroke:none;stroke-width:0.26458299px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m -39.054494,-54.868585 1.278474,-0.03824 h 1.248806 l -2.527434,0.729167 z"
-         id="path1637"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:#1d1d1d;fill-opacity:1;stroke:none;stroke-width:0.26458299px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m -34.624311,-58.773695 0.263755,-1.147451 0.193305,1.30207 -0.188989,0.980377 z"
-         id="path1646" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path1648"
-         d="m -37.38966,-59.101998 0.684595,-1.147451 0.501737,1.30207 -0.490534,0.980377 z"
-         style="fill:#1d1d1d;fill-opacity:1;stroke:none;stroke-width:0.42626399px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:#1d1d1d;fill-opacity:1;stroke:none;stroke-width:0.42626399px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m -27.962664,-57.867557 -0.967963,-0.921064 1.380719,-0.201844 0.847864,0.694902 z"
-         id="path1650" />
-    </g>
-    <path
-       inkscape:connector-curvature="0"
-       d="m 9.8336081,268.21846 c -2.7103641,0 -4.8930192,2.17574 -4.9061603,4.8829 0.00645,0.31783 0.2634822,0.57206 0.5829102,0.57206 h 6.373771 c 0.323501,0 0.583944,-0.26044 0.583944,-0.58394 v -4.28708 c 0,-0.3235 -0.260443,-0.58394 -0.583944,-0.58394 z"
-       style="fill:url(#linearGradient1803);fill-opacity:1;stroke:none;stroke-width:0.24168311;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:1"
-       id="rect1793" />
-    <path
-       inkscape:connector-curvature="0"
-       d="m 9.8336081,268.21846 c -1.9115487,0 -3.5573279,1.08414 -4.3682086,2.67167 l 7.0026735,-0.0165 v -2.07119 c 0,-0.3235 -0.260442,-0.58394 -0.583944,-0.58394 z"
-       style="opacity:0.3929;fill:url(#radialGradient1861);fill-opacity:1;stroke:none;stroke-width:0.24168311;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:1"
-       id="rect1809" />
-    <g
-       transform="matrix(0.60420488,0,0,0.60420488,-2.2100486,312.76254)"
-       id="g1779">
-      <path
-         inkscape:connector-curvature="0"
-         transform="matrix(0.43790333,0,0,0.43790333,3.6664976,-82.416534)"
-         d="m 21.005859,88.806641 c -1.222683,0 -2.207031,0.984348 -2.207031,2.207031 v 1.771484 C 20.050664,101.82616 27.750274,108.75 37.146484,108.75 h 9.533204 c 0.383405,-0.39666 0.621093,-0.93541 0.621093,-1.5332 V 91.013672 c 0,-1.222683 -0.982395,-2.207031 -2.205078,-2.207031 z"
-         style="fill:#adadad;fill-opacity:1;stroke:none;stroke-width:0.91344398;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:1"
-         id="rect1673" />
-      <path
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc"
-         id="path1677"
-         d="m 17.294018,-41.408957 1.091924,-0.08294 1.218358,0.06163 -1.180483,0.08341 z"
-         style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.424254;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.424254;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         d="m 14.983736,-41.387647 1.091924,-0.08294 1.218358,0.06163 -1.180483,0.08341 z"
-         id="path1679"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc"
-         id="path1681"
-         d="m 12.253068,-41.729055 1.091924,-0.08294 1.218358,0.06163 -1.180483,0.08341 z"
-         style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.424254;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.424254;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         d="m 11.884711,-41.026371 1.091924,-0.08294 1.218358,0.06163 -1.180483,0.08341 z"
-         id="path1683"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc"
-         id="path1685"
-         d="m 19.288268,-41.13937 1.091924,-0.08294 1.218358,0.06163 -1.180483,0.08341 z"
-         style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.424254;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.424254;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         d="m 20.23096,-41.596687 1.091924,-0.08294 1.218358,0.06163 -1.180483,0.08341 z"
-         id="path1687"
-         sodipodi:nodetypes="ccccc" />
-      <g
-         id="g1709">
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1689"
-           d="m 12.846087,-40.227186 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 14.244018,-40.435874 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1691"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1693"
-           d="m 15.852941,-39.971117 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 16.719505,-40.428528 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1695"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1697"
-           d="m 19.854061,-40.512011 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 12.034768,-39.853122 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1699"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1701"
-           d="m 18.548553,-39.94667 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 20.350432,-39.361987 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1703"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1705"
-           d="m 22.228168,-40.583295 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 22.902081,-40.098605 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1707"
-           sodipodi:nodetypes="ccccc" />
-      </g>
-      <g
-         id="g1731"
-         transform="translate(0.055571,1.087924)"
-         style="fill:#ffffff;fill-opacity:0.07814349">
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 12.846087,-40.227186 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1711"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1713"
-           d="m 14.244018,-40.435874 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 15.852941,-39.971117 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1715"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1717"
-           d="m 16.719505,-40.428528 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 19.854061,-40.512011 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1719"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1721"
-           d="m 12.034768,-39.853122 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 18.548553,-39.94667 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1723"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1725"
-           d="m 20.350432,-39.361987 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 22.228168,-40.583295 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1727"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1729"
-           d="m 22.902081,-40.098605 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-      </g>
-      <g
-         style="fill:#ffffff;fill-opacity:0.23629402"
-         transform="translate(0.06222562,2.8464061)"
-         id="g1753">
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 14.244018,-40.435874 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1735"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1737"
-           d="m 15.852941,-39.971117 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 16.719505,-40.428528 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1739"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1741"
-           d="m 19.854061,-40.512011 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1745"
-           d="m 18.548553,-39.94667 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 20.350432,-39.361987 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1747"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1749"
-           d="m 22.228168,-40.583295 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 22.902081,-40.098605 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1751"
-           sodipodi:nodetypes="ccccc" />
-      </g>
-      <path
-         inkscape:connector-curvature="0"
-         id="path1755"
-         style="fill:#ffffff;fill-opacity:0.03830872;stroke:none;stroke-width:0.264999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         d="m 24.422015,-41.144888 -0.425814,0.0832 0.4408,0.06201 0.460437,-0.08371 z m -2.374015,0.07131 -0.426331,0.0832 0.4408,0.06201 0.460954,-0.08372 z m -5.609993,0.07596 -0.426331,0.0832 0.4408,0.06201 0.460954,-0.0832 z m 2.4753,0.0078 -0.425813,0.08268 0.4408,0.06201 0.460437,-0.0832 z m -3.873148,0.201023 -0.426331,0.0832 0.4408,0.06201 0.460437,-0.0832 z m 10.055717,0.128672 -0.425814,0.0832 0.4408,0.06201 0.460437,-0.08371 z m -7.049182,0.127643 -0.425814,0.08268 0.4408,0.06201 0.460437,-0.0832 z m 2.695442,0.02429 -0.425813,0.0832 0.440799,0.06201 0.460438,-0.08371 z m -6.513297,0.09354 -0.426331,0.0832 0.4408,0.06201 0.460437,-0.08372 z m 8.315255,0.491443 -0.425814,0.08268 0.4408,0.06201 0.460437,-0.0832 z" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path1757"
-         style="fill:#ffffff;fill-opacity:0.38948604;stroke:none;stroke-width:1.00156999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         d="m 79.232422,-147.68555 -1.609375,0.31446 1.666015,0.23437 1.740235,-0.3164 z m -8.972656,0.26953 -1.611328,0.31446 1.666015,0.23437 1.742188,-0.3164 z m -21.203125,0.28711 -1.611329,0.31446 1.666016,0.23437 1.742188,-0.31445 z m 9.355468,0.0293 -1.609375,0.3125 1.666016,0.23438 1.740234,-0.31446 z m -13.441406,0.91602 v 0.18554 l 0.597656,-0.10742 z m 36.808594,0.33007 -1.609375,0.31446 1.666016,0.23437 1.740234,-0.3164 z m -26.642578,0.48243 -1.609375,0.3125 1.666015,0.23437 1.740235,-0.31445 z m 10.1875,0.0918 -1.609375,0.31446 1.666015,0.23437 1.740235,-0.31641 z m 6.810547,2.21094 -1.609375,0.3125 1.666015,0.23438 1.740235,-0.31446 z"
-         transform="scale(0.26458333)" />
-      <path
-         inkscape:connector-curvature="0"
-         transform="matrix(0.43790333,0,0,0.43790333,3.6664976,-82.416534)"
-         d="m 39.974609,106.02344 -0.970703,0.18945 1.00586,0.14258 1.050781,-0.19141 z m -5.419921,0.16211 -0.97461,0.1914 1.007813,0.14063 1.052734,-0.19141 z m -6.3125,0.30078 c 0.03406,0.0186 0.06738,0.0383 0.101562,0.0566 l 0.136719,-0.0254 z m 13.271484,0.64453 -0.972656,0.18945 1.007812,0.14258 1.050781,-0.19141 z m -9.941406,0.3457 -0.757813,0.14844 c 0.107445,0.0389 0.213895,0.0803 0.322266,0.11719 l 0.46875,0.0664 1.052734,-0.1914 z"
-         style="fill:#ffffff;fill-opacity:0.38948604;stroke:none;stroke-width:0.60515398;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         id="path1759" />
-      <path
-         inkscape:connector-curvature="0"
-         transform="matrix(0.43790333,0,0,0.43790333,3.6664976,-82.416534)"
-         d="m 45.720703,104.60938 -0.972656,0.18945 1.007812,0.14062 1.050782,-0.1914 z m -5.419922,0.1621 -0.974609,0.18946 1.005859,0.14258 1.052735,-0.19141 z m -12.8125,0.17383 -0.972656,0.18946 1.005859,0.14257 1.052735,-0.1914 z m 5.652344,0.0176 -0.970703,0.18945 1.005859,0.14063 1.050781,-0.18945 z m 14.119141,0.75195 -0.972657,0.19141 1.007813,0.14063 0.0059,-0.002 v -0.32422 z m -16.097657,0.29297 -0.972656,0.1875 1.007813,0.14258 1.050781,-0.19141 z m 6.15625,0.0547 -0.972656,0.18945 1.005859,0.14258 1.052735,-0.19141 z m 4.115235,1.33594 -0.972656,0.18945 1.005859,0.14063 1.050781,-0.18946 z"
-         style="fill:#ffffff;fill-opacity:0.38948604;stroke:none;stroke-width:0.60515398;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         id="path1761" />
-      <path
-         inkscape:connector-curvature="0"
-         transform="matrix(0.43790333,0,0,0.43790333,3.6664976,-82.416534)"
-         d="m 40.541016,107.32031 -0.970704,0.18946 1.00586,0.14257 1.050781,-0.1914 z m -5.419922,0.16211 -0.97461,0.19141 1.007813,0.14062 1.052734,-0.1914 z m 6.958984,0.94531 -0.972656,0.18946 0.939453,0.13281 h 0.121094 l 0.998047,-0.18164 z"
-         style="fill:#ffffff;fill-opacity:0.38948604;stroke:none;stroke-width:0.60515398;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         id="path1763" />
-      <g
-         id="g1777"
-         transform="translate(-0.06595615,-3.2566105)">
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cccccccccccccc"
-           id="path1765"
-           d="m 19.351426,-35.747819 c 0.114809,-0.03536 0.263727,0.02423 0.284833,0.165198 0.147138,-0.04147 0.241384,0.150992 0.325592,0.219169 l -0.8524,0.03612 c -0.756955,0.123752 -1.26554,0.647059 -2.49549,0.0099 -0.379032,-0.02204 -0.829317,-0.100418 -1.291637,-0.188298 l 0.894475,-0.383789 c -0.07266,-0.381309 -0.213755,-0.747738 -0.545756,-1.072653 -0.104507,-0.09177 -0.229885,-0.161374 -0.338248,-0.126124 l -1.265543,0.438534 c 0.796399,-0.380798 1.336705,-0.938733 2.777425,-0.873858 0.212994,0.01338 0.278249,0.153653 0.34303,0.252653 l 0.565731,0.900578 z"
-           style="fill:url(#linearGradient3888);fill-opacity:1;stroke:none;stroke-width:0.05;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:url(#linearGradient3890);fill-opacity:1;stroke:none;stroke-width:0.05;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 19.402935,-35.560371 c 0.240401,-0.07405 0.397731,0.06641 0.558916,0.196919 l -0.8524,0.03612 c -0.756955,0.123752 -1.26554,0.647059 -2.49549,0.0099 -0.379032,-0.02204 -0.829317,-0.100418 -1.291637,-0.188298 l 0.894475,-0.383789 c -0.07266,-0.381309 -0.213755,-0.747738 -0.545756,-1.072653 -0.104507,-0.09177 -0.229885,-0.161374 -0.338248,-0.126124 l -1.265543,0.438534 c 0.796399,-0.380798 1.336705,-0.938733 2.777425,-0.873858 0.212994,0.01338 0.278249,0.153653 0.34303,0.252653 l 0.565731,0.900578 z"
-           id="path1767"
-           sodipodi:nodetypes="ccccccccccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccccccccccc"
-           id="path1769"
-           d="m 19.402935,-35.560371 c 0.240401,-0.07405 0.397731,0.06641 0.558916,0.196919 l -0.8524,0.03612 c -0.756955,0.123752 -1.26554,0.647059 -2.49549,0.0099 -0.379032,-0.02204 -0.829317,-0.100418 -1.291637,-0.188298 l 0.894475,-0.383789 c -0.07266,-0.381309 -0.213755,-0.747738 -0.545756,-1.072653 -0.104507,-0.09177 -0.229885,-0.161374 -0.338248,-0.126124 l -1.265543,0.438534 c 0.796399,-0.380798 1.336705,-0.938733 2.777425,-0.873858 0.212994,0.01338 0.278249,0.153653 0.34303,0.252653 l 0.565731,0.900578 z"
-           style="fill:url(#radialGradient1787);fill-opacity:1;stroke:none;stroke-width:0.05;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1771"
-           d="m 16.940372,-35.597325 c 0.577523,-0.11639 1.172383,-0.431079 1.715147,-0.149886 l 0.10847,-0.795483 -0.54513,0.09202 z"
-           style="fill:#9f9f9f;fill-opacity:1;stroke:none;stroke-width:0.26458299px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:url(#linearGradient3892);fill-opacity:1;stroke:none;stroke-width:0.05;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 19.351426,-35.747819 c 0.114809,-0.03536 0.263727,0.02423 0.284833,0.165198 0.147138,-0.04147 0.241384,0.150992 0.325592,0.219169 l -0.8524,0.03612 c -0.756955,0.123752 -1.26554,0.647059 -2.49549,0.0099 -0.379032,-0.02204 -0.829317,-0.100418 -1.291637,-0.188298 l 0.894475,-0.383789 c -0.07266,-0.381309 -0.213755,-0.747738 -0.545756,-1.072653 -0.104507,-0.09177 -0.229885,-0.161374 -0.338248,-0.126124 l -1.265543,0.438534 c 0.796399,-0.380798 1.336705,-0.938733 2.777425,-0.873858 0.212994,0.01338 0.278249,0.153653 0.34303,0.252653 l 0.565731,0.900578 z"
-           id="path1773"
-           sodipodi:nodetypes="cccccccccccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccccc"
-           id="path1775"
-           d="m 16.940372,-35.597325 c 0.441069,-0.285912 0.786602,-0.639697 1.466786,-0.755734 0.219864,-0.05227 0.209846,0.07698 0.156431,0.240493 l -0.447033,1.243465 c 0.777373,-0.484948 1.629873,-0.91218 2.156218,-1.589979 0.194172,-0.200111 -0.02268,-0.407236 -0.41634,-0.363355 -1.737259,0.0442 -2.155933,0.520356 -2.916062,1.22511 z"
-           style="fill:url(#linearGradient3894);fill-opacity:1;stroke:none;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
-    </g>
-    <path
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="csssscc"
-       d="m 12.468086,270.96794 v 2.12155 c 0,0.3235 -0.260436,0.58394 -0.583938,0.58394 H 5.51058 c -0.323501,0 -0.5839373,-0.26044 -0.5839373,-0.58394 v -2.20391 z"
-       style="opacity:0.35591401;fill:url(#radialGradient1874);fill-opacity:1;stroke:none;stroke-width:0.24168302;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:1"
-       id="rect1864" />
-    <path
-       inkscape:connector-curvature="0"
-       d="m 10.220878,270.89167 c -0.5959216,0 -1.2174535,0.45293 -1.7706642,0.6457 0.547946,-0.0366 1.1203167,-0.18695 1.4225246,0.034 -0.8229682,-0.0645 -1.2853773,0.49327 -1.7319472,0.77277 0.5545064,-0.22698 1.0408632,-0.29607 1.3841222,-0.37655 -0.3431376,0.1784 -0.8096223,0.25147 -0.9014121,0.64476 0.359741,-0.22626 0.7594298,-0.3769 1.2586052,-0.33939 -0.8147817,0.0703 -1.2936556,0.60752 -1.8524688,1.0338 0.6857066,-0.27358 1.1558823,-0.55474 2.0569813,-0.54516 l -0.03966,0.91171 h 0.766217 l 0.108655,-0.88392 c 0.510271,-0.12551 1.027886,0.0616 1.546171,0.27039 v -0.1174 c -0.404053,-0.29408 -0.823924,-0.56856 -1.498708,-0.52673 0.456402,-0.0765 0.968495,-0.001 1.498712,0.12333 v -0.14675 c -0.399078,-0.20182 -0.838494,-0.34626 -1.423465,-0.28351 0.411051,-0.0577 0.856756,-0.0873 1.423465,-0.0184 v -0.0784 c -0.614163,-0.28361 -1.245787,-0.44955 -1.811256,-0.44025 0.5906,-0.057 1.077079,-0.0984 1.757552,0.22294 -0.465821,-0.71788 -1.29342,-0.9288 -2.193426,-0.90298 z"
-       style="fill:#232323;fill-opacity:1;stroke:none;stroke-width:0.0302102;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path1877" />
-    <g
-       id="g2002"
-       transform="matrix(0.60420488,0,0,0.60420488,13.905847,294.50718)">
-      <path
-         inkscape:connector-curvature="0"
-         transform="matrix(0.43790333,0,0,0.43790333,-23.006401,-52.202673)"
-         d="m 81.509766,19.851562 c -1.026495,0.190302 -1.800782,1.082763 -1.800782,2.166016 v 16.203125 c 0,1.222683 0.984349,2.207031 2.207032,2.207031 h 24.089844 c 1.22268,0 2.20703,-0.984348 2.20703,-2.207031 V 36.884766 C 107.44581,27.324919 99.506085,19.851562 89.742188,19.851562 Z"
-         style="fill:#adadad;fill-opacity:1;stroke:none;stroke-width:0.91344398;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:1"
-         id="rect1895" />
-      <path
-         inkscape:connector-curvature="0"
-         transform="matrix(0.43790333,0,0,0.43790333,-23.006401,-52.202673)"
-         d="m 79.708984,23.375 v 14.845703 c 0,1.222683 0.984349,2.207031 2.207032,2.207031 h 24.089844 c 1.22268,0 2.20703,-0.984348 2.20703,-2.207031 V 36.884766 C 107.76578,31.312618 104.87927,26.461632 100.61328,23.375 Z"
-         style="fill:url(#linearGradient2004);fill-opacity:1;stroke:none;stroke-width:0.91344398;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:1"
-         id="path1897" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.424254;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         d="m 17.294018,-41.408957 1.091924,-0.08294 1.218358,0.06163 -1.180483,0.08341 z"
-         id="path1899"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc"
-         id="path1901"
-         d="m 14.983736,-41.387647 1.091924,-0.08294 1.218358,0.06163 -1.180483,0.08341 z"
-         style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.424254;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.424254;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         d="m 12.253068,-41.729055 1.091924,-0.08294 1.218358,0.06163 -1.180483,0.08341 z"
-         id="path1903"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc"
-         id="path1905"
-         d="m 11.884711,-41.026371 1.091924,-0.08294 1.218358,0.06163 -1.180483,0.08341 z"
-         style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.424254;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.424254;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         d="m 19.288268,-41.13937 1.091924,-0.08294 1.218358,0.06163 -1.180483,0.08341 z"
-         id="path1907"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         transform="matrix(0.43790333,0,0,0.43790333,-23.006401,-52.202673)"
-         d="m 101.23047,24.03125 -2.494142,0.189453 2.580082,0.140625 0.50976,-0.03516 c -0.10682,-0.09174 -0.20552,-0.191933 -0.31445,-0.28125 z"
-         style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.96882999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         id="path1909" />
-      <g
-         id="g1932">
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 12.846087,-40.227186 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1911"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1913"
-           d="m 14.244018,-40.435874 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 15.852941,-39.971117 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1915"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1917"
-           d="m 16.719505,-40.428528 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 19.854061,-40.512011 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1919"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1921"
-           d="m 12.034768,-39.853122 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 18.548553,-39.94667 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1923"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1925"
-           d="m 20.350432,-39.361987 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           transform="matrix(0.43790333,0,0,0.43790333,-23.006401,-52.202673)"
-           d="m 103.90625,26.414062 -0.60742,0.119141 0.80859,0.115235 c -0.0653,-0.07981 -0.1346,-0.155693 -0.20117,-0.234376 z"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.605156;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           id="path1928" />
-        <path
-           inkscape:connector-curvature="0"
-           transform="matrix(0.43790333,0,0,0.43790333,-23.006401,-52.202673)"
-           d="m 104.84766,27.638672 -0.01,0.002 0.0137,0.002 c -0.001,-0.0015 -0.003,-0.0024 -0.004,-0.0039 z"
-           style="fill:#ffffff;fill-opacity:0.25716098;stroke:none;stroke-width:0.605156;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           id="path1930" />
-      </g>
-      <g
-         style="fill:#ffffff;fill-opacity:0.07814349"
-         transform="translate(0.055571,1.087924)"
-         id="g1954">
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1934"
-           d="m 12.846087,-40.227186 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 14.244018,-40.435874 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1936"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1938"
-           d="m 15.852941,-39.971117 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 16.719505,-40.428528 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1940"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1942"
-           d="m 19.854061,-40.512011 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 12.034768,-39.853122 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1944"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1946"
-           d="m 18.548553,-39.94667 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 20.350432,-39.361987 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1948"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1950"
-           d="m 22.228168,-40.583295 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.07814349;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 22.902081,-40.098605 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1952"
-           sodipodi:nodetypes="ccccc" />
-      </g>
-      <g
-         id="g1976"
-         transform="translate(0.06222562,2.8464061)"
-         style="fill:#ffffff;fill-opacity:0.23629402">
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 12.846087,-40.227186 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1956"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1958"
-           d="m 14.244018,-40.435874 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 15.852941,-39.971117 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1960"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1962"
-           d="m 16.719505,-40.428528 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 19.854061,-40.512011 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1964"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1966"
-           d="m 12.034768,-39.853122 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 18.548553,-39.94667 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1968"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1970"
-           d="m 20.350432,-39.361987 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-           d="m 22.228168,-40.583295 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           id="path1972"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc"
-           id="path1974"
-           d="m 22.902081,-40.098605 0.426023,-0.08294 0.475352,0.06163 -0.460575,0.08341 z"
-           style="fill:#ffffff;fill-opacity:0.23629402;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598" />
-      </g>
-      <path
-         inkscape:connector-curvature="0"
-         d="m 24.422015,-41.144888 -0.425814,0.0832 0.4408,0.06201 0.460437,-0.08371 z m -2.374015,0.07131 -0.426331,0.0832 0.4408,0.06201 0.460954,-0.08372 z m -5.609993,0.07596 -0.426331,0.0832 0.4408,0.06201 0.460954,-0.0832 z m 2.4753,0.0078 -0.425813,0.08268 0.4408,0.06201 0.460437,-0.0832 z m -3.873148,0.201023 -0.426331,0.0832 0.4408,0.06201 0.460437,-0.0832 z m 10.055717,0.128672 -0.425814,0.0832 0.4408,0.06201 0.460437,-0.08371 z m -7.049182,0.127643 -0.425814,0.08268 0.4408,0.06201 0.460437,-0.0832 z m 2.695442,0.02429 -0.425813,0.0832 0.440799,0.06201 0.460438,-0.08371 z m -6.513297,0.09354 -0.426331,0.0832 0.4408,0.06201 0.460437,-0.08372 z m 8.315255,0.491443 -0.425814,0.08268 0.4408,0.06201 0.460437,-0.0832 z"
-         style="fill:#ffffff;fill-opacity:0.03830872;stroke:none;stroke-width:0.264999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         id="path1978" />
-      <path
-         inkscape:connector-curvature="0"
-         transform="scale(0.26458333)"
-         d="m 79.232422,-147.68555 -1.609375,0.31446 1.666015,0.23437 1.740235,-0.3164 z m -8.972656,0.26953 -1.611328,0.31446 1.666015,0.23437 1.742188,-0.3164 z m -21.203125,0.28711 -1.611329,0.31446 1.666016,0.23437 1.742188,-0.31445 z m 9.355468,0.0293 -1.609375,0.3125 1.666016,0.23438 1.740234,-0.31446 z m -13.441406,0.91602 v 0.18554 l 0.597656,-0.10742 z m 36.808594,0.33007 -1.609375,0.31446 1.666016,0.23437 1.740234,-0.3164 z m -26.642578,0.48243 -1.609375,0.3125 1.666015,0.23437 1.740235,-0.31445 z m 10.1875,0.0918 -1.609375,0.31446 1.666015,0.23437 1.740235,-0.31641 z m 6.810547,2.21094 -1.609375,0.3125 1.666015,0.23438 1.740235,-0.31446 z"
-         style="fill:#ffffff;fill-opacity:0.38948604;stroke:none;stroke-width:1.00156999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         id="path1980" />
-      <path
-         inkscape:connector-curvature="0"
-         transform="scale(0.26458333)"
-         d="m 80.019531,-136.01953 -1.609375,0.31445 1.666016,0.23438 1.740234,-0.31641 z m -8.972656,0.26953 -1.611328,0.31445 1.666015,0.23438 1.742188,-0.31641 z m -21.203125,0.28711 -1.611328,0.31445 1.666016,0.23438 1.742187,-0.31446 z m 9.355469,0.0293 -1.609375,0.3125 1.666015,0.23437 1.740235,-0.31445 z m -14.228516,0.8125 v 0.43164 l 1.384766,-0.25 z m 37.595703,0.43359 -1.609375,0.31445 1.666016,0.23438 1.740234,-0.31641 z m -26.642578,0.48242 -1.609375,0.3125 1.666016,0.23438 1.740234,-0.31446 z m 10.1875,0.0918 -1.609375,0.31445 1.666016,0.23438 1.740234,-0.31641 z m 6.810547,2.21094 -1.609375,0.3125 1.666016,0.23437 1.740234,-0.31445 z"
-         style="fill:#ffffff;fill-opacity:0.38948604;stroke:none;stroke-width:1.00156999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         id="path1982" />
-      <path
-         inkscape:connector-curvature="0"
-         transform="scale(0.26458333)"
-         d="m 89.529297,-138.36133 -1.609375,0.31445 1.666016,0.23438 1.740234,-0.31641 z m -8.972656,0.26953 -1.611329,0.31446 1.666016,0.23437 1.742188,-0.31641 z m -21.203125,0.28711 -1.611328,0.31446 1.666015,0.23437 1.742188,-0.31445 z m 9.355468,0.0293 -1.609375,0.3125 1.666016,0.23437 1.740234,-0.31445 z m -14.638672,0.75977 -1.611328,0.31445 1.666016,0.23437 1.740234,-0.31445 z m 38.00586,0.48632 -1.609375,0.31446 1.666015,0.23437 0.01172,-0.002 v -0.53711 z m -26.642578,0.48242 -1.609375,0.3125 1.666015,0.23438 1.740235,-0.31445 z m 10.1875,0.0918 -1.609375,0.31446 1.666015,0.23437 1.740235,-0.31641 z m -24.617188,0.35352 -1.611328,0.31445 1.666016,0.23438 1.740234,-0.31641 z m 31.427735,1.85742 -1.609375,0.3125 1.666015,0.23437 1.740235,-0.31445 z"
-         style="fill:#ffffff;fill-opacity:0.38948604;stroke:none;stroke-width:1.00156999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         id="path1984" />
-      <path
-         inkscape:connector-curvature="0"
-         transform="scale(0.26458333)"
-         d="m 80.957031,-133.87305 -1.609375,0.31446 1.666016,0.23437 1.740234,-0.3164 z m -8.972656,0.26953 -1.611328,0.31446 1.666015,0.23437 1.742188,-0.3164 z m -21.203125,0.28711 -1.611328,0.31446 1.666016,0.23437 1.742187,-0.31445 z m 9.355469,0.0293 -1.609375,0.3125 1.666015,0.23438 1.740235,-0.31446 z m -14.638672,0.75977 -0.171875,0.0332 c 0.08194,0.17475 0.167925,0.34771 0.27539,0.50586 l 1.691407,-0.30469 z m 38.005859,0.48632 -1.609375,0.31446 1.666016,0.23437 1.740234,-0.3164 z m -26.642578,0.48243 -1.609375,0.3125 1.666016,0.23437 1.740234,-0.31445 z m 10.1875,0.0918 -1.609375,0.31446 1.666016,0.23437 1.740234,-0.31641 z"
-         style="fill:#ffffff;fill-opacity:0.38948604;stroke:none;stroke-width:1.00156999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.26293598"
-         id="path1986" />
-      <g
-         transform="translate(-0.06595615,-3.2566105)"
-         id="g2000">
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:url(#linearGradient2006);fill-opacity:1;stroke:none;stroke-width:0.05;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 19.351426,-35.747819 c 0.114809,-0.03536 0.263727,0.02423 0.284833,0.165198 0.147138,-0.04147 0.241384,0.150992 0.325592,0.219169 l -0.8524,0.03612 c -0.756955,0.123752 -1.26554,0.647059 -2.49549,0.0099 -0.379032,-0.02204 -0.829317,-0.100418 -1.291637,-0.188298 l 0.894475,-0.383789 c -0.07266,-0.381309 -0.213755,-0.747738 -0.545756,-1.072653 -0.104507,-0.09177 -0.229885,-0.161374 -0.338248,-0.126124 l -1.265543,0.438534 c 0.796399,-0.380798 1.336705,-0.938733 2.777425,-0.873858 0.212994,0.01338 0.278249,0.153653 0.34303,0.252653 l 0.565731,0.900578 z"
-           id="path1988"
-           sodipodi:nodetypes="cccccccccccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccccccccccc"
-           id="path1990"
-           d="m 19.402935,-35.560371 c 0.240401,-0.07405 0.397731,0.06641 0.558916,0.196919 l -0.8524,0.03612 c -0.756955,0.123752 -1.26554,0.647059 -2.49549,0.0099 -0.379032,-0.02204 -0.829317,-0.100418 -1.291637,-0.188298 l 0.894475,-0.383789 c -0.07266,-0.381309 -0.213755,-0.747738 -0.545756,-1.072653 -0.104507,-0.09177 -0.229885,-0.161374 -0.338248,-0.126124 l -1.265543,0.438534 c 0.796399,-0.380798 1.336705,-0.938733 2.777425,-0.873858 0.212994,0.01338 0.278249,0.153653 0.34303,0.252653 l 0.565731,0.900578 z"
-           style="fill:url(#linearGradient2008);fill-opacity:1;stroke:none;stroke-width:0.05;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:url(#radialGradient2010);fill-opacity:1;stroke:none;stroke-width:0.05;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 19.402935,-35.560371 c 0.240401,-0.07405 0.397731,0.06641 0.558916,0.196919 l -0.8524,0.03612 c -0.756955,0.123752 -1.26554,0.647059 -2.49549,0.0099 -0.379032,-0.02204 -0.829317,-0.100418 -1.291637,-0.188298 l 0.894475,-0.383789 c -0.07266,-0.381309 -0.213755,-0.747738 -0.545756,-1.072653 -0.104507,-0.09177 -0.229885,-0.161374 -0.338248,-0.126124 l -1.265543,0.438534 c 0.796399,-0.380798 1.336705,-0.938733 2.777425,-0.873858 0.212994,0.01338 0.278249,0.153653 0.34303,0.252653 l 0.565731,0.900578 z"
-           id="path1992"
-           sodipodi:nodetypes="ccccccccccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#9f9f9f;fill-opacity:1;stroke:none;stroke-width:0.26458299px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           d="m 16.940372,-35.597325 c 0.577523,-0.11639 1.172383,-0.431079 1.715147,-0.149886 l 0.10847,-0.795483 -0.54513,0.09202 z"
-           id="path1994"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cccccccccccccc"
-           id="path1996"
-           d="m 19.351426,-35.747819 c 0.114809,-0.03536 0.263727,0.02423 0.284833,0.165198 0.147138,-0.04147 0.241384,0.150992 0.325592,0.219169 l -0.8524,0.03612 c -0.756955,0.123752 -1.26554,0.647059 -2.49549,0.0099 -0.379032,-0.02204 -0.829317,-0.100418 -1.291637,-0.188298 l 0.894475,-0.383789 c -0.07266,-0.381309 -0.213755,-0.747738 -0.545756,-1.072653 -0.104507,-0.09177 -0.229885,-0.161374 -0.338248,-0.126124 l -1.265543,0.438534 c 0.796399,-0.380798 1.336705,-0.938733 2.777425,-0.873858 0.212994,0.01338 0.278249,0.153653 0.34303,0.252653 l 0.565731,0.900578 z"
-           style="fill:url(#linearGradient2012);fill-opacity:1;stroke:none;stroke-width:0.05;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:url(#linearGradient2014);fill-opacity:1;stroke:none;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 16.940372,-35.597325 c 0.441069,-0.285912 0.786602,-0.639697 1.466786,-0.755734 0.219864,-0.05227 0.209846,0.07698 0.156431,0.240493 l -0.447033,1.243465 c 0.777373,-0.484948 1.629873,-0.91218 2.156218,-1.589979 0.194172,-0.200111 -0.02268,-0.407236 -0.41634,-0.363355 -1.737259,0.0442 -2.155933,0.520356 -2.916062,1.22511 z"
-           id="path1998"
-           sodipodi:nodetypes="ccccccc" />
-      </g>
-    </g>
-    <g
-       id="g2032"
-       transform="matrix(0.60420488,0,0,0.60420488,36.529569,305.79793)">
-      <rect
-         style="fill:#adadad;fill-opacity:1;stroke:none;stroke-width:0.40000001;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:1"
-         id="rect2016"
-         width="12.481599"
-         height="9.0284538"
-         x="-39.054649"
-         y="-62.22197"
-         rx="0.96645641"
-         ry="0.96645641" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path2018"
-         d="m -37.610377,-57.345682 c 0.214357,-0.02363 1.97259,0.234693 1.97259,0.234693 l 0.992238,0.770755 -3.348667,0.483481 z"
-         style="fill:#f1f1f1;fill-opacity:1;stroke:none;stroke-width:0.26458299px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path2020"
-         style="fill:url(#linearGradient2034);fill-opacity:1;stroke:none;stroke-width:0.40000001;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:1"
-         d="m -26.573049,-61.255514 v 4.265539 h -12.481599 l -0.03864,-3.468429 z"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         d="m -39.054494,-59.001664 v 4.13308 l 1.278474,-0.03824 0.192236,-1.398881 -0.26665,-1.489313 z"
-         style="fill:#1d1d1d;fill-opacity:1;stroke:none;stroke-width:0.26458299px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="path2022" />
-      <path
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc"
-         id="path2024"
-         d="m -39.054494,-54.868585 1.278474,-0.03824 h 1.248806 l -2.527434,0.729167 z"
-         style="fill:#f1f1f1;fill-opacity:1;stroke:none;stroke-width:0.26458299px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path2026"
-         d="m -34.624311,-58.773695 0.263755,-1.147451 0.193305,1.30207 -0.188989,0.980377 z"
-         style="fill:#1d1d1d;fill-opacity:1;stroke:none;stroke-width:0.26458299px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:#1d1d1d;fill-opacity:1;stroke:none;stroke-width:0.42626399px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m -37.38966,-59.101998 0.684595,-1.147451 0.501737,1.30207 -0.490534,0.980377 z"
-         id="path2028" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path2030"
-         d="m -27.962664,-57.867557 -0.967963,-0.921064 1.380719,-0.201844 0.847864,0.694902 z"
-         style="fill:#1d1d1d;fill-opacity:1;stroke:none;stroke-width:0.42626399px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-    </g>
-    <g
-       transform="matrix(1.0289394,0,0,1.0289394,-1.2680176,262.02235)"
-       id="g2178">
-      <path
-         d="m 30.695663,25.791679 a 6.8185558,6.8185558 0 0 1 -6.813051,6.818554 6.8185558,6.8185558 0 0 1 -6.824051,-6.807545 6.8185558,6.8185558 0 0 1 6.802034,-6.829544 6.8185558,6.8185558 0 0 1 6.835033,6.796519"
-         sodipodi:arc-type="arc"
-         sodipodi:open="true"
-         sodipodi:end="6.2799564"
-         sodipodi:start="0"
-         sodipodi:ry="6.8185558"
-         sodipodi:rx="6.8185558"
-         sodipodi:cy="25.791679"
-         sodipodi:cx="23.877108"
-         sodipodi:type="arc"
-         id="path1347"
-         style="fill:url(#radialGradient1363);fill-opacity:1;stroke:none;stroke-width:0.172612;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke" />
-      <g
-         id="g1820"
-         transform="matrix(0.06517044,0,0,0.06517044,-34.292512,1.0627905)">
-        <path
-           inkscape:connector-curvature="0"
-           id="path1809"
-           d="m 701.88733,263.56836 c -3.45538,0 -6.23691,1.32367 -6.23691,3.81503 0,0.58509 0.15779,1.07951 0.43734,1.49925 h -0.46097 v 195.02277 c 0,5.15552 4.15602,9.30638 9.31794,9.30638 h 328.73197 c 5.162,0 9.316,-4.15086 9.316,-9.30638 V 268.88264 h -1.4795 c 0.6947,-0.52476 1.1745,-1.17529 1.3042,-1.9754 0.4327,-2.67158 -2.7815,-3.33888 -6.237,-3.33888 z"
-           style="opacity:1;fill:#202020;fill-opacity:0.08791211;stroke:none;stroke-width:0.201599;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.13736303;paint-order:fill markers stroke" />
-        <path
-           style="opacity:1;fill:#202020;fill-opacity:0.08791211;stroke:none;stroke-width:0.203821;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.13736303;paint-order:fill markers stroke"
-           d="m 700.41202,263.10394 c -3.4878,0 -6.29544,1.34043 -6.29544,3.86333 0,0.5925 0.15927,1.09318 0.44144,1.51824 h -0.46529 v 197.4923 c 0,5.2208 4.19502,9.42422 9.40538,9.42422 h 331.81699 c 5.2105,0 9.4034,-4.20342 9.4034,-9.42422 v -197.4923 h -1.4933 c 0.7011,-0.5314 1.1855,-1.19017 1.3163,-2.00042 0.4368,-2.70541 -2.8076,-3.38115 -6.2954,-3.38115 z"
-           id="path1816"
-           inkscape:connector-curvature="0" />
-      </g>
-      <path
-         style="fill:url(#linearGradient825);fill-opacity:1;stroke:none;stroke-width:0.0130341;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.13736303;paint-order:fill markers stroke"
-         d="m 33.592349,18.583409 v 12.616803 c 0,0.333528 -0.268509,0.602037 -0.602032,0.602037 h -21.24043 c -0.333529,0 -0.602038,-0.268509 -0.602038,-0.602037 V 18.583409 Z"
-         id="rect817"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="csssscc" />
-      <path
-         style="fill:#c9c9c9;fill-opacity:1;stroke:none;stroke-width:0.0110352;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.13736303;paint-order:fill markers stroke"
-         d="m 11.55237,18.239662 h 21.62558 c 0.22326,0 0.430959,0.04311 0.403001,0.215948 -0.02796,0.172834 -0.304711,0.240836 -0.527972,0.240941 l -21.500609,0.01009 c -0.223264,1.3e-4 -0.403004,-0.05906 -0.403004,-0.220236 0,-0.161175 0.17974,-0.246746 0.403004,-0.246746 z"
-         id="rect837-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sszssss" />
-      <path
-         d="m 16.299076,18.405167 a 1.9749957,0.14138672 0 0 1 -1.973401,0.141386 1.9749957,0.14138672 0 0 1 -1.976588,-0.141158 1.9749957,0.14138672 0 0 1 1.970211,-0.141615 1.9749957,0.14138672 0 0 1 1.979768,0.14093"
-         style="fill:#0e0e0e;fill-opacity:0.747253;stroke:none;stroke-width:0.0130341;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.13736303;paint-order:fill markers stroke"
-         id="path908"
-         sodipodi:type="arc"
-         sodipodi:cx="14.32408"
-         sodipodi:cy="18.405167"
-         sodipodi:rx="1.9749957"
-         sodipodi:ry="0.14138672"
-         sodipodi:start="0"
-         sodipodi:end="6.2799564"
-         sodipodi:open="true"
-         sodipodi:arc-type="arc" />
-      <path
-         style="fill:#ffffff;fill-opacity:0.36813199;stroke:none;stroke-width:0.0110352;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.13736303;paint-order:fill markers stroke"
-         d="m 33.575522,18.396883 c -0.04613,0.157343 -0.30853,0.219977 -0.522511,0.220077 l -21.500642,0.01018 c -0.199301,1.3e-4 -0.363582,-0.04732 -0.396623,-0.172091 -0.004,0.01552 -0.0064,0.03174 -0.0064,0.04901 0,0.161175 0.179724,0.220336 0.402988,0.220205 l 21.500645,-0.01006 c 0.223261,-1.31e-4 0.500027,-0.06812 0.527985,-0.240952 0.0047,-0.02909 0.0022,-0.05422 -0.0055,-0.07637 z"
-         id="path841"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 16.242047,17.970943 a 1.9277488,0.10724217 0 0 1 -1.926192,0.107243 1.9277488,0.10724217 0 0 1 -1.929303,-0.107069 1.9277488,0.10724217 0 0 1 1.923078,-0.107415 1.9277488,0.10724217 0 0 1 1.932407,0.106895"
-         style="fill:url(#linearGradient886);fill-opacity:1;stroke:none;stroke-width:0.0106085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.13736303;paint-order:fill markers stroke"
-         id="path873-7"
-         sodipodi:type="arc"
-         sodipodi:cx="14.314299"
-         sodipodi:cy="17.970943"
-         sodipodi:rx="1.9277488"
-         sodipodi:ry="0.10724217"
-         sodipodi:start="0"
-         sodipodi:end="6.2799564"
-         sodipodi:open="true"
-         sodipodi:arc-type="arc" />
-      <path
-         style="fill:url(#linearGradient855);fill-opacity:1;stroke:none;stroke-width:0.0130341;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.13736303;paint-order:fill markers stroke"
-         d="m 16.242038,17.970597 v 0.352723 c 0,0.06482 -0.05235,0.11242 -0.117003,0.117002 -1.205017,0.0854 -2.410035,0.08038 -3.615052,0 -0.06467,-0.0043 -0.117002,-0.05218 -0.117002,-0.117002 v -0.352723 c 1.295481,0.0997 2.577123,0.08868 3.849057,0 z"
-         id="rect846"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="csssscc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:#ffffff;fill-opacity:0.29120902;stroke:none;stroke-width:0.0130341;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.13736303;paint-order:fill markers stroke"
-         d="m 12.392923,17.970601 v 0.03437 c 1.295481,0.0997 2.577195,0.08869 3.849129,0 v -0.03437 c -1.271934,0.08869 -2.553648,0.0997 -3.849129,0 z"
-         id="path875-5" />
-      <path
-         d="m 29.641558,24.669109 a 5.7796059,5.7796059 0 0 1 -5.774941,5.779604 5.7796059,5.7796059 0 0 1 -5.784264,-5.770273 5.7796059,5.7796059 0 0 1 5.765602,-5.78892 5.7796059,5.7796059 0 0 1 5.793573,5.760928"
-         sodipodi:open="true"
-         sodipodi:end="6.2799564"
-         sodipodi:start="0"
-         sodipodi:ry="5.7796059"
-         sodipodi:rx="5.7796059"
-         sodipodi:cy="24.669109"
-         sodipodi:cx="23.861952"
-         sodipodi:type="arc"
-         id="path1274"
-         style="fill:#696d6f;fill-opacity:1;stroke:none;stroke-width:0.16585401;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
-         sodipodi:arc-type="arc" />
-      <path
-         d="m 29.641558,24.88496 a 5.7796059,5.7796059 0 0 1 -5.774941,5.779604 5.7796059,5.7796059 0 0 1 -5.784264,-5.770273 5.7796059,5.7796059 0 0 1 5.765602,-5.78892 5.7796059,5.7796059 0 0 1 5.793573,5.760927"
-         style="fill:#c0c0bd;fill-opacity:1;stroke:none;stroke-width:0.16585401;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
-         id="path1127"
-         sodipodi:type="arc"
-         sodipodi:cx="23.861952"
-         sodipodi:cy="24.88496"
-         sodipodi:rx="5.7796059"
-         sodipodi:ry="5.7796059"
-         sodipodi:start="0"
-         sodipodi:end="6.2799564"
-         sodipodi:open="true"
-         sodipodi:arc-type="arc" />
-      <path
-         d="m 29.849856,25.576567 a 5.9879084,5.9879084 0 0 1 -5.983074,5.987906 5.9879084,5.9879084 0 0 1 -5.992735,-5.978239 5.9879084,5.9879084 0 0 1 5.9734,-5.997558 5.9879084,5.9879084 0 0 1 6.002378,5.968556"
-         style="fill:#e2e1e0;fill-opacity:1;stroke:#e2e0df;stroke-width:0.151584;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
-         id="path1101"
-         sodipodi:type="arc"
-         sodipodi:cx="23.861948"
-         sodipodi:cy="25.576567"
-         sodipodi:rx="5.9879084"
-         sodipodi:ry="5.9879084"
-         sodipodi:start="0"
-         sodipodi:end="6.2799564"
-         sodipodi:open="true"
-         sodipodi:arc-type="arc" />
-      <path
-         d="m 29.635537,25.576567 a 5.7735853,5.7735853 0 0 1 -5.768925,5.773583 5.7735853,5.7735853 0 0 1 -5.778238,-5.764262 5.7735853,5.7735853 0 0 1 5.759596,-5.78289 5.7735853,5.7735853 0 0 1 5.787537,5.754926"
-         style="fill:#e2e1e0;fill-opacity:1;stroke:#262626;stroke-width:0.13034099;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
-         id="path1099"
-         sodipodi:type="arc"
-         sodipodi:cx="23.861952"
-         sodipodi:cy="25.576567"
-         sodipodi:rx="5.7735853"
-         sodipodi:ry="5.7735853"
-         sodipodi:start="0"
-         sodipodi:end="6.2799564"
-         sodipodi:open="true"
-         sodipodi:arc-type="arc" />
-      <path
-         d="m 28.79281,25.576565 a 4.9308619,4.9308619 0 0 1 -4.926882,4.93086 4.9308619,4.9308619 0 0 1 -4.934836,-4.9229 4.9308619,4.9308619 0 0 1 4.918915,-4.938808 4.9308619,4.9308619 0 0 1 4.942777,4.914927"
-         sodipodi:arc-type="arc"
-         style="fill:url(#linearGradient1028);fill-opacity:1;stroke:#000000;stroke-width:0.0847216;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.9670333;paint-order:fill markers stroke"
-         id="path1020"
-         sodipodi:type="arc"
-         sodipodi:cx="23.861948"
-         sodipodi:cy="25.576565"
-         sodipodi:rx="4.9308619"
-         sodipodi:ry="4.9308619"
-         sodipodi:start="0"
-         sodipodi:end="6.2799564"
-         sodipodi:open="true" />
-      <path
-         d="m 28.2573,25.576565 a 4.3953524,4.3953524 0 0 1 -4.391804,4.395351 4.3953524,4.3953524 0 0 1 -4.398895,-4.388255 4.3953524,4.3953524 0 0 1 4.384703,-4.402436 4.3953524,4.3953524 0 0 1 4.405973,4.381148"
-         sodipodi:arc-type="arc"
-         style="fill:url(#linearGradient1040);fill-opacity:1;stroke:#1f1f1f;stroke-width:0.0953404;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.9670333;paint-order:fill markers stroke"
-         id="path1032"
-         sodipodi:type="arc"
-         sodipodi:cx="23.861948"
-         sodipodi:cy="25.576565"
-         sodipodi:rx="4.3953524"
-         sodipodi:ry="4.3953524"
-         sodipodi:start="0"
-         sodipodi:end="6.2799564"
-         sodipodi:open="true" />
-      <path
-         d="m 27.954797,25.576565 a 4.0928473,4.0928473 0 0 1 -4.089543,4.092846 4.0928473,4.0928473 0 0 1 -4.096146,-4.086239 4.0928473,4.0928473 0 0 1 4.08293,-4.099443 4.0928473,4.0928473 0 0 1 4.102738,4.07962"
-         sodipodi:arc-type="arc"
-         style="fill:#000000;fill-opacity:0.86263697;stroke:none;stroke-width:0.0970173;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.9670333;paint-order:fill markers stroke"
-         id="path1044"
-         sodipodi:type="arc"
-         sodipodi:cx="23.86195"
-         sodipodi:cy="25.576565"
-         sodipodi:rx="4.0928473"
-         sodipodi:ry="4.0928473"
-         sodipodi:start="0"
-         sodipodi:end="6.2799564"
-         sodipodi:open="true" />
-      <path
-         d="m 27.555678,25.576565 a 3.6937277,3.7114012 0 0 1 -3.690746,3.7114 3.6937277,3.7114012 0 0 1 -3.696705,-3.705408 3.6937277,3.7114012 0 0 1 3.684778,-3.717383 3.6937277,3.7114012 0 0 1 3.702653,3.699407"
-         sodipodi:arc-type="arc"
-         style="fill:url(#radialGradient918);fill-opacity:1;stroke:none;stroke-width:0.0145247;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.13736303;paint-order:fill markers stroke"
-         id="path910"
-         sodipodi:type="arc"
-         sodipodi:cx="23.86195"
-         sodipodi:cy="25.576565"
-         sodipodi:rx="3.6937277"
-         sodipodi:ry="3.7114012"
-         sodipodi:start="0"
-         sodipodi:end="6.2799564"
-         sodipodi:open="true" />
-      <path
-         d="m 27.555678,25.576565 a 3.6937277,3.7114012 0 0 1 -3.690746,3.7114 3.6937277,3.7114012 0 0 1 -3.696705,-3.705408 3.6937277,3.7114012 0 0 1 3.684778,-3.717383 3.6937277,3.7114012 0 0 1 3.702653,3.699407"
-         sodipodi:arc-type="arc"
-         sodipodi:open="true"
-         sodipodi:end="6.2799564"
-         sodipodi:start="0"
-         sodipodi:ry="3.7114012"
-         sodipodi:rx="3.6937277"
-         sodipodi:cy="25.576565"
-         sodipodi:cx="23.86195"
-         sodipodi:type="arc"
-         id="path1059"
-         style="fill:url(#linearGradient2180);fill-opacity:1;stroke:none;stroke-width:0.0145247;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.13736303;paint-order:fill markers stroke" />
-      <path
-         d="m 25.620973,25.688669 a 1.5552539,1.5552539 0 0 1 -1.553998,1.555254 1.5552539,1.5552539 0 0 1 -1.556507,-1.552743 1.5552539,1.5552539 0 0 1 1.551485,-1.55776 1.5552539,1.5552539 0 0 1 1.559012,1.550227"
-         sodipodi:arc-type="arc"
-         style="fill:url(#linearGradient1003);fill-opacity:1;stroke:none;stroke-width:0.0130341;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
-         id="path995"
-         sodipodi:type="arc"
-         sodipodi:cx="24.06572"
-         sodipodi:cy="25.688669"
-         sodipodi:rx="1.5552539"
-         sodipodi:ry="1.5552539"
-         sodipodi:start="0"
-         sodipodi:end="6.2799564"
-         sodipodi:open="true" />
-      <path
-         d="m 27.555678,25.576565 a 3.6937277,3.7114012 0 0 1 -3.690746,3.7114 3.6937277,3.7114012 0 0 1 -3.696705,-3.705408 3.6937277,3.7114012 0 0 1 3.684778,-3.717383 3.6937277,3.7114012 0 0 1 3.702653,3.699407"
-         sodipodi:arc-type="arc"
-         sodipodi:open="true"
-         sodipodi:end="6.2799564"
-         sodipodi:start="0"
-         sodipodi:ry="3.7114012"
-         sodipodi:rx="3.6937277"
-         sodipodi:cy="25.576565"
-         sodipodi:cx="23.86195"
-         sodipodi:type="arc"
-         id="path964"
-         style="fill:url(#linearGradient974);fill-opacity:1;stroke:none;stroke-width:0.0145247;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.13736303;paint-order:fill markers stroke" />
-      <path
-         d="m 25.781533,24.918606 a 1.6620928,1.6620928 0 0 1 -1.660751,1.662092 1.6620928,1.6620928 0 0 1 -1.663433,-1.659409 1.6620928,1.6620928 0 0 1 1.658066,-1.664771 1.6620928,1.6620928 0 0 1 1.666109,1.656721"
-         sodipodi:arc-type="arc"
-         style="fill:url(#linearGradient1077);fill-opacity:1;stroke:none;stroke-width:0.0847216;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.9670333;paint-order:fill markers stroke"
-         id="path1069"
-         sodipodi:type="arc"
-         sodipodi:cx="24.11944"
-         sodipodi:cy="24.918606"
-         sodipodi:rx="1.6620928"
-         sodipodi:ry="1.6620928"
-         sodipodi:start="0"
-         sodipodi:end="6.2799564"
-         sodipodi:open="true" />
-      <path
-         d="m 26.883958,25.620844 a 2.8243079,2.8243079 0 0 1 -2.822028,2.824307 2.8243079,2.8243079 0 0 1 -2.826584,-2.819747 2.8243079,2.8243079 0 0 1 2.817465,-2.82886 2.8243079,2.8243079 0 0 1 2.831133,2.81518"
-         sodipodi:arc-type="arc"
-         style="opacity:0.41300001;fill:url(#radialGradient930);fill-opacity:1;stroke:none;stroke-width:0.0145109;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.13736303;paint-order:fill markers stroke"
-         id="path922"
-         sodipodi:type="arc"
-         sodipodi:cx="24.05965"
-         sodipodi:cy="25.620844"
-         sodipodi:rx="2.8243079"
-         sodipodi:ry="2.8243079"
-         sodipodi:start="0"
-         sodipodi:end="6.2799564"
-         sodipodi:open="true" />
-      <path
-         d="m 27.555678,25.576565 a 3.6937277,3.7114012 0 0 1 -3.690746,3.7114 3.6937277,3.7114012 0 0 1 -3.696705,-3.705408 3.6937277,3.7114012 0 0 1 3.684778,-3.717383 3.6937277,3.7114012 0 0 1 3.702653,3.699407"
-         sodipodi:arc-type="arc"
-         style="fill:url(#linearGradient993);fill-opacity:1;stroke:none;stroke-width:0.0145247;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.13736303;paint-order:fill markers stroke"
-         id="path978"
-         sodipodi:type="arc"
-         sodipodi:cx="23.86195"
-         sodipodi:cy="25.576565"
-         sodipodi:rx="3.6937277"
-         sodipodi:ry="3.7114012"
-         sodipodi:start="0"
-         sodipodi:end="6.2799564"
-         sodipodi:open="true" />
-      <path
-         d="m 26.883958,25.620844 a 2.8243079,2.8243079 0 0 1 -2.822028,2.824307 2.8243079,2.8243079 0 0 1 -2.826584,-2.819747 2.8243079,2.8243079 0 0 1 2.817465,-2.82886 2.8243079,2.8243079 0 0 1 2.831133,2.81518"
-         sodipodi:arc-type="arc"
-         sodipodi:open="true"
-         sodipodi:end="6.2799564"
-         sodipodi:start="0"
-         sodipodi:ry="2.8243079"
-         sodipodi:rx="2.8243079"
-         sodipodi:cy="25.620844"
-         sodipodi:cx="24.05965"
-         sodipodi:type="arc"
-         id="path932"
-         style="fill:url(#radialGradient934);fill-opacity:1;stroke:none;stroke-width:0.0145109;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.13736303;paint-order:fill markers stroke" />
-      <path
-         d="m 27.668542,34.910927 a 1.6758949,1.1622154 0 0 1 -1.674542,1.162215 1.6758949,1.1622154 0 0 1 -1.677246,-1.160339 1.6758949,1.1622154 0 0 1 1.671835,-1.164088 1.6758949,1.1622154 0 0 1 1.679944,1.158459"
-         sodipodi:arc-type="arc"
-         style="fill:#ffffff;fill-opacity:0.23076902;stroke:none;stroke-width:0.0133413;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.13736303;paint-order:fill markers stroke"
-         id="path942"
-         sodipodi:type="arc"
-         sodipodi:cx="25.992647"
-         sodipodi:cy="34.910927"
-         sodipodi:rx="1.6758949"
-         sodipodi:ry="1.1622154"
-         sodipodi:start="0"
-         sodipodi:end="6.2799564"
-         sodipodi:open="true"
-         transform="matrix(0.95447999,-0.29827496,0,1,0,0)" />
-      <path
-         d="m 25.434309,27.220451 a 0.32492039,0.32492039 0 0 1 -0.324658,0.324921 0.32492039,0.32492039 0 0 1 -0.325183,-0.324396 0.32492039,0.32492039 0 0 1 0.324133,-0.325444 0.32492039,0.32492039 0 0 1 0.325706,0.32387"
-         sodipodi:arc-type="arc"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0130341;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.13736303;paint-order:fill markers stroke"
-         id="path944"
-         sodipodi:type="arc"
-         sodipodi:cx="25.109388"
-         sodipodi:cy="27.220451"
-         sodipodi:rx="0.32492039"
-         sodipodi:ry="0.32492039"
-         sodipodi:start="0"
-         sodipodi:end="6.2799564"
-         sodipodi:open="true" />
-      <path
-         d="m 25.63426,27.182961 a 0.53736836,0.53736836 0 0 1 -0.536935,0.537368 0.53736836,0.53736836 0 0 1 -0.537801,-0.536501 0.53736836,0.53736836 0 0 1 0.536066,-0.538234 0.53736836,0.53736836 0 0 1 0.538667,0.535631"
-         sodipodi:arc-type="arc"
-         sodipodi:open="true"
-         sodipodi:end="6.2799564"
-         sodipodi:start="0"
-         sodipodi:ry="0.53736836"
-         sodipodi:rx="0.53736836"
-         sodipodi:cy="27.182961"
-         sodipodi:cx="25.096891"
-         sodipodi:type="arc"
-         id="path946"
-         style="fill:url(#radialGradient954);fill-opacity:1;stroke:none;stroke-width:0.0215564;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.13736303;paint-order:fill markers stroke" />
-      <path
-         style="fill:#ecf8fc;fill-opacity:0.67582397;stroke:none;stroke-width:0.0651704px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 21.928662,24.321098 c 0.04999,0.02499 0.912276,0.549866 0.912276,0.549866 0.330676,-0.30379 0.62771,-0.658043 1.149718,-0.674835 l -0.124969,-1.074737 c -0.83412,0.05728 -1.469422,0.476036 -1.937025,1.199706 z"
-         id="path956"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:#ecf8fc;fill-opacity:0.66483495;stroke:none;stroke-width:0.0651704px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 22.828588,25.0701 c -0.04452,0.167557 -0.186891,0.237269 -0.10604,0.5302 l -1.11342,-0.176733 c -0.02227,-0.304902 0.05191,-0.590512 0.265099,-0.84832 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         d="M 33.558601,1.6677361 A 0.27393678,0.39323184 0 0 1 33.284885,2.0609678 0.27393678,0.39323184 0 0 1 33.010728,1.6683709 0.27393678,0.39323184 0 0 1 33.284001,1.2745054 0.27393678,0.39323184 0 0 1 33.5586,1.6664663"
-         sodipodi:arc-type="arc"
-         style="fill:#ecf8fc;fill-opacity:0.66483495;stroke:none;stroke-width:0.0130341;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
-         id="path960"
-         sodipodi:type="arc"
-         sodipodi:cx="33.284664"
-         sodipodi:cy="1.6677361"
-         sodipodi:rx="0.27393678"
-         sodipodi:ry="0.39323184"
-         sodipodi:start="0"
-         sodipodi:end="6.2799564"
-         sodipodi:open="true"
-         transform="rotate(43.915346)" />
-      <path
-         d="m 48.370132,-13.085805 a 0.15328924,0.22004426 0 0 1 -0.153166,0.220044 0.15328924,0.22004426 0 0 1 -0.153412,-0.219689 0.15328924,0.22004426 0 0 1 0.152917,-0.220399 0.15328924,0.22004426 0 0 1 0.15366,0.219334"
-         sodipodi:arc-type="arc"
-         transform="rotate(43.915346)"
-         sodipodi:open="true"
-         sodipodi:end="6.2799564"
-         sodipodi:start="0"
-         sodipodi:ry="0.22004426"
-         sodipodi:rx="0.15328924"
-         sodipodi:cy="-13.085805"
-         sodipodi:cx="48.216843"
-         sodipodi:type="arc"
-         id="path962"
-         style="fill:#ecf8fc;fill-opacity:0.66483495;stroke:none;stroke-width:0.00729362;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke" />
-      <g
-         id="g1472"
-         transform="matrix(0.06517044,0,0,0.06517044,1.3076195,1.094131)">
-        <path
-           d="m 475.52807,254.76938 a 30.321989,2.2284784 0 0 1 -30.29751,2.22848 30.321989,2.2284784 0 0 1 -30.34642,-2.22488 30.321989,2.2284784 0 0 1 30.24852,-2.23207 30.321989,2.2284784 0 0 1 30.39526,2.22127"
-           sodipodi:open="true"
-           sodipodi:end="6.2799564"
-           sodipodi:start="0"
-           sodipodi:ry="2.2284784"
-           sodipodi:rx="30.321989"
-           sodipodi:cy="254.76938"
-           sodipodi:cx="445.20609"
-           sodipodi:type="arc"
-           id="path1454"
-           style="opacity:1;fill:url(#linearGradient1462);fill-opacity:1;stroke:none;stroke-width:2.01013994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
-           sodipodi:arc-type="arc" />
-        <path
-           d="m 480.13559,267.05084 a 34.305084,2.3728814 0 0 1 -34.27739,2.37288 34.305084,2.3728814 0 0 1 -34.33273,-2.36905 34.305084,2.3728814 0 0 1 34.22196,-2.3767 34.305084,2.3728814 0 0 1 34.38798,2.36521"
-           sodipodi:open="true"
-           sodipodi:end="6.2799564"
-           sodipodi:start="0"
-           sodipodi:ry="2.3728814"
-           sodipodi:rx="34.305084"
-           sodipodi:cy="267.05084"
-           sodipodi:cx="445.83051"
-           sodipodi:type="arc"
-           id="path1464"
-           style="opacity:1;fill:#1d1e1e;fill-opacity:0.214286;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
-           sodipodi:arc-type="arc" />
-        <path
-           d="m 477.42373,266.59543 a 31.367151,1.9174567 0 0 1 -31.34183,1.91745 31.367151,1.9174567 0 0 1 -31.39243,-1.91436 31.367151,1.9174567 0 0 1 31.29115,-1.92054 31.367151,1.9174567 0 0 1 31.44295,1.91126"
-           style="opacity:1;fill:#1d1e1e;fill-opacity:0.214286;stroke:none;stroke-width:1.71914995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
-           id="path1466"
-           sodipodi:type="arc"
-           sodipodi:cx="446.05658"
-           sodipodi:cy="266.59543"
-           sodipodi:rx="31.367151"
-           sodipodi:ry="1.9174567"
-           sodipodi:start="0"
-           sodipodi:end="6.2799564"
-           sodipodi:open="true"
-           sodipodi:arc-type="arc" />
-        <path
-           style="opacity:1;fill:url(#linearGradient1386);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
-           d="m 475.52792,254.76349 v 10.26242 c 0,0.78215 -0.0895,1.35305 -0.86945,1.41182 -18.65485,1.40566 -37.59704,2.14086 -57.77182,0 -0.77778,-0.0825 -1.37054,-0.63076 -1.41182,-1.41182 l -0.54237,-10.26242 c 20.6974,2.99349 40.59158,1.16764 60.59546,0 z"
-           id="path1378"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="csssscc" />
-      </g>
-    </g>
-    <path
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="sccssssccssscss"
-       id="path2188"
-       d="m 16.712514,273.33134 c -1.740629,-0.21267 -3.670574,0.51666 -4.696282,2.99835 -0.153253,0.85255 -0.156518,1.31117 0.444418,0.18292 0.959404,-2.32127 2.617261,-2.89774 4.193233,-2.7052 1.575974,0.19255 3.046682,1.24598 3.440422,2.13883 0.17573,0.39849 0.196905,1.07215 0.01525,1.75305 -0.181661,0.6809 -0.556961,1.36818 -1.111629,1.83512 -0.554668,0.46695 -1.280039,0.7276 -2.234984,0.57106 -1.687825,-0.15617 -3.544375,-1.79145 -4.150316,-2.1517 1.46318,1.31938 2.9919,2.44823 4.072924,2.62543 1.081025,0.17721 1.973,-0.13145 2.621944,-0.67776 0.648943,-0.54631 1.063273,-1.31645 1.266412,-2.07786 0.20314,-0.7614 0.204863,-1.51586 -0.03987,-2.07082 -0.505744,-1.14683 -2.080888,-2.20876 -3.821517,-2.42142 z"
-       style="color:#000000;fill:#9f2f13;fill-opacity:0.79818702;stroke-width:0.48029801" />
   </g>
 </svg>

--- a/128x128/apps/softwarecenter.svg
+++ b/128x128/apps/softwarecenter.svg
@@ -13,7 +13,7 @@
    viewBox="0 0 33.866666 33.866667"
    version="1.1"
    id="svg6"
-   sodipodi:docname="software-properties-mint.svg"
+   sodipodi:docname="softwarecenter.svg"
    inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
   <metadata
      id="metadata112">
@@ -40,18 +40,6 @@
          style="stop-color:#caf9fe;stop-opacity:1"
          offset="1"
          id="stop9596" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient1630">
-      <stop
-         style="stop-color:#14afe1;stop-opacity:1"
-         offset="0"
-         id="stop1626" />
-      <stop
-         style="stop-color:#0d5fd1;stop-opacity:1"
-         offset="1"
-         id="stop1628" />
     </linearGradient>
     <linearGradient
        gradientTransform="translate(0,-896)"
@@ -115,16 +103,6 @@
          stop-color="#0070e0"
          id="stop9-7" />
     </radialGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1630"
-       id="linearGradient1632"
-       x1="132.21078"
-       y1="42.151531"
-       x2="132.21078"
-       y2="70.679932"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.97573206,0,0,0.97573206,-111.77632,-37.20309)" />
     <filter
        y="-0.012004"
        x="-0.011996"
@@ -395,6 +373,150 @@
        y1="25.057371"
        x2="17.757063"
        y2="11.635189" />
+    <linearGradient
+       id="a"
+       gradientUnits="userSpaceOnUse"
+       x1="-15.855"
+       x2="-27.194"
+       y1="61.602001"
+       y2="37.011002"
+       gradientTransform="matrix(0.99999017,0,0,0.99999017,34.395662,-31.749687)">
+      <stop
+         id="stop48"
+         stop-color="#08bcfe"
+         offset="0" />
+      <stop
+         id="stop46"
+         stop-color="#0d6be6"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="b-3"
+       gradientUnits="userSpaceOnUse"
+       x1="-9.776"
+       x2="-9.776"
+       y1="50.637001"
+       y2="53.326"
+       gradientTransform="matrix(0.99999017,0,0,0.99999017,34.395662,-31.749687)">
+      <stop
+         offset="0"
+         stop-color="#d0edff"
+         id="stop35-6" />
+      <stop
+         offset=".25"
+         stop-color="#d1edff"
+         id="stop37-7" />
+      <stop
+         offset=".5"
+         stop-color="#ceebff"
+         id="stop39" />
+      <stop
+         offset=".75"
+         stop-color="#9acfff"
+         id="stop41" />
+      <stop
+         offset="1"
+         stop-color="#52a7ff"
+         id="stop43" />
+    </linearGradient>
+    <linearGradient
+       id="c-5"
+       gradientUnits="userSpaceOnUse"
+       x1="-15.421"
+       x2="-13.087"
+       y1="50.25"
+       y2="48.944"
+       gradientTransform="matrix(0.99999017,0,0,0.99999017,34.395662,-31.749687)">
+      <stop
+         offset="0"
+         stop-color="#bee1ff"
+         id="stop2-3" />
+      <stop
+         offset=".25"
+         stop-color="#e6f4ff"
+         id="stop4-5" />
+      <stop
+         offset=".5"
+         stop-color="#e9f5ff"
+         id="stop6" />
+      <stop
+         offset=".75"
+         stop-color="#d5ecff"
+         id="stop8" />
+      <stop
+         offset="1"
+         stop-color="#8ec8ff"
+         id="stop10-6" />
+    </linearGradient>
+    <linearGradient
+       id="d-2"
+       gradientUnits="userSpaceOnUse"
+       x1="-22.393999"
+       x2="-19.941"
+       y1="50.338001"
+       y2="51.808998"
+       gradientTransform="matrix(0.99999017,0,0,0.99999017,34.395662,-31.749687)">
+      <stop
+         offset="0"
+         stop-color="#e7f5ff"
+         id="stop13" />
+      <stop
+         offset=".25"
+         stop-color="#ebf7ff"
+         id="stop15-9" />
+      <stop
+         offset=".5"
+         stop-color="#e1f2ff"
+         id="stop17-1" />
+      <stop
+         offset=".75"
+         stop-color="#addcff"
+         id="stop19" />
+      <stop
+         offset="1"
+         stop-color="#96d3ff"
+         id="stop21" />
+    </linearGradient>
+    <linearGradient
+       id="e-2"
+       gradientUnits="userSpaceOnUse"
+       x1="-22.169001"
+       x2="-22.169001"
+       y1="50.671001"
+       y2="53.334999"
+       gradientTransform="matrix(0.99999017,0,0,0.99999017,34.395662,-31.749687)">
+      <stop
+         offset="0"
+         stop-color="#e8f6ff"
+         id="stop24" />
+      <stop
+         offset=".25"
+         stop-color="#ebf7ff"
+         id="stop26" />
+      <stop
+         offset=".5"
+         stop-color="#e9f6ff"
+         id="stop28" />
+      <stop
+         offset=".75"
+         stop-color="#d2edff"
+         id="stop30-7" />
+      <stop
+         offset="1"
+         stop-color="#b4e1ff"
+         id="stop32-0" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="radialGradient1003"
+       cx="16.933332"
+       cy="14.760176"
+       fx="16.933332"
+       fy="14.760176"
+       r="14.543357"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.6730642,0,0,-1.735591,45.263885,32.022228)" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -403,9 +525,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="3.5935388"
-     inkscape:cx="-6.4193129"
-     inkscape:cy="54.739656"
+     inkscape:zoom="5.0820313"
+     inkscape:cx="98.727403"
+     inkscape:cy="-11.230054"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      showgrid="false"
@@ -422,9 +544,9 @@
     <g
        id="g1702"
        transform="matrix(0.97573206,0,0,0.97573206,-65.748383,-37.203094)"
-       style="opacity:0.2967651">
+       style="opacity:0.29676508">
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1634"
          width="29.810888"
          height="29.810888"
@@ -440,9 +562,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1638"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.30000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1640"
          width="29.810888"
          height="29.810888"
@@ -458,9 +580,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1642"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.40000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1644"
          width="29.810888"
          height="29.810888"
@@ -476,9 +598,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1646"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.7;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.69999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1648"
          width="29.810888"
          height="29.810888"
@@ -494,9 +616,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1650"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.80000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1652"
          width="29.810888"
          height="29.810888"
@@ -512,9 +634,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1654"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.20000005;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.39999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1656"
          width="29.810888"
          height="29.810888"
@@ -530,9 +652,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1658"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.79999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1660"
          width="29.810888"
          height="29.810888"
@@ -548,9 +670,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1662"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.20000005;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1664"
          width="29.810888"
          height="29.810888"
@@ -566,9 +688,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1666"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.5999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1668"
          width="29.810888"
          height="29.810888"
@@ -584,9 +706,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1670"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3.4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3.4000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3.8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:3.79999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1672"
          width="29.810888"
          height="29.810888"
@@ -602,9 +724,9 @@
          height="29.810888"
          width="29.810888"
          id="rect1674"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:4.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:4.19999981;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
       <rect
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:4.6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:4.5999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002"
          id="rect1676"
          width="29.810888"
          height="29.810888"
@@ -620,35 +742,55 @@
          height="29.810888"
          width="29.810888"
          id="rect1678"
-         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02" />
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.02000002" />
     </g>
     <rect
-       style="fill:url(#linearGradient1632);fill-opacity:1;stroke-width:2.68768001;stroke-linecap:round;stroke-linejoin:round"
-       id="rect849"
-       width="29.087439"
-       height="29.087439"
-       x="2.3962677"
-       y="2.5185883"
-       rx="6.4494534"
-       ry="6.4494534" />
-    <image
-       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGgAAABeCAYAAADPP1ERAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz AAAOxAAADsQBlSsOGwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAvGSURB VHic7Vztcqu4EhzbOfv+73sTe39setO0u0eCxMCtzVRRyCDEaFrzKZKqX/qlF9CFjtn+/5d0dsb3 4u+x03tW01kBUr5exacCczqgzgbQZWV7Cz1Wtg+lMwHkQLhI+yfpQeeHXNP2YXQWgBQEBcbd30IK hILj7h9KZwAogeOOkvZacoC4o8z5EHo78uXlgwE+rqHtnh2RAnOXtuuL9xwG0tEAgRIwVzq+A5ID 5/p5vtO9DqhD6AwAJXN2rapbLUFisLZoEEDAwePcy4/5nzVxybwBhBudb3IN/dw4ShAwTNq9qj7o rHSX5/COQ4A6WoNSgMAgvdUXSKpRXX6kIfOjvoC5frYvps8lnA+howGqyuCw9rzJmfvwGI7YrN3q H2AYXBfFnQKcquMAGkVv7IMADB9s6lzQ4EJpmLR36ccBg/JwuJk7kwah7bQIwPyppcnrtIh9D8BR zeGAgUFifv6TGuSoM3XX8iB1UZ1qDoPprr+yrLSZzgRQla8mJG16o2sJINYOgJOAOR04VecDqOrZ xGjA4KI7FbLmPJzrsKlTYE8FTtU5AQK5+tulliG3CxiqluB81DIYcPW9oudORWcEyFWXQck/qZl7 0O9HZY1x2wunAukogCBAbqd9GUepHOTC7FEQ4RbCafaHzqZBo+0AJhdIcFiMsFnHhunrthtOo0Vn AUiFogmmEyjTKAJz9Tg+3LinAOk67vJSSuYlHXfqn0Aquc+guLO2nRYfRmfRoKoeEN6rSUJzGpg0 Rq8ncA6nIzUoRVCdT9hy34HT+aERr7vS0SauoxlQnCkaaY4zcafTHNCZTNwMpUCi0xwFo2qduTyU jtSgUVnFRWZpS7qL+lx7LW+HlYDOokGupOMO7lv1DEzVEqQUQqd34/yrQZ+U6m2cgLpzl+84zUnv 1fckfqryO19KZ91R1U+tRns26l+S4+/eg98PGvtwTTraB420Jn125arXKQl9mPHT2NxHeaxaLopd 6AgN6rTHCc990dNVpJNp0/E/Ps+67Y1nrzUfVLyMjjRxydykT650W8FVrl0Ux+/U8UeJq9ue2DWI 2BugpD0dMJ0GuWRWBa7vuQ3689kthF3ptvP7nNboNjY+DMHxF7X5W4Qu3O4iOH3G/dbrbh670J4a pAknH05bRtoD6qrULHSO0pwWvZnn9CvU3bXoCBPX+R33saKChGdTBSFtSfBiKPOsjgN+OGDY3dzt BZAr12ieo59UKUid7+EPQzTyYj9yrWfhOk1y2ugS5JcDtbeJ01zHfaHjtIc1rGqZlOKDePU9KlD3 BWrSwLd6BsglsC83e68GaFTGSWZNNSf5Hv4zErRd5MamquorXAcpQKMtcQbqpSC9CqAuIHAJqDNp 7q8ZQCy891oCxO91WqPmDvkQTNsIoHs9g/sy3/RdgLpw02kPmzYIXcFJGgRiQQGY93r2P9fQ5iDD jTmz8+rmna7j3iZaC1BiwCWgOPOKdXnPCByuHjhwWHv4L+YYEERlzF+q5c0AVOaaM3VqEvX6kGYB SgDMtJ3mOFD+mGsuelNhApz3ehaWC8mZPzVVycy558EDxpoJIpwPa2kEUKcZ7qzXXNVgDTgAiCfj wOFIDoKCb7nUUsjMW9WX+XuTsbu86lLL5FU1axRETAPVAdQJvbuWfI8DiEs43NbEVKlLUkEA52r6 K//8DFcUXDWbwUl7T9q+lAdrGK4ngFwUxm090r0qXwhlreG6W6c9TgBVfmKd0Jh0P8yB7p5F+cf5 p5GvcrxWBZBmTFx36FbxTL4zAodBUt/DPM3wreQExOG41ujUZ1V9gYPyzwikR9On46uqPECdRmh5 RkFSwLhfMm9/1XPFWs3bvZ55YX5dCYcF7yhpfNVy9Wt/jRxTrsRtBZNNMb/zSYsUoBE43aGAuOiN w+o/5uDtBDzLwtKxecUz/1WeH6dVzhc5YPA+JMYcnDzCmQ+MA3CmQJo1cWqm2OFzruI060ZnjeCS /+HkFCvwIe9AlIbq9Af1q8qLxs0PQkm5kr5XNUh9Vooy9T+bAKTVJs45fy3PQNh8nQGZ2UpwIbar vd1pbDUhKmS9plqetIkXgcoB736rpQZ1B755QMSn4Gh0x9f/JQYorS4n5LQd0H2F4+pvOg5rIwsO jD+ojwYNHE7z9ZEW8dz5mbs8j2T4rXz+peDgSCZU/Zya1UfVOMx26s0C1ryFNWAGJC2IsvYx0yrs m1yHALvISwFyQQXf0/exRiRQFBz+ryYYF4tslCNVlQ8Skoq7XKbL/kcgqR9zK5yZd1qCPl3OonNh cskr92Pg4fO2goP3cVSn5vlp8cxqUAoW0i7obLSnAYVSWuUA6maudTkMC4DDYBUS979KXxehcT1Q 58KgdL5wSoNUGCqYzi/prmgCxp2ZVLipWMkCdeA42+7GhdkqGmekcQrOlcbgRaDApJDfglM1V81O 2uSAcsA5J60M3mv5HkyQBZ3K/h3PHUjs6zS8VpCUJ5go8O3C5wSItltaux+kQhnZ+wQIP5sE7TRB Q+zUp7vOfGI8FxVq8svXnb/AWNxX26upAyhNrhNSt7I5UhmBkt47EnzHp953/owJwYeaYgYW97Qq oD4uaf9okUaAdIU4x5j2TZh5rgLwuEnASaAJAD13mqT3GSDd99HoSrWJ+zB1wKicdCtjtQ9yk3PO kSOXZHPZxzAzbgIjwXbnxDfepX3hJxQg8D0TnifZaNLqiqUjq/MEkLPRygD/rzUciPlTts4mIk0q aaMDyPGbNMqNw3xxbpcAqno2gWkOnAel7yZc3mZ5nNUgNlkJJBelJefoJpSY70ByKy8BpP3ZxCEJ dSaO54E5JmAUlHdzTU3ctAapf1BnCCZ4Yin07gB61BKMtNK6sDpNaNY/scCv1WuPhtloj0yaAyfN zfFYVXNRHJjBhBxQmvvwKmEfBCbSKtO9FtZg5WnEc2caS3jXBeAAetSykJtMWzJvqYa32gdpVquC BcNs6rhOxdvBGsqW9Hs3hzMHI2Erjcwha5CaN9xPppq1yQnc1eUcOMn3TPsgfpjb6o/ATNrP17az 2+9V9b9aatLqkNTwnvpriO3upwo4V9o7cNYGQJYcQKxFLme5y8Q0mumip84kOC1yYSmfZyiZNwYh 3eM2xoKZg0VRwfN5BEzymf/SKFF1Nl1B6kBxPqQzAz8NUAKniP+r9FPw1MSlQEHBGcmkTPuJRkGC MubsZsfQXcZI5mA24okTGRCe0XKN8y0a+LAGVS21TufhZJFM2pTJnimW8uQ6kBw4HCyw9mi048xe p0FbSTWFBT9KIUD6QaXy6drTJk1pJkjQHEAdm/NDfHA/B8JMOLpqUhPEJkqvXypXRjCHm/xm3juL 4ubRzmfr3wc59XXOEcJmpzoyaep8t5o37evqaVyJvtRSi1KiCr6cVRjlN6vnsWU/SE2cAsI2GlqX ANKAgG15WoFbyT2vZjiBxGMwQBij852a96yiWYCcH3I+B8xyP159zv+kqG3kWH+KMGanSeh3r6/P rvT6KNGu2rDQZoMEZx4YGJ4Q9+GVxqar06A9wNGFw3P6+Pyt4GjwownrmnriNFBbTBxrBwBg7QFh Iqm4yAApOFXLCbxCc9w7VItcH1RNNH3gxce/Oz/67SjOEZsErsnxfTjgq1xP4bSru/2E3+mIF1vJ WaM7vo4veNi3shYxSE6LVtEagHhwjmDwG4SanOYZKcIbRT97gMTv6cBh85aCh6Q9m/zQmiBBGeKX qQZxDqGT0MmMfM8epO9SkJinNLduXinsHpJu43akgYLe01XPgHTa0pmBvUDq5qaLUefWAaI+dfXc vpOogsAEio6cU7hV5ib5yohtDTlNwuLjr045OuXndE53ue/e0VK3crr+fO4ybyXniBM4e4OkhVOd y+z8UqCzaQGuBYifcYy7+yAHQAfKEVrkQHJt7VuV5/etuX0HIG6PmAclQI4GhulU89sCkHs2tR11 zB4NDkjncNj81kRxjrYA7Jg8CzBKWxfwjy2872jQd8c6KyiJfmox/tIv/dJu9DdWjcxkUfjz8QAA AABJRU5ErkJggg== "
-       width="27.516666"
-       height="24.870832"
-       id="image1024"
-       x="3.4395833"
-       y="5.9956365" />
+       style="fill:url(#radialGradient1003);fill-opacity:1;stroke-width:0.99999017"
+       id="rect51"
+       y="2.3899767"
+       x="2.389976"
+       width="29.086714"
+       rx="6.4489365"
+       height="29.086714" />
     <path
-       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0284808;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 15.419264,7.8937763 c -0.282792,0 -0.346449,0.012374 -0.532832,0.103882 -0.270041,0.1325904 -0.49822,0.3610705 -0.618149,0.6189149 -0.127372,0.2738496 -0.150453,0.6927967 -0.05236,0.9504493 0.03728,0.097902 0.37827,0.7140785 0.757772,1.3693145 0.379502,0.655237 0.690889,1.215952 0.691994,1.246035 0.0011,0.03008 -0.934277,1.676126 -2.078623,3.657858 l -2.08064,3.603137 -1.8888673,0.01036 -1.8888668,0.01036 -0.2136058,0.09964 c -0.2782358,0.129815 -0.5213467,0.371811 -0.6469362,0.644008 -0.085086,0.184414 -0.1004025,0.263646 -0.1005448,0.520177 0,0.25708 0.014864,0.334747 0.099571,0.516214 0.168706,0.361418 0.5023731,0.640052 0.870277,0.72676 0.07442,0.01755 2.8093929,0.03305 6.1714119,0.03505 l 6.0377,0.0036 0.06786,-0.07509 c 0.05716,-0.06326 0.0675,-0.12901 0.06585,-0.418313 -0.005,-0.877408 -0.511079,-1.715041 -1.203688,-1.992471 -0.129433,-0.05184 -0.405741,-0.06119 -2.285274,-0.07711 l -2.138074,-0.01807 0.610294,-1.050229 C 18.86078,11.844084 20.087291,9.7174495 20.14536,9.5670167 20.19897,9.4281232 20.2109,9.3264321 20.19946,9.104203 20.17351,8.6002739 19.922982,8.2175787 19.475064,7.9976528 c -0.18627,-0.091458 -0.250102,-0.103882 -0.532067,-0.103882 -0.278554,0 -0.349651,0.013478 -0.544376,0.1033949 -0.308789,0.1425882 -0.495514,0.3620421 -0.876951,1.0307601 -0.174712,0.3062951 -0.328751,0.5568905 -0.342312,0.5568905 -0.01356,0 -0.166952,-0.2501022 -0.340921,-0.5557777 C 16.455149,8.3555705 16.295993,8.1672493 15.977616,8.0105134 15.762655,7.904688 15.710265,7.8937668 15.419264,7.8937668 Z m 3.659947,5.0032557 c -0.07542,-0.0023 -0.270724,0.189592 -0.406283,0.39933 -0.469799,0.72687 -0.657041,2.222011 -0.395643,3.159584 0.04964,0.178036 0.666026,1.271547 2.678833,4.752589 1.437877,2.486727 2.669182,4.582259 2.736268,4.656772 0.359823,0.399642 0.954858,0.516932 1.46388,0.288493 0.480846,-0.215788 0.780997,-0.727694 0.736425,-1.256045 -0.01094,-0.129763 -0.0522,-0.308019 -0.09164,-0.396131 -0.03945,-0.08811 -0.373945,-0.68087 -0.74331,-1.317237 l -0.671551,-1.157029 1.123311,-0.01779 1.123308,-0.01779 0.213603,-0.09971 c 0.278239,-0.12982 0.521351,-0.371819 0.646938,-0.644016 0.08509,-0.184413 0.100333,-0.263575 0.100473,-0.520108 0,-0.257025 -0.01479,-0.334784 -0.09943,-0.516214 -0.129736,-0.278058 -0.371869,-0.521272 -0.64408,-0.647075 l -0.217509,-0.100568 -1.869817,-0.01036 -1.869817,-0.01036 -1.886086,-3.272507 c -1.037355,-1.799896 -1.9049,-3.273117 -1.927873,-3.273836 z m -8.908724,9.699454 c -0.2019802,4.23e-4 -0.3728355,0.01794 -0.4441772,0.05451 -0.07635,0.03915 -0.2125427,0.240878 -0.5283126,0.782596 -0.6347116,1.088875 -0.6826822,1.197669 -0.6818419,1.546416 0.0013,0.552177 0.3017584,0.988086 0.8270968,1.20007 0.2397831,0.09676 0.7378879,0.07535 0.9843109,-0.04228 0.328764,-0.156922 0.482227,-0.361063 1.1765,-1.564981 l 0.646728,-1.121421 -0.05723,-0.101867 c -0.152239,-0.271108 -0.607523,-0.540289 -1.135337,-0.671272 -0.216997,-0.05385 -0.52805,-0.08216 -0.787741,-0.08177 z"
-       id="path875-0"
-       inkscape:connector-curvature="0" />
-    <image
-       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFgAAABPCAYAAABvRgIXAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz AAAOxAAADsQBlSsOGwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAB8hSURB VHic5Z1LjyRJct9/ZuYeEVlZ2dPdM9Wzj9nFYEmsgG1IAkEsdeGhCR10EPbYe+ZNB34INr/EfgKd 1EcBq4sOpZNAEBIIAdMCV+RwOEPO7HbNTnV3VlZmhLub6RBZVT2P7dnXVC1IAwIZiPRID/+npbm9 U7h5kvnlkfAIeOcduXzn/v3gEcCj2F+J3+CeGyG7yckBgUfCwyNlUY3/876xODOmbyvTT5X/+Vy5 fw++fyQ8+SFw/Ol77t1T/uqdz9/z7Sr88Xd46Z4bI/nyIV/l3I+EP/zQuNcrT0dj+Kmx65U7wLoL 0jrYReNebTz9lvOdUwfg3TvKvQ+Up8kY5OqeU2AYnd3XGvf6xtPR+cE3Go8eBTfEyTcFsPDwofLu HaU7TXiXb+mUXIbkFvtf1Tnaommk+kJXhd3JDDTA02SkW+nqno3hnaApZGqusatrOSjoVJjuVL5z 6jx+7NwAyDchImbOXVSjO01sS08/9Oo6OLUPpQsiByl7ZHPcKqp0WRjvCOPKyNYh1iu194ghNHce nhFJEZFi0dsQKlO/FZiCj+8EH/0gbkJc3AAHh/DgTwzeTqw3/TKlwXPt3TWjn/nCiwXWXNWLhFWN XAFcSvKYcpATyRRvn16H01S9aEnjptYdq+XI0abw+L84yLVy8XVzsIAIr3dK/6JbTalvixi8Ro+J oRbUFqKp4RGECik0NBmIeYQ5kUOlC0sZQhGFFk4QuEMVIaHRQumERTGfVtL4cOV89L+vnYuvH+CH R0q+bXdOz7pykIeQ0iGaKBaSStXcTdq8SCuOKIQLuIVrCsgBOQITquDh0qSql6KWinS5USrkpAiK ONLcy3l17t1u/MHfB0+eXCsHp+ucDICTE2FEfZE1prBQDAPJY5Oi07b3EdFGhC695ZZbH5KVVI2m CoC5E1pFSrHKuJEoiDq4LYzAkYAUBfOEvWZZnz/7qbI9uXaRqNc73Z55pp1EK0LfBM8yi4bs6qmS auHAJg7SuOnPR+tslCSTOA3RQDTEaZJkss7GzbLsOEgjBzaRalFPleqO2jxZNY1W5HPPcE10zQDv 19kN8ypHC7TM56ohtgu2ozNZg2Xlxd1pU/OoLY2SbZQ6TVKnSbKN2tK4qXnkk1WBZWWyxvosxFKg eoXiBdCffYZrousXEUdHwckyFFzKzgkNQHCXiEGoVcnAycYZz4KvNc7P32C5FXfVAqBbqZvsEwcf T/zUKu0wOFoq9VDCd8oChQyiIam55uWsAx/989eDZ5M3/Y3ucm+dYwFGnUxyBmpUo7FdN2pyDt8M TsPhPIoOXoeh1tSVUqMwrQunh5XDN4O6E+5YotWclC5CM6khRZu6TOsahWe7wvF9v24t4ppFxJ5e +5ZTl1UjVxmmiiWPVjSkpUMZEsOR8e2vCaufBEcnDl8v3P1kBHbAbj7/epnfA46WynO3pacckhPh wqQx6867Sl1Whjs3YirfgCV3DH/8Hci3ZTp7pn2vFkUNCRXrJXyKGpPzIjvT685bGvzx7znPnwfn HwY8c+7cce7sguUSPtopoyXubPo0dT2JTLhIaDMYz6QbeWNVePPjxpMfXbtP4vplMMDj+8EffuiU oW7Oz8pCWiINGq0oktOyRd6kTeXu3Qb47H587J/+kEfCg2Pl6G1lvUnLlnKTlqI1FcsurZSNMPsi no7Of7sf8PifvQze0/HMxcMbsKvSYxoihqCiKlCjSpu5+HQRfLT6vAX28Ej5h6WxLHnVp7659BGR IUQoNcnBOOli5O4/Vd70C+69droZGQzB4/vB09GpL+pGa5EoVUqN8CYhOS09ZdImce8D5eGlQ30P 0iPh5ES4hVFzbiW6ICeaqeShqXTlTFvB15XttvH4/o25K2/Q4X68l8U7YQoZQN0wsEsuPpDm4wt3 6qnz3ntXtz48UiIS0+v5MNZ9w/toOSETKrWaxjglHzml8vbSb4p74eY4GC64eLtt7KKdRaoSVkUt wptgs5nLalBOjpRZEAOPhHfvKE+/Zfg6tyYz91qZZW9YPbNlYaRxdHJjfuALukmAgUfB0VGwet3p i0vqHS1BuEQ1pQ1CGWfx8PCdfajoHWE1GXdO87Knizx0ETUTLlR3jVwp2nhB4/joRuNxcOMAv0Tr HHA+a7qinzZ3x7MrkJ9gsEmMdG1ng9fWIynFpSNoF+T1/t77Nw7wzahpVyR775qwyIqbQEPUQtRd NBz6oO9noE5OhFtHRs15kXa9O30EPa4qyoSqxiRKWgjjRwLvCP+Co8rCo0fCX22MW2RUu2SWsWYU CYW6CZ3YnFfSUaN+AIuFMUVmkoWFHjgsUe9RM1wQ9QatVY3GIjV+/77z3gPg+MZAvkGAHykcK2mZ SKU7aN5HTRl1EdNmPpaJ1cTiZ43p9WB6XdicJyINQ+4PQlgm10VTMoIK4mhqEtoGLW1idD56P/j3 z4MnT25slTcFsFypWpEP6XqX3KHVqNk1om5CJsZl4YU20gLu9cro3UFfFy5yEMpCLXp1MZPA0SpB FZ0aMnghO1ad06MbC3jCjQH8aE402byW0NInrI9KxkJEpZm0aWI1cXdRGXOwOxUOa0bbYDUvIuIA tV6cXEXwiCahRTyKaG60yQfzmOIgWBK8/dex16P/RZjKM/dWS/guL0P6sNahzWidq1jZhE7sTgs/ 3zlpAXfMkG13UPLgNRahOiRaFnH1sCbqk0gbBSZxaTLkEG0Ub0EqwcnSeXD/RkTFdatpsy77BKNr tgrLzphjH66X5K6MlTir3KuN4U7wnVOBTVrVlL15F5SMNa0iUZwmEkVcR4m0U2OSjgbgI3YoQ4KS GHaJd+8oPBKuOaRx/Q73BxhpmZBtl7P33nIXISbN3PIwbfR8onaFp93MvZtdIi271OjdpwHd5084 IqINiaLCqCajWhSR8Bib0HeCVykIfFpUXKuYuE4OntOlTo6UHjtsObtbJqmKWsgwVWWskCu3z5zh TnDvA0XHdNg22dt5h2KEC80cpxGtSmgV9aLayuZ8UXSdqvYzF4dhB/SJOM90zTg5Uh5dLxdfI8B7 D9iwS9QZ3Ni1FN5mExer61RnH8LTbzm7UyElQw6Tu+Ugp/AkqLtEaZK1StCEWgWrG1Ll1rauqUUa jXEKvElITcuDlJkscwvjmAtRcS10XQDPPoTFwki30qFb9tAcF9wbU9XzWtChcnJ2FQZ6ejWWZPOz Og1SgVpJNGp2SnPG6lQaK9pZ5Kp1z8UT5m75sG0y3mUWP7e9+/NaQL4OGXyV7Pesy9zZ9DaWgZQy 3lSwamHTWWMi9QW563znVKiWWIydjbUPoYNQaeqi0oQWAtASItVVrZTuYGK9rpAc2TIMg/pYjMBw lYiQhY8x9e68W4OTH16Lbnw9AD/A6FeJuu2WWfcbWzWx7OKlnIuP3B4Kd7eN0wVUM55tu6UxeLWe XBOVEKRqlkqkABALAXEJbxUqdWq8vnOeK1O/kj5XjciGiYGJDERpfZCK8/tPrkU3/qpFxOxvODlS 2KTVKs2yV/c5wE4zGQrezYkj7+43ts+OVQ1pNJFWVFtR8SIuDbUgfNYYWhG+Afw/mPOIN1VJVYo7 QNDSpajQMXFypDx8+JWLiq+agxXY+xuWXSp1CG0dLVTMXdFpo4xM68KLaNSdEJ1dqGUhZR7LzOmW dbJChULkpFFdoRPBfLDappIab07O+4dBgimN2neioWLUbMio0YQayZE7+3jfD+KrdAZ9lQDPatly aZyN3WGbBlfpwsg0UJViGuMU24m7tTK+GXzjY519E957tNl8BlS9mByMZ4vVNLbcJhU6TLFqVDXy CDQv2pzNwhkJ3jwDvcPwDIveNLwajhImfZgXrc4bK99nXH5lIHyFAO/9DaeLjJbe0D7UO+hUzJvS TxsbRqrPRkXdCa97YjPMvglpHTGI5DaPFZ/oWmE8b8iSXs41AgvcCBWxFAvJPiV33qbxj28GKZim Ufq+zbkXQyguQljUMOd057xY+VfpDPqqAL7MA2Z80S1DelfrIkeiEKpaksU4MU6szhrPu312Ts7L kN5F+/BISFyN1TrRvVF5eubwQqa00C7E0GTkpGyLoCXKi+ZszWkL560XoIMUdpqn3iLCaFUJl/6g 91K3zsr8q7TwvgqAX1LLzjJ3tE8TfWjrsBAp2iy36Sz5iC8LH0nw7TNBF4m86dPU+lDp6F8au/aR flmo32gsnwS3DcYmfbiFoFGaYXsuXuy5+PbHccHFnJsMphJgSCiKoh6LwXxidE6Wzp/9MDg+/q2D 8dsGeN6RP6WW1d4bHV4TYaH003m/m7CDibvbxgkQnZFrXjbtvWhPNCMs1FM5H8aR9cFEHSpvvR/8 +I+Ct/4W6i2ZrL/i4lqMBHiOooOzEWezC85L8NaGaczS4Yomo5mSEtRGieR07vzjk+C9P+W3LSp+ FYDllzjg4cMvzrgREKk1SR6nMU1oqvzs0PnGx0p06bAwuDMEZCJEsGowlsNuJKdK/3fOj/8o4BF8 //ugZ8LYpFdV95IQUxwVaQxRZs68t3PGN4PFMy7GBjPX04qKRgw+xaTFOdTgD55flBj8cmv9JUH7 kuu/gt1+EfUddonFqj8IX7joEAWTPDaNvDsX3XJnPfLuUAFeHtsiFihGc9ds43YjW1Z1xwkTRyfO 0VFw/37wzn4eGzLLXb+ARZj3QUo4TcN3W9jyxm53Oc8tjH7ZH7S6cBmHKL2JuUsr4xa2rIaRf9rN GZvHD/xVy/w0PXpZdn9Ojn8ReFf5BycnAg9g/eHVuN3pLwb8aKl0zZgsLzeboeXcR6NDS6gxmbA9 M7YszgpPv+Xc65VPPumX+KL19cBL6gkXUaZLkHomWFb+8WdBfxifmuuTZtxq3YHo4DIO4ZoBRL3Y mM436JZFnlh3jXsfKNvDvCINFR18qj2di+ysap7G8xh2HNjEZI2TzS8G+OU02NU3Zu3j6GhOouHz FaXyufOHD5WTk9kx8+xQ2QzK3d3VuItEkM9SXQnjRunElgcpe6XzRkfOIrtStW+7c/MtYx6Z7sxc 1Z0mYLHItmylLGHISA1pNmrvu220HZErRRppHZ+bb7FR1ot0METn1nov3pNUJbQqvtumdE6XttjH laffclaTsd70y9tpaJtYRFcyRUMkFzWdzs9boW0r/dI/N98F5f7q+vqO050Gt8+c7bbNQF9mgcZn AA7h4Q+VJxi3MHSVkF1apbBoVWiDAESrnwfYq8TQBO8kDAtaioJhqjR3rTYml+369bS9/BmeHClH dIdTPai6OPRWloElLFwqkyYbpcgk3bbJzgJN8UVzRjUNySnS2EXrugsRI62OlvLmPA/njJuRFzS+ B/zNlVhx0QHFKBbSlypYlUZjN4XoF8wJiO2v2S7EUqyrNOKs4n3dz9FeLni8SDy5AteGjLXu0Etu XnIFC8+C7yt1Xoa321dYugsxENEETGlNZyPZXNyKakxr1fnndyFLT4AySrSlRBQlJSGq0gw0LKLk UFRCnAUB9fPc5CIhKmizCE0hnghPmAYkXEo7nHI907Hx7eK8+y3nm33lxT+oaW+EmzeE5BaNLkwT XkIWg8MIWmcwp5cKabzsXw2J6otGM7FyZrlgNvFkBw9/CI9xIIwLh8xfViMtModjfyC7oYUNIXRR U6ab6yjQXhFVpCjSKaYGpoQYhILPEQcAp0mTqmmcsuZxnNaF6XblP/xr5949eLcKi2K9eopsKaKZ SEJUAsRxDTFA8/ylfdERYuAWTYwUKSPJ0UyQUBeKQBetNm28cGdXg+dn0CWWO3CShBYlVBCU8PlV UFBF0jyP29WaRZUYjT5bTJZCZ2uy0yqlt4DXgtNF8J9+EBwfY3uenPXW6UW3dB888hB56kCVrFCb S3KX6i6CC+qCu1gNwV0kXCKFiLmYN6lWdciT9YznNY/jC5soVL67c370o+D4gfCv/pcwLuUgL8Ub QiGI1qRaFWpVsyramuD+C49ogcvstowkTSKlIKmGqaMuBlV9aN6KHTS+dtQYc7DZxS7tKMvG0A4D 1yAIyeFC3q+vzOvCXdpLa/YS0kXQBDoVCMXCKJ30pVJiN1uH783WYYJHwvpD4fWtrVYpV48cpSU8 Cc1dqlQRLyLhIsk/tUeO6VIesiywATSFdNXPxtbwrlJfVNpQZ9l0sQE8Co4eBk9oz4afT6yMlS2K b5Ox2IuibcQrU+cWVWITwmAS0pK32uFohRRCSmIpKV2T1jfLE9UKaazsTmO/B1Q64szd0akeJizG pJeiEOWLZDCSCBk1WrFwmcUSSUNaciyvVlLXXav8/LsNHkjiEfCfP1CGr6vXahEt0amiFuJWrC/j 5rwWplRJGqQ+4OOXZnxjftmOQrd/z/rgfOesls76643vnfqsxjy+uu3x/eDhO40nA6yWvv6kGXd3 +3TVN/bYvjzPZ2i7EhKQNwqLtGi1ec4StRieDIlE9RRIF6n1B9nL+XZbOVo6nDhHJ876u8G9D5xn h+VsMSj20vx8DKz4wrWeV8VqWi5ablPuQ8cOkkZrybfJKFl5/oHy6BvNODpSVpPynJyH3IXpXMXe wrVN5bz4SG4Tmgp3jir9+43eXzrO5mOx3Z9746OukY4a/d/NVUL378dsgT6Q2RQN4H8IP7wHnATn 3w3OPgrOadzb+eVnfmqezxyLbYNbztgasY1aV9GlKlHFkEimbmgSj7aX6dKqWuMTaZz1wdtLv6xe Gk+cZ19zpkXjrDR2U2OX5td7O//cWkvnpBJlRLKgETbXl1gKSdbK9rzy7any/HnMv8HtVuBwVn0i 5DLOMZehBjkFLAP+Ft4//GL98Ito/V1hjXByHDy4uPgA+JP59Phi3IdyqcA//Uw926sMGzazo+hp arCtqhQXSpBLcU/ZmiZVreEpupwPinfnuq7cvd04ec95RFxVLz3Y2wH7+U5OhPV35fJ5Xn6Oo+WM y6cFJnNm/h687VY4PCRx/37wl38ZbLuQPLlUjyBB50LF8CHB2imfCN0bjgFfewWoP18EfMR8XAC4 ujq/qFN+mbrTX/x53SvmAniahNWgsJQNG3rREAunaS3Nk1g41SRoycPy4SrnMzaVkyPn4TvB48vC mvn18SN4cKysvyvc+0B5drhH7MLY+jpwqlASIglNRnKhKqI1xDxIXbBYBPfv7zn4/cPgaHJpNLxv JIyKupMXqYSSVZQmUw3uAtM81RcZHbKqAYdgOViv52t75fxFq3LrJVPyxcWJ5V/fF9shnC+E1GzR dcm7SfAUaHVxrYQ7M+B6EZcjtHKrNE5OfPa1XPoT5tq7xcJYY3xyN5HDaEXohnlEO5HDljQsmyfL 4ZqoTeeOAdaklcZiH7b6dxeeoQcPjPEov2Z5KBcOGtoMvtMkuVOzy0VlPBCehVQUz58GWUugFkwa cnH+WXr5mk7B9teGdybvhGzqPuboNOOao077YKk76o4lF6eJ25jYbs/kzpZbH00cHtZZuwl49BfC 43cS3xzyrfWubz2du+XLljUXz+1NIpnGFHbRBkeoVSPvsuj2eSs7+pPC8fEexKOj4Ant+VEpK5LF dqdkIUpv9GhQlU4jADwLrWikplS10GZz6n+ZWxJECsYaJGvU5MK+d4NqwAgjQJvrMOanRuwLvoRf gUKq0Ca5yFmjMauUjSbZGqUEFzuLYq2lTKwrT7/VeIrPHPwXcHys3DoyJstVbWhTLKKTTKCfWQs4 oE1mbYsmpUy2kOk5pXBK43tzAc7sD37yBO7fE7jHVLqoU9AlDbEaiCMeQQVqCIKGRoqQDrEO6CLo COlg7vwEYqibqAghQgOhAQmyQwPkZTdIiMhvkEEQIYhAagjZRaUpMgnjpKVOMkRFU1Bc6FzwTO8a RatfJgV+fwPnfyRsP0gcDJ2VWIS1RVTrcUmSRNEI8QisBYUQqS4tVcWnbZ/GaasTeSgsP2z8+McO xJUmf/zAeXBcyW9DrnFeczuUlmJMGp1pxKgY5k6mS0p1kGIhZhn00kmhCIHUBkF1kdTE3AWrVJoo Qd5z7BeJj1+DhARbIImgEoxTaKXpsq/rsTokPSjReRhBS0FLTsqrQ6tra41/Opp14wu3bCuChyBJ sDZ/87WFKC5GkUojvImEq5VqkSuUwmJZ4b06+5OP98/28nNeFFifHOnsoMbYdspio5zfsqWU5Ln2 jg4hOoRHh2B7DroEK0mL6uZEq2JM0nTUJJNqK9Jo0i2c9Zq1fYGl9BvSa5bjeeqCbXEWk9MNwSYr w2m3OE9DWO6jFZVG077fndvZ512olodFkmUb/TDMewARLxq+k6bjNjFRaUxzLhwjc13epbP+yi/8 mZDRMbz398GDxzCeOOu3Gm/8bM41SIso7UwyahGRZmdIAFSpWkRikqCIe3VRJyxQQiRcJVXFpvPS polxmvq+TJvzgqXC7Cb7rR1jeCV1lVsfVz7qGuvqrHJwbjLoqCFoBHOQVCpDmE+Zxu2Pg81rwesf z+GlKRtpMlRFXEPCm4pMW+rEQieeDYXbfeGkVG6dNN5eXoS0PuV0/6yxHyAXrjbggfDgJ8Fbh8Hz ojwDvAlq0NwFJumsSm+V2hx2YDI7UiUyzfViBtmNwWs0Nn3ln3aNo7XD+tdn1VfREbOq+M794OE7 wrtd0G3KmS7sQNQkjxbFLfDknme1LSVndxq8fxgMu7ZZyLRomsQRpCYsO144tBRn29G5u2zwduV7 7wSPH+yBfQyviGh8lq4iHGdniRe5OwxbVGQRaejwJrODuoxbqYW6mvtKxjYvejpHhwjNaA2NvLOx nG+61eYl1ej6KuAfPpx93Ud0K9JQPRZeoyNcRHJJ2Pas+Y5FnjjZON8+E7aH+bCxaMHiMjIzebHW dpvX2FKX4yxvjy9qob9wLa/auuMyafrZoSKHyaVP6LDX+/bgtsUOubPlduw42I4kJgmrOI3mTk2O lpA8OHk9c8j9y/YC13HA48ezc4dlXa9rUW1z8uCMgLWQzOE+C/7bZ8L7h8FIO+uZ9GI9QGiYa5fY YKx/Plt7l0XqX0yvAnhvk+9T/qWkkJaiFaWUEEq1xER+NpG9YLcr652/bJWJZZcsTbAqVRrr3bzQ 6203O89z/MBZd40y1M3IJNKKWJ57BcWUly1lfJcuTePbZ44OdXNei8ReBIZLSJt7WQxiPP9A9+W6 v5BerXw+fEc4WioJc1oKPJGzSKaJ9OXMlgXv6xyF/VtYDUqfNKrtowMlBKsSU1237Vw5dHQjFfCz jPzOqfPNjyu6KnPa7G7Ogtcwd8urmjI9V1w8WaOlqj5VSe5kl5mLa3pNDhNvvSk8eHU3wVcAHPs2 iBu5tcFiwi4r2mt2bZtG+aRx+8z5HvDsUEnYsm1zSEtkF5wmoxcbDyfKMEd2H99YBfxVfwpf1zNt RaUrkmmES9BSa5apOZOS8T1gsQpWtM0yVfG5JIFkSjb1aausf64XH80v2M9ekdkjyuud0p5Z14bO e7pIOQEopVrupsm0Uu8Ep2WuBvLUOzZn8iSQctH5iZE379xY56crOobvf1/4R2Dl0hMaYhohhsus tvkUU3foPG1BBHQmrM9Tznmu52sozVwzdbp1WHn2tVd2df217dOYdsq2U9gkdEwU61qlCy+ZyDLH 71rZaC3UF3PnpxvsnXPx2C9veGdWrja8cAlyak06tt7h3bzpPXfjYBB8Hx6E2ZX7S9IrAP7zYPWT yxyA2clR5tIoxVz6RPWO89ofaj8c5L6PTDdXbY4IOm+COhZ2w9zm+9NpRjdHFxtetyoXm9jVhmd5 obU/7Kae9a5n4d1BsxwThicBkNpcLAX94kvX8wqAhYt2LzZFk0aTmud6hzEnL61faCwWBzLrilKG GD1Bj4RVTUxnVgr5btn3zrlp7r2gqw3PblfkoJjpdLnhiaeYvG/BYgGLxVYHL7UP6/dFkO50NK3S +Ph0z4R//mvpwXNg8mTjz27nqtqKUCrNndwkOs2eWu+jDV72iXd9j/jYRFrZjEx8siqsu7ZPpvtd APeCrtqK6VTOtBW1g0l6q9ATpOSt71x0cJ2G6DSjo2HZRXLRTarPi8wb/NFRvMpe+3IZfHTijLSz cyYtaVRj4mJHNVVMlZwErSGUKk3HNKURHQvf/Phl0fC7BDCXXPyCxoFNNm4mLUwSpZLcsaLoPv3L m+B9k8mLmk4pyzTvK1+uFX1JfvAxvPen8GYFns2JGnUZtB1ECqnuYi1EaepSlH7alm6c+n72i9aP L/2ivy1Yfqv05Ak8uA//9xnT60OUGtF1DXEFjZBIIaiLtqZGsdymc9dxPLCJ030izZdoRb9EAvbx 3EDu9Chgisk1qkYbtDRp2nSQortUrNdpo91EPi8c3i3Un7SX/aK/ozS32/03fwuLCPKtKDH6Qvsm O22SxiZSq07dZLUbzxZ1Yv3axOnZy4k0r2SeX1bdmPPX/uuHdvkPLKthr6YBaR0sX3PWO7/KMPzi fNnfQZrjkg8fzkndFznOm6zs1kra/yPN+jXnrjXWXXvpj0/gS9b3y5cQHB/DRz+Y0+zrv3VOTpyp VX6/VT5IjbJqHHzQ+I9/1PjRjy4U7991cK/oyZPgz34YvPfXwbOvOWfPG9/YJ9T87KDSrxpvvWj8 9997uVXjl67vVy0j3Y/flxU8eumdR/C78g9YvwFdre8RV//y9Rv8w9f/B9AAGZNZ/XlzAAAAAElF TkSuQmCC "
-       width="88"
-       height="79"
-       id="image986"
-       transform="matrix(0.26458333,0,0,0.26458333,6.0854167,6.6145833)"
-       clip-path="url(#clipPath988)" />
+       style="fill:#0232ad;fill-opacity:0.275;stroke-width:0.99999017"
+       inkscape:connector-curvature="0"
+       id="path53"
+       d="M 19.30481,9.0159123 A 1.322987,1.322987 0 0 0 18.134822,9.6879057 L 17.634827,10.543897 17.134832,9.6879057 a 1.322987,1.322987 0 0 0 -1.210988,-0.6699934 1.322987,1.322987 0 0 0 -1.07399,2.0059807 l 1.251988,2.142978 -3.667964,6.278939 H 9.6019057 a 1.322987,1.322987 0 0 0 0,2.645974 h 1.2849873 l -1.00399,1.719983 a 1.322987,1.322987 0 1 0 2.284978,1.332987 l 1.783982,-3.05297 h 7.364928 l 1.784982,3.05297 a 1.322987,1.322987 0 1 0 2.283978,-1.334987 L 24.38176,22.089784 h 1.513986 a 1.322987,1.322987 0 0 0 0,-2.644974 h -3.05997 l -3.669964,-6.279939 1.252987,-2.141978 A 1.322987,1.322987 0 0 0 19.30381,9.0149123 Z m -1.669983,6.7739337 2.135979,3.655964 h -4.271958 z" />
+    <path
+       style="fill:none;stroke:url(#b-3);stroke-width:2.64597392;stroke-linecap:round"
+       inkscape:connector-curvature="0"
+       id="path55"
+       d="M 17.211831,20.231802 H 25.48175" />
+    <path
+       style="fill:none;stroke:url(#c-5);stroke-width:2.64597392;stroke-linecap:round"
+       inkscape:connector-curvature="0"
+       id="path57"
+       d="M 23.731767,23.947765 15.511848,9.855904" />
+    <path
+       style="fill:#4da1ff;stroke-width:0.99999017"
+       inkscape:connector-curvature="0"
+       id="path59"
+       d="m 18.063823,11.609887 -1.723984,2.297977 1.571985,2.689974 c -0.1,-1.485986 0.298997,-2.821973 1.474986,-2.723973 z" />
+    <path
+       style="fill:none;stroke:url(#d-2);stroke-width:2.64597392;stroke-linecap:round"
+       inkscape:connector-curvature="0"
+       id="path61"
+       d="M 10.499897,23.947765 18.719816,9.855904" />
+    <path
+       style="fill:#76b6ff;stroke-width:0.99999017"
+       inkscape:connector-curvature="0"
+       id="path63"
+       d="m 10.505897,21.309791 -0.419996,0.717993 c 1.111989,-0.349996 2.03698,0.088 2.334977,1.249988 l 1.149989,-1.967981 z" />
+    <path
+       style="fill:url(#e-2);stroke-width:0.99999017"
+       inkscape:connector-curvature="0"
+       id="path65"
+       d="m 9.0719109,18.916815 c -1.7459828,0.017 -1.7459828,2.628974 0,2.645974 H 19.996804 l -1.05799,-2.645974 z" />
+    <path
+       style="fill:#87caff;stroke-width:0.99999017"
+       inkscape:connector-curvature="0"
+       id="path67"
+       d="m 18.431819,18.916815 c 1.286987,0.752993 1.106989,1.938981 0.555994,2.645974 h 1.821983 l -1.544985,-2.645974 z" />
   </g>
 </svg>


### PR DESCRIPTION
- `application-default-icon.svg` modeled after the _Generic App Icon_ in Big Sur
- `qtransmission.svg` in the same style as `transmission.svg`
- `org.gnome.Todo.svg` modeled after _Reminders_ in Big Sur
- `softwarecenter.svg` in vibrant colors and 3d-look
- `badge.svg` updated to match later Big Sur betas
- `shotwell.svg` modeled after _Image Capture_ in Big Sur