### PR TITLE
Add existing icons for Anydesk, Plex Desktop and Popsicle

### DIFF
--- a/128x128/apps/com.anydesk.Anydesk.svg
+++ b/128x128/apps/com.anydesk.Anydesk.svg
@@ -1,0 +1,1 @@
+anydesk.svg

--- a/128x128/apps/com.system76.Popsicle.svg
+++ b/128x128/apps/com.system76.Popsicle.svg
@@ -1,0 +1,1 @@
+gnome-multi-writer.svg

--- a/128x128/apps/plex-desktop.svg
+++ b/128x128/apps/plex-desktop.svg
@@ -1,0 +1,1 @@
+plexhometheater.svg

--- a/128x128/apps/tv.plex.PlexDesktop.svg
+++ b/128x128/apps/tv.plex.PlexDesktop.svg
@@ -1,0 +1,1 @@
+plexhometheater.svg


### PR DESCRIPTION
Icons for Anydesk, Plex, and Popsicle already exists but do not apply for flatpak installs:

- com.anydesk.Anydesk
- tv.plex.PlexDesktop
- com.system76.Popsicle

Existing icons for Plex also does not currently apply for Plex Desktop install from the AUR:

- plex-desktop

This PR partially addresses #28 for Plex and USB Flasher (Popsicle).