### PR TITLE
Point `im.riot.Riot` to `element-desktop`

### DIFF
--- a/128x128/apps/im.riot.Riot.svg
+++ b/128x128/apps/im.riot.Riot.svg
@@ -1,1 +1,1 @@
-riot-web.svg
+element-desktop.svg


### PR DESCRIPTION
# Changes

- Updated the target icon of `im.riot.Riot.svg` to `element-desktop.svg`, in place of `riot-web.svg`


# Notes

- `im.riot.Riot` is an (unofficial) [Element Flatpak](https://flathub.org/apps/im.riot.Riot) app - I feel the existing `element-desktop.svg` icon is more representative of the app and its default icon